### PR TITLE
完善按键绑定

### DIFF
--- a/配置文件/default.custom.yaml
+++ b/配置文件/default.custom.yaml
@@ -13,38 +13,61 @@ patch:
         Control_L: noop
         Control_R: noop
 
-    key_binder/bindings: # 设置翻页
-      - { when: composing, accept: ISO_Left_Tab, send: Page_Up }
-      - { when: composing, accept: Shift+Tab, send: Page_Up }
-      - { when: paging, accept: minus, send: Page_Up }
+    # 按键绑定
+    key_binder/bindings:
+      # emacs_editing
+      # - { when: composing, accept: Control+p, send: Up }
+      # - { when: composing, accept: Control+n, send: Down }
+      # - { when: composing, accept: Control+b, send: Left }
+      # - { when: composing, accept: Control+f, send: Right }
+      - { when: composing, accept: Control+a, send: Home }
+      - { when: composing, accept: Control+e, send: End }
+      # - { when: composing, accept: Control+d, send: Delete }
+      # - { when: composing, accept: Control+k, send: Shift+Delete }
+      # - { when: composing, accept: Control+h, send: BackSpace }
+      # - { when: composing, accept: Control+g, send: Escape }
+      # - { when: composing, accept: Control+bracketleft, send: Escape }
+      # - { when: composing, accept: Control+y, send: Page_Up }
+      # - { when: composing, accept: Alt+v, send: Page_Up }
+      # - { when: composing, accept: Control+v, send: Page_Down }
+
+      # move_by_word_with_tab
+      - { when: composing, accept: ISO_Left_Tab, send: Shift+Left }
+      - { when: composing, accept: Shift+Tab, send: Shift+Left }
+      - { when: composing, accept: Tab, send: Shift+Right }
+
+      # paging_with_minus_equal:
+      - { when: has_menu, accept: minus, send: Page_Up }
       - { when: has_menu, accept: equal, send: Page_Down }
+
+      # paging_with_comma_period:
+      # - { when: paging, accept: comma, send: Page_Up }
+      # - { when: has_menu, accept: period, send: Page_Down }
+
+      # paging_with_brackets:
       - { when: paging, accept: bracketleft, send: Page_Up }
       - { when: has_menu, accept: bracketright, send: Page_Down }
-      - { when: paging, accept: comma, send: Page_Up }
-      - { when: composing, accept: Tab, send: Page_Down }
-    # - { when: has_menu, accept: period, send: Page_Down }
-    # - {accept: "Control+p", send: Up, when: composing}
-    # - {accept: "Control+n", send: Down, when: composing}
-    # - {accept: "Control+b", send: Left, when: composing}
-    # - {accept: "Control+f", send: Right, when: composing}
-    # - {accept: "Control+a", send: Home, when: composing}
-    # - {accept: "Control+e", send: End, when: composing}
-    # - {accept: "Control+d", send: Delete, when: composing}
-    # - {accept: "Control+k", send: "Shift+Delete", when: composing}
-    # - {accept: "Control+h", send: BackSpace, when: composing}
-    # - {accept: "Control+g", send: Escape, when: composing}
-    # - {accept: "Control+bracketleft", send: Escape, when: composing}
-    # - { when: has_menu, accept: semicolon, send: 2 }
-    # - { when: has_menu, accept: apostrophe, send: 3 }
-    # - {accept: "Control+Shift+1", select: .next, when: always}
-    # - {accept: "Control+Shift+2", toggle: ascii_mode, when: always}
-    # - {accept: "Control+Shift+3", toggle: full_shape, when: always}
-    # - {accept: "Control+Shift+4", toggle: simplification, when: always}
-    # - {accept: "Control+Shift+5", toggle: extended_charset, when: always}
-    # - {accept: "Control+Shift+exclam", select: .next, when: always}
-    # - {accept: "Control+Shift+at", toggle: ascii_mode, when: always}
-    # - {accept: "Control+Shift+numbersign", toggle: full_shape, when: always}
-    # - {accept: "Control+Shift+dollar", toggle: simplification, when: always}
-    # - {accept: "Control+Shift+percent", toggle: extended_charset, when: always}
-    # - {accept: "Shift+space", toggle: full_shape, when: always}
-    # - {accept: "Control+period", toggle: ascii_punct, when: always}
+
+      # numbered_mode_switch:
+      # - { when: always, accept: Control+Shift+1, select: .next }
+      # - { when: always, accept: Control+Shift+2, toggle: ascii_mode }
+      # - { when: always, accept: Control+Shift+3, toggle: full_shape }
+      - { when: always, accept: Control+Shift+4, toggle: simplification }
+      # - { when: always, accept: Control+Shift+5, toggle: extended_charset }
+      # - { when: always, accept: Control+Shift+exclam, select: .next }
+      # - { when: always, accept: Control+Shift+at, toggle: ascii_mode }
+      # - { when: always, accept: Control+Shift+numbersign, toggle: full_shape }
+      # - { when: always, accept: Control+Shift+dollar, toggle: simplification }
+      # - { when: always, accept: Control+Shift+percent, toggle: extended_charset }
+
+      # windows_compatible_mode_switch:
+      # - { when: always, accept: Shift+space, toggle: full_shape }
+      # - { when: always, accept: Control+period, toggle: ascii_punct }
+
+      # optimized_mode_switch:
+      # - { when: always, accept: Control+Shift+space, select: .next }
+      # - { when: always, accept: Shift+space, toggle: ascii_mode }
+      # - { when: always, accept: Control+comma, toggle: full_shape }
+      # - { when: always, accept: Control+period, toggle: ascii_punct }
+      - { when: always, accept: Control+slash, toggle: zh_simp }
+      # - { when: always, accept: Control+backslash, toggle: extended_charset }


### PR DESCRIPTION
参考这里 https://github.com/rime/rime-prelude/blob/master/key_bindings.yaml 做了一个完善的按键绑定。
取消了原来的 Tab 翻页功能，改为移动光标，这个太好用啦！

默认开启了：
- 加减号翻页
- 中括号翻页
- ctrl + a/e 移动光标到首尾
- Tab 和 Shift+Tab 移动光标的功能

另外关于简繁切换的问题
```
- { when: always, accept: Control+Shift+4, toggle: simplification }
# - { when: always, accept: Control+slash, toggle: simplification }
- { when: always, accept: Control+slash, toggle: zh_simp }
```
我将另一个的 toggle 改成了 zh_simp，我这里试了两种都可以切换繁体，不知道这俩有啥区别。