### PR TITLE
fix: gushici词典的错误

### DIFF
--- a/配置文件/luna_gushici_1.dict.yaml
+++ b/配置文件/luna_gushici_1.dict.yaml
@@ -1,0 +1,16959 @@
+# Rime dictionary
+# encoding: utf-8
+# 古诗词名句、诗词名句
+
+---
+name: luna_gushici_1
+version: "2021-01-31"
+sort: by_weight
+use_preset_vocabulary: true
+...
+
+阿母为汝求	a mu wei ru qiu	1
+阿母谢媒人	a mu xie mei ren	1
+阿那曲	a na qu	1
+阿若憍陈如	a ruo jiao chen ru	1
+蔼蔼帝王州	ai ai di wang zhou	1
+哀哀父母	ai ai fu mu	1
+蔼蔼树色深	ai ai shu se shen	1
+暧暧远人村	ai ai yuan ren cun	1
+哀多如更闻	ai duo ru geng wen	1
+爱而不见	ai er bu jian	1
+哀而不伤	ai er bu shang	1
+哀公问曰	ai gong wen yue	1
+爱国治民	ai guo zhi min	1
+爱好由来落笔难	ai hao you lai luo bi nan	1
+爱酒不愧天	ai jiu bu kui tian	1
+爱君得自遂	ai jun de zi sui	1
+哀鸣嗷嗷	ai ming ao ao	1
+欸乃曲	ai nai qu	1
+爱神仙	ai shen xian	1
+爱他明月好	ai ta ming yue hao	1
+哀王孙	ai wang sun	1
+哀吾生之须臾	ai wu sheng zhi xu yu	1
+爱以身为天下	ai yi shen wei tian xia	1
+哀怨起骚人	ai yuan qi sao ren	1
+哀乐不能入也	ai yue bu neng ru ye	1
+哀哉王孙慎勿疏	ai zai wang sun shen wu shu	1
+爱之欲其生	ai zhi yu qi sheng	1
+爱竹最知王子猷	ai zhu zui zhi wang zi you	1
+暗暗淡淡紫	an an dan dan zi	1
+黯黯见临洮	an an jian lin tao	1
+安禅制毒龙	an chan zhi du long	1
+暗尘随马去	an chen sui ma qu	1
+安得长苦悲	an de chang ku bei	1
+安得临仙坛	an de lin xian tan	1
+安得上方断马剑	an de shang fang duan ma jian	1
+安得倚天抽宝剑	an de yi tian chou bao jian	1
+安得倚天剑	an de yi tian jian	1
+安得至老不更归	an de zhi lao bu geng gui	1
+安得壮士挽天河	an de zhuang shi wan tian he	1
+安定城楼	an ding cheng lou	1
+暗飞萤自照	an fei ying zi zhao	1
+安凤	an feng	1
+暗风吹雨入寒窗	an feng chui yu ru han chuang	1
+安鸿渐	an hong jian	1
+岸花飞送客	an hua fei song ke	1
+安乐公主	an le gong zhu	1
+安且吉兮	an qie ji xi	1
+岸容待腊将舒柳	an rong dai la jiang shu liu	1
+安上纯父	an shang chun fu	1
+岸上蝴蝶飞	an shang hu die fei	1
+岸上沙	an shang sha	1
+安石东山三十春	an shi dong shan san shi chun	1
+安时而处顺	an shi er chu shun	1
+安守范	an shou fan	1
+暗水流花径	an shui liu hua jing	1
+安危定变	an wei ding bian	1
+安危托妇人	an wei tuo fu ren	1
+安危相易	an wei xiang yi	1
+暗香疏影	an xiang shu ying	1
+暗相思	an xiang si	1
+安心是药更无方	an xin shi yao geng wu fang	1
+安阳好	an yang hao	1
+安在其不辱也	an zai qi bu ru ye	1
+安知峰壑今来变	an zhi feng he jin lai bian	1
+暗掷金钱卜远人	an zhi jin qian bu yuan ren	1
+安知千里外	an zhi qian li wai	1
+安知鱼之乐	an zhi yu zhi le	1
+卬须我友	ang xu wo you	1
+傲吏身闲笑五侯	ao li shen xian xiao wu hou	1
+傲世似未敬	ao shi si wei jing	1
+翱翔蓬蒿之间	ao xiang peng hao zhi jian	1
+八哀诗	ba ai shi	1
+八宝妆	ba bao zhuang	1
+八庚	ba geng	1
+罢归无旧业	ba gui wu jiu ye	1
+把剑觅徐君	ba jian mi xu jun	1
+拔剑起蒿莱	ba jian qi hao lai	1
+拔剑撞而破之	ba jian zhuang er po zhi	1
+芭蕉叶大栀子肥	ba jiao ye da zhi zi fei	1
+芭蕉雨	ba jiao yu	1
+八节同欢	ba jie tong huan	1
+把酒话桑麻	ba jiu hua sang ma	1
+把酒酹滔滔	ba jiu lei tao tao	1
+把酒留君听琴	ba jiu liu jun ting qin	1
+把酒问天	ba jiu wen tian	1
+八骏日行三万里	ba jun ri xing san wan li	1
+灞陵伤别	ba ling shang bie	1
+巴陵无限酒	ba ling wu xian jiu	1
+巴陵一望洞庭秋	ba ling yi wang dong ting qiu	1
+八年七旱	ba nian qi han	1
+八拍蛮	ba pai man	1
+八齐	ba qi	1
+八千岁为秋	ba qian sui wei qiu	1
+巴人讼芋田	ba ren song yu tian	1
+把汝裁为三截	ba ru cai wei san jie	1
+罢如江海凝清光	ba ru jiang hai ning qing guang	1
+八塞	ba sai	1
+八上	ba shang	1
+灞上秋居	ba shang qiu ju	1
+灞水流浩浩	ba shui liu hao hao	1
+巴水流若兹	ba shui liu ruo zi	1
+八岁偷照镜	ba sui tou zhao jing	1
+巴谈	ba tan	1
+八万四千人	ba wan si qian ren	1
+八佾第三	ba yi di san	1
+把意念沉潜得下	ba yi nian chen qian dei xia	1
+八佾舞于庭	ba yi wu yu ting	1
+八音谐	ba yin xie	1
+巴渝辞	ba yu ci	1
+灞原风雨定	ba yuan feng yu ding	1
+八月剥枣	ba yue bo zao	1
+八月洞庭秋	ba yue dong ting qiu	1
+八月蝴蝶来	ba yue hu die lai	1
+八月十八潮	ba yue shi ba chao	1
+八月十五夜	ba yue shi wu ye	1
+八月萧关道	ba yue xiao guan dao	1
+八月在宇	ba yue zai yu	1
+八阵图	ba zhen tu	1
+白波九道流雪山	bai bo jiu dao liu xue shan	1
+百步九折萦岩峦	bai bu jiu zhe ying yan luan	1
+百草竞春华	bai cao jing chun hua	1
+拜臣郎中	bai chen lang zhong	1
+百尺楼	bai chi lou	1
+百尺楼高水接天	bai chi lou gao shui jie tian	1
+百川灌河	bai chuan guan he	1
+白帝城边古木疏	bai di cheng bian gu mu shu	1
+白帝城高急暮砧	bai di cheng gao ji mu zhen	1
+白帝城头月向西	bai di cheng tou yue xiang xi	1
+白帝城下雨翻盆	bai di cheng xia yu fan pen	1
+白帝城中云出门	bai di cheng zhong yun chu men	1
+白帝高为三峡镇	bai di gao wei san xia zhen	1
+百堵皆作	bai du jie zuo	1
+拜而受之	bai er shou zhi	1
+百尔所思	bai er suo si	1
+百发百中无虚弦	bai fa bai zhong wu xu xian	1
+白发悲花落	bai fa bei hua luo	1
+白发催年老	bai fa cui nian lao	1
+白发自然生	bai fa zi ran sheng	1
+百夫之特	bai fu zhi te	1
+百舸争流	bai ge zheng liu	1
+白鸽子	bai ge zi	1
+白骨乱蓬蒿	bai gu luan peng hao	1
+百官之富	bai guan zhi fu	1
+白鹤子	bai he zi	1
+百花迹已绝	bai hua ji yi jue	1
+百花如旧日	bai hua ru jiu ri	1
+百花潭水即沧浪	bai hua tan shui ji cang lang	1
+白花垣上望京师	bai hua yuan shang wang jing shi	1
+白君瑞	bai jun rui	1
+白狼河北音书断	bai lang he bei yin shu duan	1
+白浪茫茫与海连	bai lang mang mang yu hai lian	1
+白浪滔天	bai lang tao tian	1
+百牢关	bai lao guan	1
+百里见秋毫	bai li jian qiu hao	1
+百里闻雷震	bai li wen lei zhen	1
+百里榆堤半日风	bai li yu di ban ri feng	1
+百两御之	bai liang yu zhi	1
+白露含明月	bai lu han ming yue	1
+白鹭下秋水	bai lu xia qiu shui	1
+白马出城中	bai ma chu cheng zhong	1
+败马号鸣向天悲	bai ma hao ming xiang tian bei	1
+白马嚼啮黄金勒	bai ma jiao nie huang jin le	1
+白茅包之	bai mao bao zhi	1
+白茅纯束	bai mao chun shu	1
+百媚娘	bai mei niang	1
+白门寥落意多违	bai men liao luo yi duo wei	1
+白敏中	bai min zhong	1
+百亩之田	bai mu zhi tian	1
+百年长扰扰	bai nian chang rao rao	1
+百年都是几多时	bai nian dou shi ji duo shi	1
+百年歌自苦	bai nian ge zi ku	1
+百年老屋	bai nian lao wu	1
+百年离别在高楼	bai nian li bie zai gao lou	1
+百年魔怪舞翩跹	bai nian mo guai wu pian xian	1
+百年三万六千日	bai nian san wan liu qian ri	1
+白鸟悠悠下	bai niao you you xia	1
+白日不照吾精诚	bai ri bu zhao wu jing cheng	1
+白日当天三月半	bai ri dang tian san yue ban	1
+白日登山望烽火	bai ri deng shan wang feng huo	1
+白日何短短	bai ri he duan duan	1
+白日落梁州	bai ri luo liang zhou	1
+白日暖	bai ri nuan	1
+白日向西没	bai ri xiang xi mei	1
+白石皓皓	bai shi hao hao	1
+白石岩扉碧藓滋	bai shi yan fei bi xian zi	1
+白首不相弃	bai shou bu xiang qi	1
+拜手落花春	bai shou luo hua chun	1
+白首太玄经	bai shou tai xuan jing	1
+白首忘机	bai shou wang ji	1
+白首卧松云	bai shou wo song yun	1
+白首相知犹按剑	bai shou xiang zhi you an jian	1
+白首一先生	bai shou yi xian sheng	1
+白水明田外	bai shui ming tian wai	1
+白水暮东流	bai shui mu dong liu	1
+白水真人居	bai shui zhen ren ju	1
+白头吊古风霜里	bai tou diao gu feng shuang li	1
+白头宫女在	bai tou gong nv zai	1
+白兔捣药秋复春	bai tu dao yao qiu fu chun	1
+白团扇	bai tuan shan	1
+百万工农齐踊跃	bai wan gong nong qi yong yue	1
+百万雄师过大江	bai wan xiong shi guo da jiang	1
+百万之师	bai wan zhi shi	1
+百物生焉	bai wu sheng yan	1
+拜新月	bai xin yue	1
+拜星	bai xing	1
+百姓不足	bai xing bu zu	1
+百姓皆谓	bai xing jie wei	1
+百姓有过	bai xing you guo	1
+拜星月	bai xing yue	1
+百姓之不见保	bai xing zhi bu jian bao	1
+白萱	bai xuan	1
+白雪	bai xue	1
+白雪词	bai xue ci	1
+白雪关山远	bai xue guan shan yuan	1
+白雪梅花处处吹	bai xue mei hua chu chu chui	1
+白雪难同调	bai xue nan tong diao	1
+百宜娇	bai yi jiao	1
+拜迎官长心欲碎	bai ying guan zhang xin yu sui	1
+百有余年矣	bai you yu nian yi	1
+白玉不毁	bai yu bu hui	1
+白玉谁家郎	bai yu shui jia lang	1
+白玉堂前一树梅	bai yu tang qian yi shu mei	1
+百越之君	bai yue zhi jun	1
+白云长在天	bai yun chang zai tian	1
+白云愁色满苍梧	bai yun chou se man cang wu	1
+白云处处长随君	bai yun chu chu chang sui jun	1
+白云还自散	bai yun hai zi san	1
+白云回望合	bai yun hui wang he	1
+白云千里万里	bai yun qian li wan li	1
+白云如有意	bai yun ru you yi	1
+白云山头云欲立	bai yun shan tou yun yu li	1
+白云山下呼声急	bai yun shan xia hu sheng ji	1
+白云生镜里	bai yun sheng jing li	1
+白云无尽时	bai yun wu jin shi	1
+白云依静渚	bai yun yi jing zhu	1
+白云映水摇空城	bai yun ying shui yao kong cheng	1
+白云在青天	bai yun zai qing tian	1
+百战疲劳壮士哀	bai zhan pi lao zhuang shi ai	1
+百战沙场碎铁衣	bai zhan sha chang sui tie yi	1
+百丈山	bai zhang shan	1
+柏舟	bai zhou	1
+百字谣	bai zi yao	1
+百字字	bai zi zi	1
+半壁见海日	ban bi jian hai ri	1
+半留相送半迎归	ban liu xiang song ban ying gui	1
+半落青天外	ban luo qing tian wai	1
+板桥晓别	ban qiao xiao bie	1
+半洒云天里	ban sa yun tian li	1
+伴云来	ban yun lai	1
+斑竹一支千滴泪	ban zhu yi zhi qian di lei	1
+斑竹一枝千滴泪	ban zhu yi zhi qian di lei	1
+斑竹枝	ban zhu zhi	1
+斑骓只系垂杨岸	ban zhui zhi xi chui yang an	1
+半作障泥半作帆	ban zuo zhang ni ban zuo fan	1
+邦君之妻	bang jun zhi qi	1
+邦无道如矢	bang wu dao ru shi	1
+邦以民为本	bang yi min wei ben	1
+邦有道如矢	bang you dao ru shi	1
+邦有道则仕	bang you dao ze shi	1
+抱布贸丝	bao bu mao si	1
+保持乐观	bao chi le guan	1
+保此道者	bao ci dao zhe	1
+报答平生未展眉	bao da ping sheng wei zhan mei	1
+报道敌军宵遁	bao dao di jun xiao dun	1
+报到山中去	bao dao shan zhong qu	1
+报得三春辉	bao de san chun hui	1
+鲍防	bao fang	1
+褒公鄂公毛发动	bao gong e gong mao fa dong	1
+抱关击柝	bao guan ji tuo	1
+报国无成空白首	bao guo wu cheng kong bai shou	1
+包何	bao he	1
+包贺	bao he	1
+暴虎冯河	bao hu ping he	1
+包恢	bao hui	1
+包佶	bao ji	1
+宝剑直千金	bao jian zhi qian jin	1
+宝镜似空水	bao jing si kong shui	1
+包举宇内	bao ju yu nei	1
+鲍君徽	bao jun hui	1
+暴君污吏	bao jun wu li	1
+鲍老催	bao lao cui	1
+鲍令晖	bao ling hui	1
+抱明月而长终	bao ming yue er chang zhong	1
+抱琴看鹤去	bao qin kan he qu	1
+报任安书节选	bao ren an shu jie xuan	1
+包融	bao rong	1
+鲍溶	bao rong	1
+宝扇迎归九华帐	bao shan ying gui jiu hua zhang	1
+饱食终日	bao shi zhong ri	1
+褒姒灭之	bao si mie zhi	1
+报孙会宗书	bao sun hui zong shu	1
+暴殄天物圣所哀	bao tian tian wu sheng suo ai	1
+报我不述	bao wo bu shu	1
+包羞忍耻是男儿	bao xiu ren chi shi nan er	1
+包颖	bao ying	1
+鸨羽	bao yu	1
+褒之庐冢也	bao zhi lu zhong ye	1
+报之以琼玖	bao zhi yi qiong jiu	1
+报之以琼琚	bao zhi yi qiong ju	1
+北朝民歌	bei chao min ge	1
+北狄愿和亲	bei di yuan he qin	1
+北斗兼春远	bei dou jian chun yuan	1
+北斗阑干南斗斜	bei dou lan gan nan dou xie	1
+北斗七星高	bei dou qi xing gao	1
+北斗七星横夜半	bei dou qi xing heng ye ban	1
+北风北风	bei feng bei feng	1
+北风吹白云	bei feng chui bai yun	1
+北风吹裙带	bei feng chui qun dai	1
+北风其凉	bei feng qi liang	1
+背负青天朝下看	bei fu qing tian chao xia kan	1
+背归鸿	bei gui hong	1
+北国风光	bei guo feng guang	1
+北海若曰	bei hai ruo yue	1
+背后何所见	bei hou he suo jian	1
+北极朝庭终不改	bei ji chao ting zhong bu gai	1
+北京中华书局	bei jing zhong hua shu ju	1
+悲来乎	bei lai hu	1
+悲凉千里道	bei liang qian li dao	1
+北流活活	bei liu huo huo	1
+北邙无数荒丘	bei mang wu shu huang qiu	1
+背面秋千下	bei mian qiu qian xia	1
+杯盘狼籍	bei pan lang ji	1
+北齐二首	bei qi er shou	1
+北青萝	bei qing luo	1
+被驱不异犬与鸡	bei qu bu yi quan yu ji	1
+北阙休上书	bei que xiu shang shu	1
+背若泰山	bei ruo tai shan	1
+北山白云里	bei shan bai yun li	1
+北山移文	bei shan yi wen	1
+北上太行山	bei shang tai hang shan	1
+背世返能厌俗态	bei shi fan neng yan su tai	1
+北收要害之郡	bei shou yao hai zhi jun	1
+北土非吾愿	bei tu fei wu yuan	1
+北杨柳	bei yang liu	1
+悲哉行	bei zai xing	1
+悲中乐	bei zhong le	1
+奔波奚所营	ben bo xi suo ying	1
+本长安倡女	ben chang an chang nv	1
+本电子版	ben dian zi ban	1
+本纪十二	ben ji shi er	1
+本是池中物	ben shi chi zhong wu	1
+奔腾急	ben teng ji	1
+本图宦达	ben tu huan da	1
+本为贵公子	ben wei gui gong zi	1
+本性能耐寒	ben xing neng nai han	1
+本以高难饱	ben yi gao nan bao	1
+本在于上	ben zai yu shang	1
+本之则无	ben zhi ze wu	1
+本自无教训	ben zi wu jiao xun	1
+本自无人识	ben zi wu ren shi	1
+崩年亦在永安宫	beng nian yi zai yong an gong	1
+迸泉飒飒飞木末	beng quan sa sa fei mu mo	1
+迸水落遥空	beng shui luo yao kong	1
+必变色而作	bi bian se er zuo	1
+必表而出之	bi biao er chu zhi	1
+必不得已而去	bi bu de yi er qu	1
+彼采艾兮	bi cai ai xi	1
+彼采葛兮	bi cai ge xi	1
+彼采萧兮	bi cai xiao xi	1
+彼苍者天	bi cang zhe tian	1
+必朝服而朝	bi chao fu er chao	1
+碧城三首	bi cheng san shou	1
+碧城十二曲阑干	bi cheng shi er qu lan gan	1
+彼出于是	bi chu yu shi	1
+碧窗梦	bi chuang meng	1
+彼此甘心无后期	bi ci gan xin wu hou qi	1
+彼恶得而知之	bi e de er zhi zhi	1
+彼恶知之	bi e zhi zhi	1
+彼尔维何	bi er wei he	1
+蔽芾甘棠	bi fei gan tang	1
+碧峰出山后	bi feng chu shan hou	1
+比干谏而死	bi gan jian er si	1
+必告父母	bi gao fu mu	1
+敝笱	bi gou	1
+必故强之	bi gu qiang zhi	1
+必故兴之	bi gu xing zhi	1
+必故与之	bi gu yu zhi	1
+必故张之	bi gu zhang zhi	1
+彼何人斯	bi he ren si	1
+碧荷生幽泉	bi he sheng you quan	1
+必河之鲤	bi he zhi li	1
+必积其德义	bi ji qi de yi	1
+比及三年	bi ji san nian	1
+彼稷之苗	bi ji zhi miao	1
+彼稷之实	bi ji zhi shi	1
+彼稷之穗	bi ji zhi sui	1
+彼狡童兮	bi jiao tong xi	1
+必浚其泉源	bi jun qi quan yuan	1
+彼君子兮	bi jun zi xi	1
+壁立千仞无依倚	bi li qian ren wu yi yi	1
+鄙陋没世	bi lou mo shi	1
+彼路斯何	bi lu si he	1
+鄙嫚不能萌	bi man bu neng meng	1
+比梅	bi mei	1
+彼美孟姜	bi mei meng jiang	1
+彼美人兮	bi mei ren xi	1
+闭门春尽杨花落	bi men chun jin yang hua luo	1
+碧梦	bi meng	1
+碧牡丹	bi mu dan	1
+比目鱼	bi mu yu	1
+比其反也	bi qi fan ye	1
+必齐如也	bi qi ru ye	1
+彼其于世	bi qi yu shi	1
+必齐之姜	bi qi zhi jiang	1
+彼其之子	bi qi zhi zi	1
+必千乘之家	bi qian sheng zhi jia	1
+彼且恶乎待哉	bi qie e hu dai zai	1
+彼窃钩者诛	bi qie gou zhe zhu	1
+彼且奚适也	bi qie xi shi ye	1
+比权量力	bi quan liang li	1
+碧纱如烟隔窗语	bi sha ru yan ge chuang yu	1
+必世而后仁	bi shi er hou ren	1
+必使反之	bi shi fan zhi	1
+彼是莫得其偶	bi shi mo de qi ou	1
+避世之人	bi shi zhi ren	1
+必熟而荐之	bi shu er jian zhi	1
+彼黍离离	bi shu li li	1
+碧树银台万种色	bi shu yin tai wan zhong se	1
+碧水浩浩云茫茫	bi shui hao hao yun mang mang	1
+笔所未到气已吞	bi suo wei dao qi yi tun	1
+彼童子之师	bi tong zi zhi shi	1
+必闻其政	bi wen qi zheng	1
+碧文圆顶夜深缝	bi wen yuan ding ye shen feng	1
+碧梧栖老凤凰枝	bi wu qi lao feng huang zhi	1
+鼻息干虹蜺	bi xi gan hong ni	1
+彼陷溺其民	bi xian ni qi min	1
+碧虚	bi xu	1
+毕耀	bi yao	1
+彼尧舜之耿介兮	bi yao shun zhi geng jie xi	1
+必也狂狷乎	bi ye kuang juan hu	1
+必也临事而惧	bi ye lin shi er ju	1
+必也射乎	bi ye she hu	1
+必也圣乎	bi ye sheng hu	1
+必也使无讼乎	bi ye shi wu song hu	1
+必以告妾	bi yi gao qie	1
+比翼共翱翔	bi yi gong ao xiang	1
+必以身后之	bi yi shen hou zhi	1
+彼亦是也	bi yi shi ye	1
+必以言下之	bi yi yan xia zhi	1
+彼亦一是非	bi yi yi shi fei	1
+碧鹦鹉对红蔷薇	bi ying wu dui hong qiang wei	1
+必有可观者焉	bi you ke guan zhe yan	1
+必有明衣	bi you ming yi	1
+必有寝衣	bi you qin yi	1
+必有事焉而勿正	bi you shi yan er wu zheng	1
+必有我师	bi you wo shi	1
+必有凶年	bi you xiong nian	1
+彼与彼年相若也	bi yu bi nian xiang ruo ye	1
+比于赤子	bi yu chi zi	1
+碧玉搔头落水中	bi yu sao tou luo shui zhong	1
+碧玉箫	bi yu xiao	1
+比予于毒	bi yu yu du	1
+彼于致福者	bi yu zhi fu zhe	1
+碧云深	bi yun shen	1
+彼泽之陂	bi ze zhi bei	1
+笔阵独扫千人军	bi zhen du sao qian ren jun	1
+必正席先尝之	bi zheng xi xian chang zhi	1
+敝之而无憾	bi zhi er wu han	1
+必作于细	bi zuo yu xi	1
+必作于易	bi zuo yu yi	1
+边草尽来兵老	bian cao jin lai bing lao	1
+边草无穷日暮	bian cao wu qiong ri mu	1
+边城路	bian cheng lu	1
+边城暮雨雁飞低	bian cheng mu yu yan fei di	1
+遍地英雄下夕烟	bian di ying xiong xia xi yan	1
+变调如闻杨柳春	bian diao ru wen yang liu chun	1
+笾豆之事	bian dou zhi shi	1
+变而有气	bian er you qi	1
+边风飘飘那可度	bian feng piao piao na ke du	1
+汴河怀古	bian he huai gu	1
+汴河阻冻	bian he zu dong	1
+辩乎荣辱之境	bian hu rong ru zhi jing	1
+便即下阶拜	bian ji xia jie bai	1
+便可白公姥	bian ke bai gong lao	1
+便利此月内	bian li ci yue nei	1
+遍历名山大川	bian li ming shan da chuan	1
+褊浅无所用	bian qian wu suo yong	1
+遍绕篱边日渐斜	bian rao li bian ri jian xie	1
+边亭流血成海水	bian ting liu xue cheng hai shui	1
+边庭流血成海水	bian ting liu xue cheng hai shui	1
+边庭飘摇那可度	bian ting piao yao na ke du	1
+便言多令才	bian yan duo ling cai	1
+便有精生白骨堆	bian you jing sheng bai gu dui	1
+便至四十西营田	bian zhi si shi xi ying tian	1
+便作旦夕间	bian zuo dan xi jian	1
+变作呜咽声	bian zuo wu ye sheng	1
+骠国乐	biao guo yue	1
+摽有梅	biao you mei	1
+别房太尉墓	bie fang tai wei mu	1
+别君去时何时还	bie jun qu shi he shi hai	1
+别来沧海事	bie lai cang hai shi	1
+别离时节	bie li shi jie	1
+别离在今晨	bie li zai jin chen	1
+别路绕山川	bie lu rao shan chuan	1
+别梦依稀咒逝川	bie meng yi xi zhou shi chuan	1
+别时多	bie shi duo	1
+别时茫茫江浸月	bie shi mang mang jiang jin yue	1
+别树羁雌昨夜惊	bie shu ji ci zuo ye jing	1
+别仙子	bie xian zi	1
+别巷寂寥人散后	bie xiang ji liao ren san hou	1
+别徐州	bie xu zhou	1
+别样清幽	bie yang qing you	1
+别有根芽	bie you gen ya	1
+别有天地非人间	bie you tian di fei ren jian	1
+别怨	bie yuan	1
+鬓边华	bin bian hua	1
+宾不顾矣	bin bu gu yi	1
+鬓发各已苍	bin fa ge yi cang	1
+鬓丝生几缕	bin si sheng ji lv	1
+鬓云松	bin yun song	1
+兵残楚帐夜闻歌	bing can chu zhang ye wen ge	1
+兵车行	bing che xing	1
+并蒂芙蓉	bing di fu rong	1
+兵法修列	bing fa xiu lie	1
+兵革非不坚利也	bing ge fei bu jian li ye	1
+兵革既未息	bing ge ji wei xi	1
+秉国之钧	bing guo zhi jun	1
+冰肌玉骨清无汗	bing ji yu gu qing wu han	1
+禀君子	bing jun zi	1
+屏气似不息者	bing qi si bu xi zhe	1
+冰轻叶未凋	bing qing ye wei diao	1
+兵刃既接	bing ren ji jie	1
+冰山滴	bing shan di	1
+病身坚固道情深	bing shen jian gu dao qing shen	1
+病身最觉风露早	bing shen zui jue feng lu zao	1
+冰霜昨夜除	bing shuang zuo ye chu	1
+并添高阁迥	bing tian gao ge jiong	1
+并吞八荒之心	bing tun ba huang zhi xin	1
+兵卫森画戟	bing wei sen hua ji	1
+病为兀兀安身物	bing wei wu wu an shen wu	1
+冰崖转石万壑雷	bing ya zhuan shi wan he lei	1
+兵者不祥之器	bing zhe bu xiang zhi qi	1
+并作南楼一味凉	bing zuo nan lou yi wei liang	1
+拨不断	bo bu duan	1
+薄乎云尔	bo hu yun er	1
+薄宦梗犹泛	bo huan geng you fan	1
+薄酒可与忘忧	bo jiu ke yu wang you	1
+波澜动远空	bo lan dong yuan kong	1
+波澜誓不起	bo lan shi bu qi	1
+波澜相背惊	bo lan xiang bei jing	1
+薄命女	bo ming nv	1
+薄暮空潭曲	bo mu kong tan qu	1
+薄暮渔樵乘水入	bo mu yu qiao cheng shui ru	1
+伯牛有疾	bo niu you ji	1
+勃如战色	bo ru zhan se	1
+波上马嘶看棹去	bo shang ma si kan zhao qu	1
+伯氏吹埙	bo shi chui xun	1
+薄苇纫如丝	bo wei ren ru si	1
+薄污我私	bo wu wo si	1
+伯兮	bo xi	1
+博学而无所成名	bo xue er wu suo cheng ming	1
+博学于文	bo xue yu wen	1
+薄言采之	bo yan cai zhi	1
+薄言掇之	bo yan duo zhi	1
+薄言捋之	bo yan luo zhi	1
+薄言有之	bo yan you zhi	1
+伯也执殳	bo ye zhi shu	1
+伯夷叔齐	bo yi shu qi	1
+伯禹亦不如	bo yu yi bu ru	1
+泊岳阳城下	bo yue yang cheng xia	1
+搏之不得	bo zhi bu de	1
+伯仲之间见伊吕	bo zhong zhi jian jian yi lv	1
+泊舟微径度深松	bo zhou wei jing du shen song	1
+不爱红装爱武装	bu ai hong zhuang ai wu zhuang	1
+不把双眉斗画长	bu ba shuang mei dou hua chang	1
+不保社稷	bu bao she ji	1
+不保四海	bu bao si hai	1
+不保四体	bu bao si ti	1
+不必取长途	bu bi qu chang tu	1
+不必问君平	bu bi wen jun ping	1
+不辩牛马	bu bian niu ma	1
+不辨仙源何处寻	bu bian xian yuan he chu xun	1
+不薄今人爱古人	bu bo jin ren ai gu ren	1
+步步娇	bu bu jiao	1
+不采而佩	bu cai er pei	1
+不才明主弃	bu cai ming zhu qi	1
+不惭世上英	bu can shi shang ying	1
+步蟾宫	bu chan gong	1
+不撤姜食	bu che jiang shi	1
+不称其服	bu cheng qi fu	1
+不成人之恶	bu cheng ren zhi e	1
+不耻相师	bu chi xiang shi	1
+不愁明月尽	bu chou ming yue jin	1
+步出城东门	bu chu cheng dong men	1
+步出东斋读	bu chu dong zhai du	1
+不出三日	bu chu san ri	1
+不出三十年	bu chu san shi nian	1
+不辞山路远	bu ci shan lu yuan	1
+不待作年芳	bu dai zuo nian fang	1
+不到长城非好汉	bu dao chang cheng fei hao han	1
+不道引而寿	bu dao yin er shou	1
+不道早已	bu dao zao yi	1
+不道之道	bu dao zhi dao	1
+不得便相许	bu de bian xiang xu	1
+不得春风花不开	bu de chun feng hua bu kai	1
+不得到辽西	bu de dao liao xi	1
+不得顾采薇	bu de gu cai wei	1
+不得乎亲	bu de hu qin	1
+不得其酱	bu de qi jiang	1
+不得其死然	bu de qi si ran	1
+不得其所	bu de qi suo	1
+不得收骨肉	bu de shou gu rou	1
+不得通其道	bu de tong qi dao	1
+不得吾心	bu de wu xin	1
+不得已而用之	bu de yi er yong zhi	1
+不得已也	bu de yi ye	1
+不得与之言	bu de yu zhi yan	1
+不得志独行其道	bu de zhi du xing qi dao	1
+不得中行而与之	bu de zhong hang er yu zhi	1
+卜尔	bu er	1
+不二法门无别路	bu er fa men wu bie lu	1
+不犯此	bu fan ci	1
+不妨长作岭南人	bu fang chang zuo ling nan ren	1
+不分贫富	bu fen pin fu	1
+不复东西征	bu fu dong xi zheng	1
+不复理残机	bu fu li can ji	1
+不复挺者	bu fu ting zhe	1
+不抚壮而弃秽兮	bu fu zhuang er qi hui xi	1
+不改清阴待我归	bu gai qing yin dai wo gui	1
+不敢暴虎	bu gan bao hu	1
+不敢不告也	bu gan bu gao ye	1
+不敢告劳	bu gan gao lao	1
+不敢过临洮	bu gan guo lin tao	1
+不敢恨长沙	bu gan hen chang sha	1
+不敢请耳	bu gan qing er	1
+不敢为天下先	bu gan wei tian xia xian	1
+不敢言而敢怒	bu gan yan er gan nu	1
+不敢倚先贤	bu gan yi xian xian	1
+不敢饮食	bu gan yin shi	1
+不共楚王言	bu gong chu wang yan	1
+不管风吹浪打	bu guan feng chui lang da	1
+不关情处总伤心	bu guan qing chu zong shang xin	1
+不贵难得之货	bu gui nan de zhi huo	1
+不贵其师	bu gui qi shi	1
+不过满腹	bu guo man fu	1
+不过数仞而下	bu guo shu ren er xia	1
+不过一枝	bu guo yi zhi	1
+不耗复不盈	bu hao fu bu ying	1
+不恒其德	bu heng qi de	1
+步花间	bu hua jian	1
+不患莫己知	bu huan mo ji zhi	1
+不患贫而患不安	bu huan pin er huan bu an	1
+不患人之不己知	bu huan ren zhi bu ji zhi	1
+不患无位	bu huan wu wei	1
+不记归时节	bu ji gui shi jie	1
+不霁何虹	bu ji he hong	1
+不及卢家有莫愁	bu ji lu jia you mo chou	1
+不及石尤风	bu ji shi you feng	1
+不稼不穑	bu jia bu se	1
+不嫁义郎体	bu jia yi lang ti	1
+不见而明	bu jian er ming	1
+不见复关	bu jian fu guan	1
+不见高人王右丞	bu jian gao ren wang you cheng	1
+不见居人只见城	bu jian ju ren zhi jian cheng	1
+不见君	bu jian jun	1
+不见李生久	bu jian li sheng jiu	1
+不见其身	bu jian qi shen	1
+不见前年秋月朗	bu jian qian nian qiu yue lang	1
+不见水端	bu jian shui duan	1
+不见一人来	bu jian yi ren lai	1
+不见有人还	bu jian you ren hai	1
+不见诸侯	bu jian zhu hou	1
+不见子充	bu jian zi chong	1
+不见子都	bu jian zi du	1
+不教而杀谓之虐	bu jiao er sha wei zhi nue	1
+不教胡马渡阴山	bu jiao hu ma du yin shan	1
+不戒视成谓之暴	bu jie shi cheng wei zhi bao	1
+不矜名节	bu jin ming jie	1
+不近人情焉	bu jin ren qing yan	1
+不久当归还	bu jiu dang gui hai	1
+不久当还归	bu jiu dang hai gui	1
+不久望君来	bu jiu wang jun lai	1
+不居其薄	bu ju qi bo	1
+不居其华	bu ju qi hua	1
+不据山河据平地	bu ju shan he ju ping di	1
+不拘于时	bu ju yu shi	1
+不觉碧山暮	bu jue bi shan mu	1
+不觉成长叹	bu jue cheng chang tan	1
+不觉前贤畏后生	bu jue qian xian wei hou sheng	1
+不绝如缕	bu jue ru lv	1
+不觉已鸣鸦	bu jue yi ming ya	1
+不觉犹歌起夜来	bu jue you ge qi ye lai	1
+不骏其德	bu jun qi de	1
+不开悟	bu kai wu	1
+不堪持寄君	bu kan chi ji jun	1
+不堪吏人妇	bu kan li ren fu	1
+不堪母驱使	bu kan mu qu shi	1
+不堪人事日萧条	bu kan ren shi ri xiao tiao	1
+不堪盈手赠	bu kan ying shou zeng	1
+不可不察也	bu ke bu cha ye	1
+不可不畏	bu ke bu wei	1
+不可不语	bu ke bu yu	1
+不可不知也	bu ke bu zhi ye	1
+不可长保	bu ke chang bao	1
+不可道也	bu ke dao ye	1
+不可得而	bu ke de er	1
+不可得而疏	bu ke de er shu	1
+不可得而闻也	bu ke de er wen ye	1
+不可得也	bu ke de ye	1
+不可得矣	bu ke de yi	1
+不可雕也	bu ke diao ye	1
+不可读也	bu ke du ye	1
+不可多取	bu ke duo qu	1
+不可方思	bu ke fang si	1
+不可沽名学霸王	bu ke gu ming xue ba wang	1
+不可乎不可	bu ke hu bu ke	1
+不可毁也	bu ke hui ye	1
+不可及也	bu ke ji ye	1
+不可救乎	bu ke jiu hu	1
+不可卷也	bu ke juan ye	1
+不可求思	bu ke qiu si	1
+不可胜记	bu ke sheng ji	1
+不可失也	bu ke shi ye	1
+不可使知之	bu ke shi zhi zhi	1
+不可数计	bu ke shu ji	1
+不可说也	bu ke shuo ye	1
+不可罔也	bu ke wang ye	1
+不可为量数	bu ke wei liang shu	1
+不可为也	bu ke wei ye	1
+不可圬也	bu ke wu ye	1
+不可陷也	bu ke xian ye	1
+不可休息	bu ke xiu xi	1
+不可选也	bu ke xuan ye	1
+不可以长处乐	bu ke yi chang chu le	1
+不可以久处约	bu ke yi jiu chu yue	1
+不可以据	bu ke yi ju	1
+不可以请	bu ke yi qing	1
+不可一日无此君	bu ke yi ri wu ci jun	1
+不可以茹	bu ke yi ru	1
+不可以物	bu ke yi wu	1
+不可以语上也	bu ke yi yu shang ye	1
+不可泳思	bu ke yong si	1
+不可则止	bu ke ze zhi	1
+不可执也	bu ke zhi ye	1
+不可转也	bu ke zhuan ye	1
+不肯低头在草莽	bu ken di tou zai cao mang	1
+不肯脱罗衣	bu ken tuo luo yi	1
+不肯暂回车	bu ken zan hui che	1
+不愧于人	bu kui yu ren	1
+不乐复何如	bu le fu he ru	1
+不露文章世已惊	bu lu wen zhang shi yi jing	1
+不论军民	bu lun jun min	1
+不寐倦长更	bu mei juan chang geng	1
+不谋其政	bu mou qi zheng	1
+不能成方圆	bu neng cheng fang yuan	1
+不能废人运酒舫	bu neng fei ren yun jiu fang	1
+不能奋飞	bu neng fen fei	1
+不能过也	bu neng guo ye	1
+不能十步	bu neng shi bu	1
+不能以礼让为国	bu neng yi li rang wei guo	1
+不能用也	bu neng yong ye	1
+不能正其身	bu neng zheng qi shen	1
+不能专对	bu neng zhuan dui	1
+不拟回头望故乡	bu ni hui tou wang gu xiang	1
+不念旧恶	bu nian jiu e	1
+不念居安思危	bu nian ju an si wei	1
+不念昔者	bu nian xi zhe	1
+不宁不令	bu ning bu ling	1
+不怕醉	bu pa zui	1
+不破楼兰终不还	bu po lou lan zhong bu huan	1
+不其然乎	bu qi ran hu	1
+不遣胡儿匹马还	bu qian hu er pi ma hai	1
+不寝听金钥	bu qin ting jin yao	1
+不求友生	bu qiu you sheng	1
+不然烦恼万涂侵	bu ran fan nao wan tu qin	1
+不然则已	bu ran ze yi	1
+不仁不智	bu ren bu zhi	1
+不忍见此物	bu ren jian ci wu	1
+不忍见其死	bu ren jian qi si	1
+不忍食其肉	bu ren shi qi rou	1
+不忍云间两分张	bu ren yun jian liang fen zhang	1
+不仁则辱	bu ren ze ru	1
+不仁者远矣	bu ren zhe yuan yi	1
+不仁之人	bu ren zhi ren	1
+不日不月	bu ri bu yue	1
+不日成之	bu ri cheng zhi	1
+不日有曀	bu ri you yi	1
+不如不相见	bu ru bu xiang jian	1
+不如不行	bu ru bu xing	1
+不如乘势	bu ru cheng shi	1
+不如待时	bu ru dai shi	1
+不如高卧且加餐	bu ru gao wo qie jia can	1
+不如归去	bu ru gui qu	1
+不如尽此花下欢	bu ru jin ci hua xia huan	1
+不辱其身	bu ru qi shen	1
+不如丘之好学也	bu ru qiu zhi hao xue ye	1
+不如仁人	bu ru ren ren	1
+不如是之甚也	bu ru shi zhi shen ye	1
+不入我门	bu ru wo men	1
+不如我所之	bu ru wo suo zhi	1
+不如相忘于江湖	bu ru xiang wang yu jiang hu	1
+不如学也	bu ru xue ye	1
+不如因善遇之	bu ru yin shan yu zhi	1
+不如友生	bu ru you sheng	1
+不如早还家	bu ru zao huan jia	1
+不如早还乡	bu ru zao huan xiang	1
+不入则止	bu ru ze zhi	1
+不如诸夏之无也	bu ru zhu xia zhi wu ye	1
+不如子之衣	bu ru zi zhi yi	1
+不如坐进此道	bu ru zuo jin ci dao	1
+不若相忘于江湖	bu ruo xiang wang yu jiang hu	1
+不若与人	bu ruo yu ren	1
+不若与众	bu ruo yu zhong	1
+不洒离别间	bu sa li bie jian	1
+不善不能改	bu shan bu neng gai	1
+不善人者	bu shan ren zhe	1
+不善人之师	bu shan ren zhi shi	1
+不上不下	bu shang bu xia	1
+不舍昼夜	bu she zhou ye	1
+不胜清怨却飞来	bu sheng qing yuan que fei lai	1
+不是宸游玩物华	bu shi chen you wan wu hua	1
+不是花中偏爱菊	bu shi hua zhong pian ai ju	1
+不是路	bu shi lu	1
+不恃其成	bu shi qi cheng	1
+不失其所者久	bu shi qi suo zhe jiu	1
+不失其性命之情	bu shi qi xing ming zhi qing	1
+不是人间富贵花	bu shi ren jian fu gui hua	1
+不使胜食气	bu shi sheng shi qi	1
+不食五谷	bu shi wu gu	1
+不仕无义	bu shi wu yi	1
+不是杨花	bu shi yang hua	1
+不是一人能领导	bu shi yi ren neng ling dao	1
+不识有诸	bu shi you zhu	1
+不食之矣	bu shi zhi yi	1
+不狩不猎	bu shou bu lie	1
+不似春光	bu si chun guang	1
+不死何俟	bu si he si	1
+不俟驾行矣	bu si jia xing yi	1
+不思旧姻	bu si jiu yin	1
+不思其反	bu si qi fan	1
+不似颍川空使酒	bu si ying chuan kong shi jiu	1
+不素餐兮	bu su can xi	1
+卜算子慢	bu suan zi man	1
+不随以止也	bu sui yi zhi ye	1
+不体认	bu ti ren	1
+不脱蓑衣卧月明	bu tuo suo yi wo yue ming	1
+不忘其所始	bu wang qi suo shi	1
+不亡以待尽	bu wang yi dai jin	1
+不为爱人	bu wei ai ren	1
+不为不多矣	bu wei bu duo yi	1
+不为登高	bu wei deng gao	1
+不为而成	bu wei er cheng	1
+不为福先	bu wei fu xian	1
+不为功名	bu wei gong ming	1
+不为酒困	bu wei jiu kun	1
+不为离人照屋梁	bu wei li ren zhao wu liang	1
+不违农时	bu wei nong shi	1
+不违如愚	bu wei ru yu	1
+不为社者	bu wei she zhe	1
+不闻先王之遗言	bu wen xian wang zhi yi yan	1
+不我过	bu wo guo	1
+不我活兮	bu wo huo xi	1
+不我遐弃	bu wo xia qi	1
+不我信兮	bu wo xin xi	1
+不我以	bu wo yi	1
+不我以归	bu wo yi gui	1
+不我与	bu wo yu	1
+不吾知也	bu wu zhi ye	1
+不息恶木枝	bu xi e mu zhi	1
+不惜珊瑚持与人	bu xi shan hu chi yu ren	1
+不习水土	bu xi shui tu	1
+不瑕有害	bu xia you hai	1
+不贤者识其小者	bu xian zhe shi qi xiao zhe	1
+不向东山久	bu xiang dong shan jiu	1
+不相见	bu xiang jian	1
+不向空门何处销	bu xiang kong men he chu xiao	1
+不降其志	bu xiang qi zhi	1
+不相为谋	bu xiang wei mou	1
+不相与为谋	bu xiang yu wei mou	1
+不祥之器	bu xiang zhi qi	1
+不笑不足以为道	bu xiao bu zu yi wei dao	1
+不信比来长下泪	bu xin bi lai chang xia lei	1
+不信道	bu xin dao	1
+不信妾肠断	bu xin qie chang duan	1
+不幸短命死矣	bu xing duan ming si yi	1
+步行夺得胡马骑	bu xing duo de hu ma qi	1
+不幸牺牲	bu xing xi sheng	1
+不徐不疾	bu xu bu ji	1
+不须惆怅怨芳时	bu xu chou chang yuan fang shi	1
+步虚词	bu xu ci	1
+不须放屁	bu xu fang pi	1
+不须怀抱重凄凄	bu xu huai bao zhong qi qi	1
+步虚声	bu xu sheng	1
+不虚心	bu xu xin	1
+不学燕丹客	bu xue yan dan ke	1
+不要这多雪	bu yao zhe duo xue	1
+不要这高	bu yao zhe gao	1
+不夜月临关	bu ye yue lin guan	1
+不亦悲乎	bu yi bei hu	1
+不以兵车	bu yi bing che	1
+不以兵强天下	bu yi bing qiang tian xia	1
+不亿不信	bu yi bu xin	1
+不以辞害志	bu yi ci hai zhi	1
+不易得也	bu yi de ye	1
+不义而富且贵	bu yi er fu qie gui	1
+不以规矩	bu yi gui ju	1
+不亦过乎	bu yi guo hu	1
+不亦可乎	bu yi ke hu	1
+不以礼节之	bu yi li jie zhi	1
+不疑灵境难闻见	bu yi ling jing nan wen jian	1
+不亦难乎	bu yi nan hu	1
+不以其道得之	bu yi qi dao de zhi	1
+不以人废言	bu yi ren fei yan	1
+不以仁政	bu yi ren zheng	1
+不以人助天	bu yi ren zhu tian	1
+不以三隅反	bu yi san yu fan	1
+不亦善乎	bu yi shan hu	1
+不亦甚乎	bu yi shen hu	1
+怖亦死	bu yi si	1
+不以文害辞	bu yi wen hai ci	1
+不亦宜乎	bu yi yi hu	1
+不宜有怒	bu yi you nu	1
+不以智治国	bu yi zhi zhi guo	1
+不饮盗泉水	bu yin dao quan shui	1
+不应回首	bu ying hui shou	1
+不盈顷筐	bu ying qing kuang	1
+不用登临恨落晖	bu yong deng lin hen luo hui	1
+不有博弈者乎	bu you bo yi zhe hu	1
+不忧不惧	bu you bu ju	1
+不有雨兼风	bu you yu jian feng	1
+卜玉郎	bu yu lang	1
+不与泥同调	bu yu ni tong diao	1
+不与秦塞通人烟	bu yu qin sai tong ren yan	1
+不与我食兮	bu yu wo shi xi	1
+不与我言兮	bu yu wo yan xi	1
+不与物交	bu yu wu jiao	1
+不欲以静	bu yu yi jing	1
+不与之为谋	bu yu zhi wei mou	1
+不远千里而来	bu yuan qian li er lai	1
+步月	bu yue	1
+不曰白乎	bu yue bai hu	1
+不曰坚乎	bu yue jian hu	1
+不在其位	bu zai qi wei	1
+不在颛臾	bu zai zhuan yu	1
+不占而已矣	bu zhan er yi yi	1
+不忮不求	bu zhi bu qiu	1
+不知答也	bu zhi da ye	1
+不知道也	bu zhi dao ye	1
+不知地之厚也	bu zhi di zhi hou ye	1
+不知东方之既白	bu zhi dong fang zhi ji bai	1
+不知东走迷	bu zhi dong zou mi	1
+不知端倪	bu zhi duan ni	1
+不知何处吊湘君	bu zhi he chu diao xiang jun	1
+不知何处归	bu zhi he chu gui	1
+不知何处是他乡	bu zhi he chu shi ta xiang	1
+不知何道士	bu zhi he dao shi	1
+不知几何时	bu zhi ji he shi	1
+不知今夕是何年	bu zhi jin xi shi he nian	1
+不知命也	bu zhi ming ye	1
+不知其不胜任也	bu zhi qi bu sheng ren ye	1
+不知其几千里也	bu zhi qi ji qian li ye	1
+不知其尽也	bu zhi qi jin ye	1
+不知其期	bu zhi qi qi	1
+不知其仁	bu zhi qi ren	1
+不知其人可乎	bu zhi qi ren ke hu	1
+不知其仁也	bu zhi qi ren ye	1
+不知其所	bu zhi qi suo	1
+不知墙外是谁家	bu zhi qiang wai shi shui jia	1
+不知秋思在谁家	bu zhi qiu si zai shui jia	1
+不知身世自悠悠	bu zhi shen shi zi you you	1
+不知谁家子	bu zhi shui jia zi	1
+不知说生	bu zhi shuo sheng	1
+不知所以裁之	bu zhi suo yi cai zhi	1
+不治天下	bu zhi tian xia	1
+不知天之高也	bu zhi tian zhi gao ye	1
+不知恶死	bu zhi wu si	1
+不知西东	bu zhi xi dong	1
+不知香积寺	bu zhi xiang ji si	1
+不知心恨谁	bu zhi xin hen shui	1
+不知学问之大也	bu zhi xue wen zhi da ye	1
+不知有之	bu zhi you zhi	1
+不知园里树	bu zhi yuan li shu	1
+不知元是此花身	bu zhi yuan shi ci hua shen	1
+不知云与我俱东	bu zhi yun yu wo ju dong	1
+不知周也	bu zhi zhou ye	1
+不周山下红旗乱	bu zhou shan xia hong qi luan	1
+不主故常	bu zhu gu chang	1
+不庄以莅之	bu zhuang yi li zhi	1
+不自得而得彼者	bu zi de er de bi zhe	1
+不自著罗衣	bu zi zhu luo yi	1
+不足多也	bu zu duo ye	1
+不足以取天下	bu zu yi qu tian xia	1
+不足以为士矣	bu zu yi wei shi yi	1
+不足迎后人	bu zu ying hou ren	1
+采柏动盈掬	cai bai dong ying ju	1
+采采芣苡	cai cai fu yi	1
+采采衣服	cai cai yi fu	1
+采蘩	cai fan	1
+采蘩祁祁	cai fan qi qi	1
+采葑采菲	cai feng cai fei	1
+彩凤飞	cai feng fei	1
+裁缝寄远道	cai feng ji yuan dao	1
+蔡孚	cai fu	1
+采芙蓉	cai fu rong	1
+采葛	cai ge	1
+蔡瑰	cai gui	1
+才见岭头云似盖	cai jian ling tou yun si gai	1
+蔡戡	cai kan	1
+才可容颜十五馀	cai ke rong yan shi wu yu	1
+采苦采苦	cai ku cai ku	1
+蔡昆	cai kun	1
+采莲从小惯	cai lian cong xiao guan	1
+采莲归	cai lian gui	1
+采莲花	cai lian hua	1
+采莲女	cai lian nv	1
+采莲舟	cai lian zhou	1
+采莲子	cai lian zi	1
+采苓	cai ling	1
+彩鸾空自舞	cai luan kong zi wu	1
+采明珠	cai ming zhu	1
+材木不可胜用	cai mu bu ke sheng yong	1
+材木不可胜用也	cai mu bu ke sheng yong ye	1
+才能不及中人	cai neng bu ji zhong ren	1
+蔡女昔造胡笳声	cai nv xi zao hu jia sheng	1
+采苹	cai ping	1
+采芑	cai qi	1
+蔡确	cai que	1
+采桑绿水边	cai sang lv shui bian	1
+采桑子重阳	cai sang zi chong yang	1
+采山因买斧	cai shan yin mai fu	1
+采荼薪樗	cai tu xin chu	1
+采薇采薇	cai wei cai wei	1
+蔡文恭	cai wen gong	1
+财物无所取	cai wu wu suo qu	1
+才饮长江水	cai yin chang jiang shui	1
+材与不材之间	cai yu bu cai zhi jian	1
+蔡允恭	cai yun gong	1
+残杯与冷炙	can bei yu leng zhi	1
+蚕丛及鱼凫	can cong ji yu fu	1
+残灯无焰影幢幢	can deng wu yan ying chuang chuang	1
+残花落尽见流莺	can hua luo jin jian liu ying	1
+蚕饥妾欲去	can ji qie yu qu	1
+蚕眠桑叶稀	can mian sang ye xi	1
+残宵犹得梦依稀	can xiao you de meng yi xi	1
+残星拂大旗	can xing fu da qi	1
+残雪乱山中	can xue luan shan zhong	1
+残阳如血	can yang ru xue	1
+残阳西入崦	can yang xi ru yan	1
+残夜水明楼	can ye shui ming lou	1
+残莺何事不知秋	can ying he shi bu zhi qiu	1
+残萤栖玉露	can ying qi yu lu	1
+残月几人行	can yue ji ren xing	1
+残月落花烟重	can yue luo hua yan zhong	1
+残月下寒沙	can yue xia han sha	1
+残月下章台	can yue xia zhang tai	1
+残云归太华	can yun gui tai hua	1
+残云收夏暑	can yun shou xia shu	1
+残贼之人	can zei zhi ren	1
+残钟广陵树	can zhong guang ling shu	1
+残妆和泪污红绡	can zhuang he lei wu hong xiao	1
+苍苍横翠微	cang cang heng cui wei	1
+仓庚喈喈	cang geng jie jie	1
+沧海成桑田	cang hai cheng sang tian	1
+沧海得壮士	cang hai de zhuang shi	1
+沧海横流	cang hai heng liu	1
+沧海横流安足虑	cang hai heng liu an zu lv	1
+沧海月明珠有泪	cang hai yue ming zhu you lei	1
+沧江好烟月	cang jiang hao yan yue	1
+沧江急夜流	cang jiang ji ye liu	1
+沧浪亭记	cang lang ting ji	1
+沧浪之水清兮	cang lang zhi shui qing xi	1
+沧浪之水浊兮	cang lang zhi shui zhuo xi	1
+苍茫对落晖	cang mang dui luo hui	1
+苍茫古木连穷巷	cang mang gu mu lian qiong xiang	1
+苍茫云海间	cang mang yun hai jian	1
+苍然满关中	cang ran man guan zhong	1
+苍山夹乱流	cang shan jia luan liu	1
+苍山如海	cang shan ru hai	1
+藏书万卷可教子	cang shu wan juan ke jiao zi	1
+苍天苍天	cang tian cang tian	1
+苍梧山崩湘水绝	cang wu shan beng xiang shui jue	1
+苍梧谣	cang wu yao	1
+苍崖渺难涉	cang ya miao nan she	1
+苍鹰画作殊	cang ying hua zuo shu	1
+苍蝇之声	cang ying zhi sheng	1
+藏之名山	cang zhi ming shan	1
+曹豳	cao bin	1
+草不谢荣于春风	cao bu xie rong yu chun feng	1
+草草杯盘供笑语	cao cao bei pan gong xiao yu	1
+草创未就	cao chuang wei jiu	1
+曹风	cao feng	1
+草夫人	cao fu ren	1
+草绿长门掩	cao lv chang men yan	1
+草绿湖南万里情	cao lv hu nan wan li qing	1
+草木畅茂	cao mu chang mao	1
+草木茂萌芽	cao mu mao meng ya	1
+草木有本心	cao mu you ben xin	1
+草铺横野六七里	cao pu heng ye liu qi li	1
+草如茵	cao ru yin	1
+草色青青柳色黄	cao se qing qing liu se huang	1
+草色新雨中	cao se xin yu zhong	1
+草上之风	cao shang zhi feng	1
+草尚之风必偃	cao shang zhi feng bi yan	1
+曹生	cao sheng	1
+草市迎江货	cao shi ying jiang huo	1
+草书歌行	cao shu ge xing	1
+曹松	cao song	1
+曹唐	cao tang	1
+曹文姬	cao wen ji	1
+草屋八九间	cao wu ba jiu jian	1
+曹邺	cao ye	1
+曹遇	cao yu	1
+曹宰	cao zai	1
+曹著	cao zhu	1
+侧犯	ce fan	1
+侧见双翠鸟	ce jian shuang cui niao	1
+侧目似愁胡	ce mu si chou hu	1
+侧身西望常咨嗟	ce shen xi wang chang zi jie	1
+侧身西望长咨嗟	ce shen xi wang chang zi jie	1
+恻隐之心	ce yin zhi xin	1
+参差连曲陌	cen ci lian qu mo	1
+岑夫子	cen fu zi	1
+岑夫子丹丘生	cen fu zi dan qiu sheng	1
+岑羲	cen xi	1
+层冰积雪摧残	ceng bing ji xue cui can	1
+曾冰延乐方	ceng bing yan le fang	1
+曾不容刀	ceng bu rong dao	1
+层城四望开	ceng cheng si wang kai	1
+曾诞	ceng dan	1
+曾到尚书墓上来	ceng dao shang shu mu shang lai	1
+曾觌	ceng di	1
+曾栋	ceng dong	1
+曾记否	ceng ji fou	1
+曾将秋竹竿	ceng jiang qiu zhu gan	1
+曾经学舞度芳年	ceng jing xue wu du fang nian	1
+曾开国	ceng kai guo	1
+曾苦伤春不忍听	ceng ku shang chun bu ren ting	1
+曾揆	ceng kui	1
+曾隶	ceng li	1
+层林尽染	ceng lin jin ran	1
+曾驱十万师	ceng qu shi wan shi	1
+曾是寂寥金烬暗	ceng shi ji liao jin jin an	1
+曾是以为孝乎	ceng shi yi wei xiao hu	1
+曾无黄石公	ceng wu huang shi gong	1
+曾协	ceng xie	1
+曾由与求之问	ceng you yu qiu zhi wen	1
+曾允元	ceng yun yuan	1
+曾肇	ceng zhao	1
+曾照吴王宫里人	ceng zhao wu wang gong li ren	1
+曾逐东风拂舞筵	ceng zhu dong feng fu wu yan	1
+察臣孝廉	cha chen xiao lian	1
+差池不相见	cha chi bu xiang jian	1
+差池其羽	cha chi qi yu	1
+察乎盈虚	cha hu ying xu	1
+察邻国之政	cha lin guo zhi zheng	1
+茶瓶儿	cha ping er	1
+察言而观色	cha yan er guan se	1
+茶烟轻扬落花风	cha yan qing yang luo hua feng	1
+插羽破天骄	cha yu po tian jiao	1
+柴夔	chai kui	1
+豺狼尽冠缨	chai lang jin guan ying	1
+豺狼在邑龙在野	chai lang zai yi long zai ye	1
+柴门鸟雀噪	chai men niao que zao	1
+柴望	chai wang	1
+蟾蜍蚀圆影	chan chu shi yuan ying	1
+禅峰	chan feng	1
+缠绵成一家	chan mian cheng yi jia	1
+蝉鸣空桑林	chan ming kong sang lin	1
+刬却君山好	chan que jun shan hao	1
+刬袜步香阶	chan wa bu xiang jie	1
+刬袜下香阶	chan wa xia xiang jie	1
+蝉休露满枝	chan xiu lu man zhi	1
+单于猎火照狼山	chan yu lie huo zhao lang shan	1
+单于已在金山西	chan yu yi zai jin shan xi	1
+长安白日照春空	chang an bai ri zhao chun kong	1
+长安不见使人愁	chang an bu jian shi ren chou	1
+长安城连东掖垣	chang an cheng lian dong ye yuan	1
+长安城头头白乌	chang an cheng tou tou bai wu	1
+长安城中月如练	chang an cheng zhong yue ru lian	1
+长安大道连狭斜	chang an da dao lian xia xie	1
+长安宫阙九天上	chang an gong que jiu tian shang	1
+长安年少惜春残	chang an nian shao xi chun can	1
+长安女	chang an nv	1
+长安秋望	chang an qiu wang	1
+长安市上酒家眠	chang an shi shang jiu jia mian	1
+长安水边多丽人	chang an shui bian duo li ren	1
+长安一片月	chang an yi pian yue	1
+长安遇冯著	chang an yu feng zhu	1
+长安早春	chang an zao chun	1
+长飙风中自来往	chang biao feng zhong zi lai wang	1
+长不掩兰房	chang bu yan lan fang	1
+长春	chang chun	1
+常存抱柱信	chang cun bao zhu xin	1
+长岛人歌动地诗	chang dao ren ge dong di shi	1
+常德不离	chang de bu li	1
+常德乃足	chang de nai zu	1
+常棣	chang di	1
+常棣之华	chang di zhi hua	1
+长簟迎风早	chang dian ying feng zao	1
+肠断春江欲尽头	chang duan chun jiang yu jin tou	1
+肠断更无疑	chang duan geng wu yi	1
+肠断江城雁	chang duan jiang cheng yan	1
+肠断未忍扫	chang duan wei ren sao	1
+长而不宰	chang er bu zai	1
+长而无述焉	chang er wu shu yan	1
+长而异俗	chang er yi su	1
+长风吹林雨堕瓦	chang feng chui lin yu duo wa	1
+长风吹月度海来	chang feng chui yue du hai lai	1
+长风几万里	chang feng ji wan li	1
+长风连日作大浪	chang feng lian ri zuo da lang	1
+长干行	chang gan xing	1
+长歌楚天碧	chang ge chu tian bi	1
+长歌怀旧游	chang ge huai jiu you	1
+长歌吟松风	chang ge yin song feng	1
+常衮	chang gun	1
+常浩	chang hao	1
+长河渐落晓星沈	chang he jian luo xiao xing shen	1
+长河浪头连天黑	chang he lang tou lian tian hei	1
+长河没晓天	chang he mei xiao tian	1
+长记别伊时	chang ji bie yi shi	1
+长记平山堂上	chang ji ping shan tang shang	1
+长铗归来乎	chang jia gui lai hu	1
+长剑一杯酒	chang jian yi bei jiu	1
+长江悲已滞	chang jiang bei yi zhi	1
+长江独至今	chang jiang du zhi jin	1
+长江绕郭知鱼美	chang jiang rao guo zhi yu mei	1
+长江一帆远	chang jiang yi fan yuan	1
+尝居于此	chang ju yu ci	1
+常恐秋风早	chang kong qiu feng zao	1
+长空雁叫霜晨月	chang kong yan jiao shuang chen yue	1
+长乐王回深父	chang le wang hui shen fu	1
+长乐钟声花外尽	chang le zhong sheng hua wai jin	1
+长眉已能画	chang mei yi neng hua	1
+长门尽日无梳洗	chang men jin ri wu shu xi	1
+长门一步地	chang men yi bu di	1
+长命女	chang ming nv	1
+长命无绝衰	chang ming wu jue shuai	1
+长宁公主	chang ning gong zhu	1
+长桥卧波	chang qiao wo bo	1
+长桥月	chang qiao yue	1
+怅然遥相望	chang ran yao xiang wang	1
+怅然吟式微	chang ran yin shi wei	1
+长沙不久留才子	chang sha bu jiu liu cai zi	1
+长沙过贾谊宅	chang sha guo jia yi zhai	1
+长沙马王堆汉墓	chang sha ma wang dui han mu	1
+长沙谪去古今怜	chang sha zhe qu gu jin lian	1
+常善救物	chang shan jiu wu	1
+长绳系日住	chang sheng ji ri zhu	1
+长生久视之道	chang sheng jiu shi zhi dao	1
+长生乐	chang sheng le	1
+常使民无知	chang shi min wu zhi	1
+长寿乐	chang shou le	1
+长孙氏	chang sun shi	1
+长亭窗户压微波	chang ting chuang hu ya wei bo	1
+长亭酒一瓢	chang ting jiu yi piao	1
+长亭怨	chang ting yuan	1
+怅望江头江水声	chang wang jiang tou jiang shui sheng	1
+怅望千秋一洒泪	chang wang qian qiu yi sa lei	1
+怅望银河吹玉笙	chang wang yin he chui yu sheng	1
+怅卧新春白袷衣	chang wo xin chun bai qia yi	1
+长我育我	chang wo yu wo	1
+长夏江村事事幽	chang xia jiang cun shi shi you	1
+常羡人间琢玉郎	chang xian ren jian zhuo yu lang	1
+长相思摧心肝	chang xiang si cui xin gan	1
+长相思令	chang xiang si ling	1
+长相思在长安	chang xiang si zai chang an	1
+长信宫中秋月明	chang xin gong zhong qiu yue ming	1
+常雅	chang ya	1
+长夜难明赤县天	chang ye nan ming chi xian tian	1
+常沂	chang yi	1
+常以身翼蔽沛公	chang yi shen yi bi pei gong	1
+长一身有半	chang yi shen you ban	1
+倡优畜之	chang you chu zhi	1
+倡予和女	chang yu he nv	1
+常于几成而败之	chang yu ji cheng er bai zhi	1
+长于水而安于水	chang yu shui er an yu shui	1
+长愿向南流	chang yuan xiang nan liu	1
+常在床蓐	chang zai chuang ru	1
+常在於险远	chang zai yu xian yuan	1
+长征	chang zheng	1
+长之育之	chang zhi yu zhi	1
+畅诸	chang zhu	1
+长作东南别	chang zuo dong nan bie	1
+常作去年花	chang zuo qu nian hua	1
+朝罢须裁五色诏	chao ba xu cai wu se zhao	1
+朝避猛虎	chao bi meng hu	1
+朝别黄鹤楼	chao bie huang he lou	1
+晁采	chao cai	1
+朝餐是草根	chao can shi cao gen	1
+朝成绣夹裙	chao cheng xiu jia qun	1
+晁冲之	chao chong zhi	1
+晁端礼	chao duan li	1
+晁公武	chao gong wu	1
+朝衡	chao heng	1
+朝回日日典春衣	chao hui ri ri dian chun yi	1
+朝扣富儿门	chao kou fu er men	1
+潮来天地青	chao lai tian di qing	1
+潮落江平未有风	chao luo jiang ping wei you feng	1
+潮落夜江斜月里	chao luo ye jiang xie yue li	1
+朝三而暮四	chao san er mu si	1
+朝天乐	chao tian le	1
+朝同一源出	chao tong yi yuan chu	1
+朝闻游子唱离歌	chao wen you zi chang li ge	1
+朝闻游子唱骊歌	chao wen you zi chang li ge	1
+朝与佳人期	chao yu jia ren qi	1
+巢在三珠树	chao zai san zhu shu	1
+朝中措	chao zhong cuo	1
+车迟迟	che chi chi	1
+车攻	che gong	1
+车邻	che lin	1
+车辚辚	che lin lin	1
+车马去闲闲	che ma qu xian xian	1
+车如鸡栖马如狗	che ru ji qi ma ru gou	1
+车如流水马如龙	che ru liu shui ma ru long	1
+车胤	che yin	1
+车走雷声语未通	che zou lei sheng yu wei tong	1
+尘埃不见咸阳桥	chen ai bu jian xian yang qiao	1
+陈黯	chen an	1
+沉彬	chen bin	1
+陈昌言	chen chang yan	1
+沉沉无问处	chen chen wu wen chu	1
+沉沉一线穿南北	chen chen yi xian chuan nan bei	1
+陈乘	chen cheng	1
+陈成之	chen cheng zhi	1
+陈璀	chen cui	1
+陈存	chen cun	1
+陈德武	chen de wu	1
+陈东甫	chen dong fu	1
+陈璠	chen fan	1
+陈凤仪	chen feng yi	1
+陈合	chen he	1
+陈侯立身何坦荡	chen hou li shen he tan dang	1
+陈祜	chen hu	1
+陈季	chen ji	1
+陈季卿	chen ji qing	1
+陈嘉言	chen jia yan	1
+陈京	chen jing	1
+臣具以表闻	chen ju yi biao wen	1
+陈康伯	chen kang bo	1
+陈亢退而喜曰	chen kang tui er xi yue	1
+陈贶	chen kuang	1
+陈力就列	chen li jiu lie	1
+陈睦	chen mu	1
+瞋目视项王	chen mu shi xiang wang	1
+尘泥渗漉	chen ni shen lu	1
+陈凝	chen ning	1
+晨前命对朝霞	chen qian ming dui zhao xia	1
+陈峤	chen qiao	1
+陈情事表	chen qing shi biao	1
+陈去疾	chen qu ji	1
+陈日章	chen ri zhang	1
+臣少多疾病	chen shao duo ji bing	1
+陈涉之位	chen she zhi wei	1
+称身不必狐裘	chen shen bu bi hu qiu	1
+臣生当陨首	chen sheng dang yun shou	1
+陈师道	chen shi dao	1
+陈师鞠旅	chen shi ju lv	1
+臣事君以忠	chen shi jun yi zhong	1
+尘世难逢开口笑	chen shi nan feng kai kou xiao	1
+臣弑其君者有之	chen shi qi jun zhe you zhi	1
+陈叔达	chen shu da	1
+臣死且不避	chen si qie bu bi	1
+臣虽下愚	chen sui xia yu	1
+陈孙	chen sun	1
+陈陶	chen tao	1
+陈王昔时宴平乐	chen wang xi shi yan ping le	1
+陈韡	chen wei	1
+臣为韩王送沛公	chen wei han wang song pei gong	1
+陈维崧	chen wei song	1
+臣未之闻也	chen wei zhi wen ye	1
+臣闻求木之长者	chen wen qiu mu zhi zhang zhe	1
+臣无祖母	chen wu zu mu	1
+陈希烈	chen xi lie	1
+陈袭善	chen xi shan	1
+陈相见孟子	chen xiang jian meng zi	1
+沉香亭北倚阑干	chen xiang ting bei yi lan gan	1
+陈偕	chen xie	1
+称心快意	chen xin kuai yi	1
+尘心未尽思乡县	chen xin wei jin si xiang xian	1
+陈彦博	chen yan bo	1
+晨摇玉佩趋金殿	chen yao yu pei qu jin dian	1
+陈翊	chen yi	1
+臣以供养无主	chen yi gong yang wu zhu	1
+臣以险衅	chen yi xian xin	1
+臣欲奉诏奔驰	chen yu feng zhao ben chi	1
+陈与兴	chen yu xing	1
+陈元初	chen yuan chu	1
+陈元光	chen yuan guang	1
+陈元裕	chen yuan yu	1
+陈慥	chen zao	1
+臣战河南	chen zhan he nan	1
+陈至	chen zhi	1
+臣之进退	chen zhi jin tui	1
+臣之事君	chen zhi shi jun	1
+臣之所好者道也	chen zhi suo hao zhe dao ye	1
+陈之贤	chen zhi xian	1
+臣之辛苦	chen zhi xin ku	1
+陈子良	chen zi liang	1
+陈祖安	chen zu an	1
+沉醉东风	chen zui dong feng	1
+成败之数	cheng bai zhi shu	1
+乘彼白云	cheng bi bai yun	1
+乘彼垝垣	cheng bi gui yuan	1
+城边有古树	cheng bian you gu shu	1
+诚不以富	cheng bu yi fu	1
+程长文	cheng chang wen	1
+澄澄变今古	cheng cheng bian jin gu	1
+乘乘马	cheng cheng ma	1
+澄澄映葭苇	cheng cheng ying jia wei	1
+程大昌	cheng da chang	1
+承恩不在貌	cheng en bu zai mao	1
+承恩数上南熏殿	cheng en shu shang nan xun dian	1
+城非不高也	cheng fei bu gao ye	1
+乘桴浮于海	cheng fu fu yu hai	1
+城高倚峭巘	cheng gao yi qiao yan	1
+程公许	cheng gong xu	1
+成固有伐	cheng gu you fa	1
+程过	cheng guo	1
+程贺	cheng he	1
+成吉思汗	cheng ji si han	1
+承籍有宦官	cheng ji you huan guan	1
+澄江平少岸	cheng jiang ping shao an	1
+成就河沙梦功德	cheng jiu he sha meng gong de	1
+承筐是将	cheng kuang shi jiang	1
+程邻	cheng lin	1
+称其德也	cheng qi de ye	1
+乘骐骥以驰骋兮	cheng qi ji yi chi cheng xi	1
+城阙夜千重	cheng que ye qian zhong	1
+城上风威冷	cheng shang feng wei leng	1
+城上高楼接大荒	cheng shang gao lou jie da huang	1
+成事不说	cheng shi bu shuo	1
+承天景命	cheng tian jing ming	1
+承天寺夜游	cheng tian si ye you	1
+城头铁鼓声犹振	cheng tou tie gu sheng you zhen	1
+城头铁鼓声犹震	cheng tou tie gu sheng you zhen	1
+城头月	cheng tou yue	1
+程武	cheng wu	1
+程先	cheng xian	1
+城小贼不屠	cheng xiao zei bu tu	1
+乘兴南游不戒严	cheng xing nan you bu jie yan	1
+成彦雄	cheng yan xiong	1
+成一家之言	cheng yi jia zhi yan	1
+乘殷之辂	cheng yin zhi lu	1
+诚有百姓者	cheng you bai xing zhe	1
+成由勤俭破由奢	cheng you qin jian po you she	1
+程正同	cheng zheng tong	1
+诚知此恨人人有	cheng zhi ci hen ren ren you	1
+城中十万户	cheng zhong shi wan hu	1
+城中相识尽繁华	cheng zhong xiang shi jin fan hua	1
+城中增暮寒	cheng zhong zeng mu han	1
+乘舟将欲行	cheng zhou jiang yu xing	1
+程准	cheng zhun	1
+赤壁词	chi bi ci	1
+赤壁歌送别	chi bi ge song bie	1
+赤壁怀古	chi bi huai gu	1
+赤橙黄绿青蓝紫	chi cheng huang lv qing lan zi	1
+驰骋畋猎	chi cheng tian lie	1
+驰骋天下之至坚	chi cheng tian xia zhi zhi jian	1
+迟迟白日晚	chi chi bai ri wan	1
+持此谢高鸟	chi ci xie gao niao	1
+持而保之	chi er bao zhi	1
+池非不深也	chi fei bu shen ye	1
+池潢不敢顾	chi huang bu gan gu	1
+迟回度陇怯	chi hui du long qie	1
+持家但有四立壁	chi jia dan you si li bi	1
+池口风雨留三日	chi kou feng yu liu san ri	1
+耻令越甲鸣吾君	chi ling yue jia ming wu jun	1
+魑魅魍魉惊本身	chi mei wang liang jing ben shen	1
+魑魅魍魉徒为尔	chi mei wang liang tu wei er	1
+魑魅魍魉徒为耳	chi mei wang liang tu wei er	1
+魑魅喜人过	chi mei xi ren guo	1
+迟日园林悲昔游	chi ri yuan lin bei xi you	1
+齿如瓠犀	chi ru hu xi	1
+池上风回舫	chi shang feng hui fang	1
+持觞劝侯嬴	chi shang quan hou ying	1
+池台日半斜	chi tai ri ban xie	1
+耻为游子颜	chi wei you zi yan	1
+絺兮绤兮	chi xi xi xi	1
+持谢邻家子	chi xie lin jia zi	1
+赤焰烧虏云	chi yan shao lu yun	1
+赤也何如	chi ye he ru	1
+赤也为之小	chi ye wei zhi xiao	1
+持一象笏至	chi yi xiang hu zhi	1
+池月渐东上	chi yue jian dong shang	1
+赤枣子	chi zao zi	1
+赤之适齐也	chi zhi shi qi ye	1
+重重似画	chong chong si hua	1
+重叠金	chong die jin	1
+重过圣女祠	chong guo sheng nv ci	1
+宠极爱还歇	chong ji ai hai xie	1
+重九开秋节	chong jiu kai qiu jie	1
+充满天地	chong man tian di	1
+虫鸣室幽幽	chong ming shi you you	1
+宠命优渥	chong ming you wo	1
+宠辱若惊	chong ru ruo jing	1
+重上井冈山	chong shang jing gang shan	1
+重上君子堂	chong shang jun zi tang	1
+重言十七	chong yan shi qi	1
+充虞路问曰	chong yu lu wen yue	1
+筹笔驿	chou bi yi	1
+惆怅长岑长	chou chang chang cen chang	1
+惆怅赤城期	chou chang chi cheng qi	1
+惆怅暮烟垂	chou chang mu yan chui	1
+惆怅南朝事	chou chang nan chao shi	1
+惆怅墙东	chou chang qiang dong	1
+惆怅无因见范蠡	chou chang wu yin jian fan li	1
+愁春未醒	chou chun wei xing	1
+愁多酒虽少	chou duo jiu sui shao	1
+愁多梦不成	chou duo meng bu cheng	1
+愁风月	chou feng yue	1
+丑妇可与白头	chou fu ke yu bai tou	1
+酬郭给事	chou guo gei shi	1
+愁红惨绿	chou hong can lv	1
+愁看直北是长安	chou kan zhi bei shi chang an	1
+愁空山	chou kong shan	1
+愁来一日即为长	chou lai yi ri ji wei chang	1
+绸缪束薪	chou mou shu xin	1
+丑奴儿	chou nu er	1
+丑奴儿令	chou nu er ling	1
+丑奴儿慢	chou nu er man	1
+丑女效之徒累身	chou nv xiao zhi tu lei shen	1
+愁人独夜看	chou ren du ye kan	1
+愁杀芳年友	chou sha fang nian you	1
+愁思看春不当春	chou si kan chun bu dang chun	1
+愁心似醉兼如病	chou xin si zui jian ru bing	1
+愁绪乱春风	chou xu luan chun feng	1
+愁颜与衰鬓	chou yan yu shuai bin	1
+愁倚阑	chou yi lan	1
+愁倚阑令	chou yi lan ling	1
+愁倚两三松	chou yi liang san song	1
+愁因薄暮起	chou yin bo mu qi	1
+愁云黪淡万里凝	chou yun can dan wan li ning	1
+酬张少府	chou zhang shao fu	1
+初八月	chu ba yue	1
+触波涛	chu bo tao	1
+楚臣伤江枫	chu chen shang jiang feng	1
+除臣洗马	chu chen xi ma	1
+处处伴愁颜	chu chu ban chou yan	1
+处处黄芦草	chu chu huang lu cao	1
+触处似花开	chu chu si hua kai	1
+处处销魂	chu chu xiao hun	1
+楚词体	chu ci ti	1
+初弹渌水后楚妃	chu dan lu shui hou chu fei	1
+出洞无论隔山水	chu dong wu lun ge shan shui	1
+初冬夜饮	chu dong ye yin	1
+楚儿	chu er	1
+处分适兄意	chu fen shi xiong yi	1
+储光羲	chu guang xi	1
+出乎尔者	chu hu er zhe	1
+初既与余成言兮	chu ji yu yu cheng yan xi	1
+出疆必载质	chu jiang bi zai zhi	1
+楚江东	chu jiang dong	1
+楚江怀古	chu jiang huai gu	1
+楚江微雨里	chu jiang wei yu li	1
+出郊旷清曙	chu jiao kuang qing shu	1
+初惊河汉落	chu jing he han luo	1
+触景生情	chu jing sheng qing	1
+楚客相思益渺然	chu ke xiang si yi miao ran	1
+楚客欲听瑶瑟怨	chu ke yu ting yao se yuan	1
+楚狂接舆	chu kuang jie yu	1
+褚亮	chu liang	1
+楚路高歌自欲翻	chu lu gao ge zi yu fan	1
+出门登车去	chu men deng che qu	1
+出门如见大宾	chu men ru jian da bin	1
+出门搔白首	chu men sao bai shou	1
+出门无侣漫看书	chu men wu lv man kan shu	1
+出门行	chu men xing	1
+出门一笑大江横	chu men yi xiao da jiang heng	1
+处默	chu mo	1
+出纳之吝	chu na zhi lin	1
+楚娘	chu niang	1
+楚女当时意	chu nv dang shi yi	1
+出其东门	chu qi dong men	1
+初七及下九	chu qi ji xia jiu	1
+处前而民不害	chu qian er min bu hai	1
+怵然为戒	chu ran wei jie	1
+初日郢门山	chu ri ying men shan	1
+出入腹我	chu ru fu wo	1
+出入高下穷烟霏	chu ru gao xia qiong yan fei	1
+出塞复入塞	chu sai fu ru sai	1
+出塞入塞寒	chu sai ru sai han	1
+楚塞三湘接	chu sai san xiang jie	1
+楚山横地出	chu shan heng di chu	1
+楚山秦山皆白云	chu shan qin shan jie bai yun	1
+出山泉水浊	chu shan quan shui zhuo	1
+出身仕汉羽林郎	chu shen shi han yu lin lang	1
+褚生	chu sheng	1
+杵声齐	chu sheng qi	1
+出生入死	chu sheng ru si	1
+初生欲缺虚惆怅	chu sheng yu que xu chou chang	1
+出世和入世	chu shi he ru shi	1
+处世若大梦	chu shi ruo da meng	1
+储嗣宗	chu si zong	1
+初随林霭动	chu sui lin ai dong	1
+初随骠骑战渔阳	chu sui piao qi zhan yu yang	1
+楚天长短黄昏雨	chu tian chang duan huang hun yu	1
+楚天谣	chu tian yao	1
+楚王台榭空山丘	chu wang tai xie kong shan qiu	1
+初为霓裳后六么	chu wei ni chang hou liu me	1
+初闻征雁已无蝉	chu wen zheng yan yi wu chan	1
+除夜有怀	chu ye you huai	1
+初疑路不同	chu yi lu bu tong	1
+初因避地去人间	chu yin bi di qu ren jian	1
+楚有春申	chu you chun shen	1
+出于林中	chu yu lin zhong	1
+楚云深	chu yun shen	1
+出则不知其所往	chu ze bu zhi qi suo wang	1
+出则事公卿	chu ze shi gong qing	1
+褚朝阳	chu zhao yang	1
+楚之南有冥灵者	chu zhi nan you ming ling zhe	1
+处众人之所恶	chu zhong ren zhi suo e	1
+出自北门	chu zi bei men	1
+出自东方	chu zi dong fang	1
+出自幽谷	chu zi you gu	1
+楚左尹项伯者	chu zuo yin xiang bo zhe	1
+川波岸柳春全回	chuan bo an liu chun quan hui	1
+川拨棹	chuan bo zhao	1
+传歌共绕梁	chuan ge gong rao liang	1
+川迥洞庭开	chuan jiong dong ting kai	1
+传其常情	chuan qi chang qing	1
+船上管弦江面绿	chuan shang guan xian jiang mian lv	1
+川为静其波	chuan wei jing qi bo	1
+传闻至此回	chuan wen zhi ci hui	1
+船下广陵去	chuan xia guang ling qu	1
+传言玉女	chuan yan yu nv	1
+传语风光共流转	chuan yu feng guang gong liu zhuan	1
+川原迷旧国	chuan yuan mi jiu guo	1
+传之其人	chuan zhi qi ren	1
+传之七十有二代	chuan zhi qi shi you er dai	1
+摐金伐鼓下榆关	chuang jin fa gu xia yu guan	1
+窗迥侵灯冷	chuang jiong qin deng leng	1
+床前看月光	chuang qian kan yue guang	1
+窗外疏梅筛月影	chuang wai shu mei shai yue ying	1
+创业艰难百战多	chuang ye jian nan bai zhan duo	1
+吹彼棘心	chui bi ji xin	1
+吹彼棘薪	chui bi ji xin	1
+垂碧柳	chui bi liu	1
+吹不散眉弯	chui bu san mei wan	1
+槌床便大怒	chui chuang bian da nu	1
+吹笛风斜隔陇闻	chui di feng xie ge long wen	1
+垂钓将已矣	chui diao jiang yi yi	1
+垂钓绿湾春	chui diao lv wan chun	1
+吹洞箫	chui dong xiao	1
+吹度玉门关	chui du yu men guan	1
+吹断檐间积雨声	chui duan yan jian ji yu sheng	1
+垂拱而治	chui gong er zhi	1
+吹花送远香	chui hua song yuan xiang	1
+垂老不得安	chui lao bu de an	1
+吹落白衣裳	chui luo bai yi shang	1
+吹人舞袖回	chui ren wu xiu hui	1
+垂緌饮清露	chui rui yin qing lu	1
+吹散万里云	chui san wan li yun	1
+吹笙鼓簧	chui sheng gu huang	1
+垂死病中惊坐起	chui si bing zhong jing zuo qi	1
+垂丝钓	chui si diao	1
+垂阳	chui yang	1
+垂杨柳	chui yang liu	1
+垂衣贵清真	chui yi gui qing zhen	1
+春别	chun bie	1
+春病	chun bing	1
+春不能朱镜里颜	chun bu neng zhu jing li yan	1
+春草碧	chun cao bi	1
+春草闭闲门	chun cao bi xian men	1
+春草明年绿	chun cao ming nian lv	1
+春草如有情	chun cao ru you qing	1
+春草昭阳路断	chun cao zhao yang lu duan	1
+春蝉	chun chan	1
+春潮夜夜深	chun chao ye ye shen	1
+春城紫禁晓阴阴	chun cheng zi jin xiao yin yin	1
+春愁黯黯独成眠	chun chou an an du cheng mian	1
+春窗曙灭九微火	chun chuang shu mie jiu wei huo	1
+春从天上来	chun cong tian shang lai	1
+春泛若耶溪	chun fan ruo ye xi	1
+春风不相识	chun feng bu xiang shi	1
+春风春雨花经眼	chun feng chun yu hua jing yan	1
+春风啜茗时	chun feng chuo ming shi	1
+春风得意	chun feng de yi	1
+春风对青冢	chun feng dui qing zhong	1
+春风尔来为阿谁	chun feng er lai wei a shui	1
+春风海上楼	chun feng hai shang lou	1
+春风举国裁宫锦	chun feng ju guo cai gong jin	1
+春风柳上归	chun feng liu shang gui	1
+春风袅娜	chun feng niao nuo	1
+春风十里扬州路	chun feng shi li yang zhou lu	1
+春风桃李花开日	chun feng tao li hua kai ri	1
+春风笑人来	chun feng xiao ren lai	1
+春风杨柳万千条	chun feng yang liu wan qian tiao	1
+春风一等少年心	chun feng yi deng shao nian xin	1
+春风倚棹阖闾城	chun feng yi zhao he lv cheng	1
+春风语流莺	chun feng yu liu ying	1
+春风争拟惜长条	chun feng zheng ni xi chang tiao	1
+春服既成	chun fu ji cheng	1
+春歌	chun ge	1
+春歌丛台上	chun ge cong tai shang	1
+春宫曲	chun gong qu	1
+春宫怨	chun gong yuan	1
+春光半道催	chun guang ban dao cui	1
+春光好	chun guang hao	1
+春光懒困倚微风	chun guang lan kun yi wei feng	1
+春光融融	chun guang rong rong	1
+春归怨	chun gui yuan	1
+春归在客先	chun gui zai ke xian	1
+春寒花较迟	chun han hua jiao chi	1
+春鸠	chun jiu	1
+春鸠鸣何处	chun jiu ming he chu	1
+春来遍是桃花水	chun lai bian shi tao hua shui	1
+春来长是闲	chun lai chang shi xian	1
+春来还发旧时花	chun lai hai fa jiu shi hua	1
+春来酿几多	chun lai niang ji duo	1
+春来我不先开口	chun lai wo bu xian kai kou	1
+春流绕蜀城	chun liu rao shu cheng	1
+春露到秋风	chun lu dao qiu feng	1
+春娘	chun niang	1
+春弄	chun nong	1
+春晴	chun qing	1
+春情著杏花	chun qing zhu xing hua	1
+春秋不变	chun qiu bu bian	1
+春去不容惜	chun qu bu rong xi	1
+春去夏犹清	chun qu xia you qing	1
+春去也	chun qu ye	1
+春日迟迟	chun ri chi chi	1
+春日凝妆上翠楼	chun ri ning zhuang shang cui lou	1
+春日偏能惹恨长	chun ri pian neng re hen chang	1
+春日潜行曲江曲	chun ri qian xing qu jiang qu	1
+春日望海	chun ri wang hai	1
+春日行	chun ri xing	1
+春日在天涯	chun ri zai tian ya	1
+春日载阳	chun ri zai yang	1
+春日醉起言志	chun ri zui qi yan zhi	1
+春入万年枝	chun ru wan nian zhi	1
+春色满	chun se man	1
+春色满皇州	chun se man huang zhou	1
+春色恼人眠不得	chun se nao ren mian bu de	1
+春色岂知心	chun se qi zhi xin	1
+春色属明年	chun se shu ming nian	1
+春色未曾看	chun se wei ceng kan	1
+春衫泪	chun shan lei	1
+春深杏花乱	chun shen xing hua luan	1
+春生江上几人还	chun sheng jiang shang ji ren hai	1
+春水船如天上坐	chun shui chuan ru tian shang zuo	1
+春思	chun si	1
+纯素之道	chun su zhi dao	1
+春宿左省	chun su zuo sheng	1
+春天和	chun tian he	1
+春夏两相期	chun xia liang xiang qi	1
+春宵曲	chun xiao qu	1
+春晓曲	chun xiao qu	1
+春心荡	chun xin dang	1
+春雪满空来	chun xue man kong lai	1
+春莺转	chun ying zhuan	1
+春雨	chun yu	1
+春与青溪长	chun yu qing xi chang	1
+春与秋其代序	chun yu qiu qi dai xu	1
+春怨	chun yuan	1
+春远独柴荆	chun yuan du chai jing	1
+春早湖山	chun zao hu shan	1
+鹑之奔奔	chun zhi ben ben	1
+春逐五更来	chun zhu wu geng lai	1
+此别何时遇	ci bie he shi yu	1
+辞不赴命	ci bu fu ming	1
+辞不就职	ci bu jiu zhi	1
+赐不受命	ci bu shou ming	1
+此大年也	ci da nian ye	1
+此道昔归顺	ci dao xi gui shun	1
+此道引之士	ci dao yin zhi shi	1
+此地别燕丹	ci di bie yan dan	1
+此地两三家	ci di liang san jia	1
+此二子者	ci er zi zhe	1
+慈父见背	ci fu jian bei	1
+辞富居贫	ci fu ju pin	1
+此妇无礼节	ci fu wu li jie	1
+此何人哉	ci he ren zai	1
+此花开尽更无花	ci hua kai jin geng wu hua	1
+此会在何年	ci hui zai he nian	1
+辞家见月两回圆	ci jia jian yue liang hui yuan	1
+辞家终拟长游衍	ci jia zhong ni chang you yan	1
+此江海之士	ci jiang hai zhi shi	1
+此酒不足尝	ci jiu bu zu chang	1
+词开豪放一派	ci kai hao fang yi pai	1
+词客哀时且未还	ci ke ai shi qie wei hai	1
+辞楼下殿	ci lou xia dian	1
+此率兽而食人也	ci lv shou er shi ren ye	1
+赐名大国虢与秦	ci ming da guo guo yu qin	1
+此木岂无阴	ci mu qi wu yin	1
+此平世之士	ci ping shi zhi shi	1
+刺破青天锷未残	ci po qing tian e wei can	1
+此其比万物也	ci qi bi wan wu ye	1
+此其志不在小	ci qi zhi bu zai xiao	1
+此情不可道	ci qing bu ke dao	1
+此情可待成追忆	ci qing ke dai cheng zhui yi	1
+此情惟有落花知	ci qing wei you luo hua zhi	1
+此去随所偶	ci qu sui suo ou	1
+此去瑶池地共长	ci qu yao chi di gong chang	1
+此曲有意无人传	ci qu you yi wu ren chuan	1
+辞让之心	ci rang zhi xin	1
+此人已成灰	ci ren yi cheng hui	1
+此日登临曙色开	ci ri deng lin shu se kai	1
+此日意无穷	ci ri yi wu qiong	1
+此日足可惜	ci ri zu ke xi	1
+此山谷之士	ci shan gu zhi shi	1
+此生此夜不长好	ci sheng ci ye bu zhang hao	1
+此时此夜难为情	ci shi ci ye nan wei qing	1
+此事何难	ci shi he nan	1
+此虽免乎行	ci sui mian hu xing	1
+此天地之道	ci tian di zhi dao	1
+此天子气也	ci tian zi qi ye	1
+此亡秦之续耳	ci wang qin zhi xu er	1
+此谓诚忘	ci wei cheng wang	1
+此谓坐忘	ci wei zuo wang	1
+此翁白头真可怜	ci weng bai tou zhen ke lian	1
+此夕闻君谪九江	ci xi wen jun zhe jiu jiang	1
+此夕相逢	ci xi xiang feng	1
+此小大之辩也	ci xiao da zhi bian ye	1
+此小年也	ci xiao nian ye	1
+此心安处是吾乡	ci xin an chu shi wu xiang	1
+此心向君君应识	ci xin xiang jun jun ying shi	1
+此行不为鲈鱼鲙	ci xing bu wei lu yu kuai	1
+此行何去	ci xing he qu	1
+赐也何敢望回	ci ye he gan wang hui	1
+赐也何如	ci ye he ru	1
+此夜红楼	ci ye hong lou	1
+赐也贤乎哉	ci ye xian hu zai	1
+此亦飞之至也	ci yi fei zhi zhi ye	1
+此一时也	ci yi shi ye	1
+此亦一是非	ci yi yi shi fei	1
+此余之所得也	ci yu zhi suo de ye	1
+词源倒流三峡水	ci yuan dao liu san xia shui	1
+赐之墙也及肩	ci zhi qiang ye ji jian	1
+此之谓物化	ci zhi wei wu hua	1
+此之谓也	ci zhi wei ye	1
+赐之彘肩	ci zhi zhi jian	1
+此州独见全	ci zhou du jian quan	1
+辞尊居卑	ci zun ju bei	1
+从臣才艺咸第一	cong chen cai yi xian di yi	1
+从此道至吾军	cong ci dao zhi wu jun	1
+从此各东西	cong ci ge dong xi	1
+从此天涯孤旅	cong ci tian ya gu lv	1
+从从容容	cong cong rong rong	1
+从今四海为家日	cong jin si hai wei jia ri	1
+从今又几年	cong jin you ji nian	1
+丛菊两开他日泪	cong ju liang kai ta ri lei	1
+从来多古意	cong lai duo gu yi	1
+从来急	cong lai ji	1
+従来佳茗似佳人	cong lai jia ming si jia ren	1
+从来系日乏长绳	cong lai xi ri fa chang sheng	1
+从来幽并客	cong lai you bing ke	1
+从郦山下	cong li shan xia	1
+从孙子仲	cong sun zi zhong	1
+从汀州向长沙	cong ting zhou xiang chang sha	1
+从头翻悔	cong tou fan hui	1
+从头越	cong tou yue	1
+从吾所好	cong wu suo hao	1
+从余问古事	cong yu wen gu shi	1
+从者见之	cong zhe jian zhi	1
+醋葫芦	cu hu lu	1
+蹙金孔雀银麒麟	cu jin kong que yin qi lin	1
+簇水	cu shui	1
+蹙缩又纵横	cu suo you zong heng	1
+粗缯大布裹生涯	cu zeng da bu guo sheng ya	1
+崔备	cui bei	1
+崔邠	cui bin	1
+摧藏马悲哀	cui cang ma bei ai	1
+催臣上道	cui chen shang dao	1
+崔琮	cui cong	1
+崔涤	cui di	1
+崔峒	cui dong	1
+崔敦礼	cui dun li	1
+崔耿	cui geng	1
+崔恭	cui gong	1
+崔瓘	cui guan	1
+崔珪	cui gui	1
+崔国辅	cui guo fu	1
+崔何	cui he	1
+翠花拂天来向东	cui hua fu tian lai xiang dong	1
+翠华想像空山里	cui hua xiang xiang kong shan li	1
+翠华引	cui hua yin	1
+崔怀宝	cui huai bao	1
+崔绩	cui ji	1
+崔江	cui jiang	1
+崔郊	cui jiao	1
+崔珏	cui jue	1
+崔立言	cui li yan	1
+崔立之	cui li zhi	1
+崔橹	cui lu	1
+崔沔	cui mian	1
+崔木	cui mu	1
+崔璞	cui pu	1
+崔翘	cui qiao	1
+崔日用	cui ri yong	1
+崔融	cui rong	1
+崔尚	cui shang	1
+崔湜	cui shi	1
+崔曙	cui shu	1
+崔枢	cui shu	1
+崔颂	cui song	1
+崔素娥	cui su e	1
+崔涂	cui tu	1
+翠微盍叶垂鬓唇	cui wei he ye chui bin chun	1
+崔嵬枝干郊原古	cui wei zhi gan jiao yuan gu	1
+催弦拂柱与君饮	cui xian fu zhu yu jun yin	1
+摧心肝	cui xin gan	1
+崔信明	cui xin ming	1
+崔兴宗	cui xing zong	1
+崔萱	cui xuan	1
+崔轩	cui xuan	1
+崔铉	cui xuan	1
+崔玄亮	cui xuan liang	1
+催雪	cui xue	1
+崔郾	cui yan	1
+崔液	cui ye	1
+翠影红霞映朝日	cui ying hong xia ying zhao ri	1
+崔庸	cui yong	1
+翠羽吟	cui yu yin	1
+崔与之	cui yu zhi	1
+崔员外	cui yuan wai	1
+粹之至也	cui zhi zhi ye	1
+崔中	cui zhong	1
+翠竹黄花皆佛性	cui zhu huang hua jie fo xing	1
+崔子弑齐君	cui zi shi qi jun	1
+崔紫云	cui zi yun	1
+崔宗之	cui zong zhi	1
+村边杏花白	cun bian xing hua bai	1
+寸步曲江头	cun bu qu jiang tou	1
+存乎人者	cun hu ren zhe	1
+村舍外	cun she wai	1
+寸心千里	cun xin qian li	1
+存者无消息	cun zhe wu xiao xi	1
+蹉跎岁月	cuo tuo sui yue	1
+大柏地	da bai di	1
+大辩不言	da bian bu yan	1
+大车槛槛	da che kan kan	1
+大车扬飞尘	da che yang fei chen	1
+大城铁不如	da cheng tie bu ru	1
+大椿	da chun	1
+大盗不止	da dao bu zhi	1
+大道泛兮	da dao fan xi	1
+大刀将军	da dao jiang jun	1
+大盗乃止	da dao nai zhi	1
+大道如青天	da dao ru qing tian	1
+大道甚夷	da dao shen yi	1
+大道直如发	da dao zhi ru fa	1
+大德不逾闲	da de bu yu xian	1
+大堤曲	da di qu	1
+大堤上	da di shang	1
+大地微微暖风吹	da di wei wei nuan feng chui	1
+大地微微暖气吹	da di wei wei nuan qi chui	1
+大渡桥横铁索寒	da du qiao heng tie suo han	1
+大而无当	da er wu dang	1
+大而无用	da er wu yong	1
+大风方发狂	da feng fang fa kuang	1
+大旱金石流	da han jin shi liu	1
+大河上下	da he shang xia	1
+大濩	da hu	1
+大江东流去	da jiang dong liu qu	1
+大江东去日夜白	da jiang dong qu ri ye bai	1
+大江翻澜神曳烟	da jiang fan lan shen ye yan	1
+大江茫茫去不还	da jiang mang mang qu bu hai	1
+大江茫茫去不黄	da jiang mang mang qu bu huang	1
+大江溯轻舟	da jiang su qing zhou	1
+大江西	da jiang xi	1
+大军之后	da jun zhi hou	1
+大君制六合	da jun zhi lu he	1
+大类女郎也	da lei nv lang ye	1
+大礼不辞小让	da li bu ci xiao rang	1
+答李淑一	da li shu yi	1
+大略驾群才	da lue jia qun cai	1
+大明夜已残	da ming ye yi can	1
+达命之情者	da ming zhi qing zhe	1
+大漠穷秋塞草衰	da mo qiong qiu sai cao shuai	1
+大漠无兵阻	da mo wu bing zu	1
+大母过余曰	da mu guo yu yue	1
+大鹏飞兮振八裔	da peng fei xi zhen ba yi	1
+打起黄莺儿	da qi huang ying er	1
+大器晚成	da qi wan cheng	1
+大千世界百杂碎	da qian shi jie bai za sui	1
+大仁不仁	da ren bu ren	1
+大人弗为	da ren fu wei	1
+大人故嫌迟	da ren gu xian chi	1
+达人无不可	da ren wu bu ke	1
+大厦如倾要梁栋	da sha ru qing yao liang dong	1
+大韶	da shao	1
+大圣不作	da sheng bu zuo	1
+大圣乐	da sheng yue	1
+大叔于田	da shu yu tian	1
+大舜有大焉	da shun you da yan	1
+大蒐王道	da sou wang dao	1
+大通智胜佛	da tong zhi sheng fo	1
+大王来何操	da wang lai he cao	1
+大屋欹倾小成倒	da wu qi qing xiao cheng dao	1
+大弦长	da xian chang	1
+大贤虎变愚不测	da xian hu bian yu bu ce	1
+大象无形	da xiang wu xing	1
+大小必双翔	da xiao bi shuang xiang	1
+大小都不类	da xiao dou bu lei	1
+大笑向文士	da xiao xiang wen shi	1
+答谢中书书	da xie zhong shu shu	1
+大行不顾细谨	da xing bu gu xi jin	1
+大雪压青松	da xue ya qing song	1
+大雅久不作	da ya jiu bu zuo	1
+达亦不足贵	da yi bu zu gui	1
+大隐金门是谪仙	da yin jin men shi zhe xian	1
+大音自成曲	da yin zi cheng qu	1
+大勇不忮	da yong bu zhi	1
+大有径庭	da you jing ting	1
+大愚	da yu	1
+大雨落幽燕	da yu luo you yan	1
+大哉孔子	da zai kong zi	1
+大醉作此篇	da zui zuo ci pian	1
+迨此独忡忡	dai ci du chong chong	1
+待到雪化时	dai dao xue hua shi	1
+待得群花过后	dai de qun hua guo hou	1
+殆而已矣	dai er yi yi	1
+逮奉圣朝	dai feng sheng chao	1
+带甲满天地	dai jia man tian di	1
+待酒不至	dai jiu bu zhi	1
+玳梁谁道好	dai liang shui dao hao	1
+带马行	dai ma xing	1
+黛眉偎破未重描	dai mei wei po wei chong miao	1
+迨其吉兮	dai qi ji xi	1
+迨其今兮	dai qi jin xi	1
+黛色参天二千尺	dai se can tian er qian chi	1
+戴山隐	dai shan yin	1
+戴叔伦	dai shu lun	1
+殆为此也	dai wei ci ye	1
+待我适东越	dai wo shi dong yue	1
+待吾还丹成	dai wu huan dan cheng	1
+待晓堂前拜舅姑	dai xiao tang qian bai jiu gu	1
+戴翼	dai yi	1
+戴盈之曰	dai ying zhi yue	1
+殆有甚焉	dai you shen yan	1
+待月池台空逝水	dai yue chi tai kong shi shui	1
+代赠二首	dai zeng er shou	1
+带之适也	dai zhi shi ye	1
+迨诸父异爨	dai zhu fu yi cuan	1
+但当对石饮	dan dang dui shi yin	1
+但道困苦乞为奴	dan dao kun ku qi wei nu	1
+但得酒中趣	dan de jiu zhong qu	1
+弹洞前村壁	dan dong qian cun bi	1
+旦而哭泣	dan er ku qi	1
+旦而田猎	dan er tian lie	1
+丹凤城南秋夜长	dan feng cheng nan qiu ye chang	1
+丹凤吟	dan feng yin	1
+惮赫千里	dan he qian li	1
+弹痕遍地	dan hen bian di	1
+但恨无过王右军	dan hen wu guo wang you jun	1
+淡乎其无味	dan hu qi wu wei	1
+但记得斑斑点点	dan ji de ban ban dian dian	1
+但见悲鸟号古木	dan jian bei niao hao gu mu	1
+但见泪痕湿	dan jian lei hen shi	1
+但见群鸥日日来	dan jian qun ou ri ri lai	1
+但见三泉下	dan jian san quan xia	1
+但见宵从海上来	dan jian xiao cong hai shang lai	1
+但见新人笑	dan jian xin ren xiao	1
+但将酩酊酬佳节	dan jiang ming ding chou jia jie	1
+但看古来歌舞地	dan kan gu lai ge wu di	1
+但看古来盛名下	dan kan gu lai sheng ming xia	1
+但恐花不实	dan kong hua bu shi	1
+但令归有日	dan ling gui you ri	1
+丹青画出是君山	dan qing hua chu shi jun shan	1
+丹青引	dan qing yin	1
+丹丘生	dan qiu sheng	1
+丹丘信云远	dan qiu xin yun yuan	1
+但去莫复问	dan qu mo fu wen	1
+但去莫复闻	dan qu mo fu wen	1
+澹然空水对斜晖	dan ran kong shui dui xie hui	1
+澹然离言说	dan ran li yan shuo	1
+旦日飨士卒	dan ri xiang shi zu	1
+淡扫蛾眉朝至尊	dan sao e mei chao zhi zun	1
+淡扫明湖开玉镜	dan sao ming hu kai yu jing	1
+丹砂访葛洪	dan sha fang ge hong	1
+但使主人能醉客	dan shi zhu ren neng zui ke	1
+澹兮其若海	dan xi qi ruo hai	1
+但相思	dan xiang si	1
+丹崖翠壁千万丈	dan ya cui bi qian wan zhang	1
+但言浑忘不言无	dan yan hun wang bu yan wu	1
+丹阳郭里送行舟	dan yang guo li song xing zhou	1
+丹阳湖	dan yang hu	1
+但以刘日薄西山	dan yi liu ri bo xi shan	1
+但用东山谢安石	dan yong dong shan xie an shi	1
+但愿长醉不复醒	dan yuan chang zui bu fu xing	1
+但愿长醉不愿醒	dan yuan chang zui bu yuan xing	1
+但远山长	dan yuan shan chang	1
+但愿天下人	dan yuan tian xia ren	1
+丹灶初开火	dan zao chu kai huo	1
+当待东宫	dang dai dong gong	1
+当花侧帽	dang hua ce mao	1
+当今世界殊	dang jin shi jie shu	1
+当今之时	dang jin zhi shi	1
+当君怀归日	dang jun huai gui ri	1
+当流赤足蹋涧石	dang liu chi zu ta jian shi	1
+当路谁相假	dang lu shui xiang jia	1
+当垆笑春风	dang lu xiao chun feng	1
+当面输心背面笑	dang mian shu xin bei mian xiao	1
+当年鏖战急	dang nian ao zhan ji	1
+当年拼却醉颜红	dang nian pin que zui yan hong	1
+当年颇似寻常人	dang nian po si xun chang ren	1
+当仁不让于师	dang ren bu rang yu shi	1
+当时敌陕郛	dang shi di shan fu	1
+当时堕地觅不得	dang shi duo di mi bu de	1
+当时共客长安	dang shi gong ke chang an	1
+当时浣纱伴	dang shi huan sha ban	1
+当是时也	dang shi shi ye	1
+当时只记入山深	dang shi zhi ji ru shan shen	1
+当轩对尊酒	dang xuan dui zun jiu	1
+当轩下马入锦茵	dang xuan xia ma ru jin yin	1
+荡漾不成圆	dang yang bu cheng yuan	1
+当尧之时	dang yao zhi shi	1
+倒碧峰	dao bi feng	1
+道不可见	dao bu ke jian	1
+道不可闻	dao bu ke wen	1
+道不可言	dao bu ke yan	1
+到处潜悲辛	dao chu qian bei xin	1
+到处莺歌燕舞	dao chu ying ge yan wu	1
+倒垂柳	dao chui liu	1
+叨叨令	dao dao ling	1
+道德三皇五帝	dao de san huang wu di	1
+道德无多只本心	dao de wu duo zhi ben xin	1
+到而今	dao er jin	1
+道恭	dao gong	1
+倒海翻江卷巨澜	dao hai fan jiang juan ju lan	1
+道兼于天	dao jian yu tian	1
+捣练子	dao lian zi	1
+捣练子令	dao lian zi ling	1
+道路入边城	dao lu ru bian cheng	1
+道路阻且长	dao lu zu qie chang	1
+稻米流脂粟米白	dao mi liu zhi su mi bai	1
+道旁过者问行人	dao pang guo zhe wen xing ren	1
+道千乘之国	dao qian sheng zhi guo	1
+道人庭宇静	dao ren ting yu jing	1
+到韶山	dao shao shan	1
+捣麝成尘香不灭	dao she cheng chen xiang bu mie	1
+道是无情还有情	dao shi wu qing hai you qing	1
+道束悬崖半	dao shu xuan ya ban	1
+道听而途说	dao ting er tu shuo	1
+到潼关	dao tong guan	1
+道通为一	dao tong wei yi	1
+道无终始	dao wu zhong shi	1
+道相似也	dao xiang si ye	1
+道心惟微	dao xin wei wei	1
+倒行逆施畏日晚	dao xing ni shi wei ri wan	1
+道亦乐得之	dao yi le de zhi	1
+盗亦有道乎	dao yi you dao hu	1
+导引	dao yin	1
+道隐于小成	dao yin yu xiao cheng	1
+道由白云尽	dao you bai yun jin	1
+道与之貌	dao yu zhi mao	1
+盗贼多有	dao zei duo you	1
+盗贼无有	dao zei wu you	1
+道之不行	dao zhi bu xing	1
+道之出口	dao zhi chu kou	1
+道之斯行	dao zhi si xing	1
+道之为物	dao zhi wei wu	1
+道芷阳间行	dao zhi yang jian xing	1
+导之以德	dao zhi yi de	1
+导之以政	dao zhi yi zheng	1
+道之云远	dao zhi yun yuan	1
+到中流击水	dao zhong liu ji shui	1
+得成比目何辞死	de cheng bi mu he ci si	1
+得春令慢	de chun ling man	1
+得地本虚心	de di ben xu xin	1
+得非施斧斤	de fei shi fu jin	1
+得复见将军于此	de fu jian jiang jun yu ci	1
+德合一君	de he yi jun	1
+德兼于道	de jian yu dao	1
+得乐天书	de le tian shu	1
+得陇又望蜀	de long you wang shu	1
+得其所哉	de qi suo zai	1
+得胜令	de sheng ling	1
+得失寸心知	de shi cun xin zhi	1
+得死似登仙	de si si deng xian	1
+得天下有道	de tian xia you dao	1
+得兔而忘蹄	de tu er wang ti	1
+得无金丸惧	de wu jin wan ju	1
+德也狂生耳	de ye kuang sheng er	1
+得意而忘言	de yi er wang yan	1
+德亦乐得之	de yi le de zhi	1
+德以象贤	de yi xiang xian	1
+德音不忘	de yin bu wang	1
+德音孔昭	de yin kong zhao	1
+德音莫违	de yin mo wei	1
+得鱼而忘荃	de yu er wang quan	1
+得与亡孰病	de yu wang shu bing	1
+德之不修	de zhi bu xiu	1
+德之流行	de zhi liu xing	1
+德之末也	de zhi mo ye	1
+德之弃也	de zhi qi ye	1
+得志与民由之	de zhi yu min you zhi	1
+德之贼也	de zhi zei ye	1
+德之至也	de zhi zhi ye	1
+登大雷岸与妹书	deng da lei an yu mei shu	1
+磴道盘虚空	deng dao pan xu kong	1
+登峨眉山	deng e mei shan	1
+登高不可以为长	deng gao bu ke yi wei zhang	1
+登高不栗	deng gao bu li	1
+登高丘	deng gao qiu	1
+登高丘而望远	deng gao qiu er wang yuan	1
+登高丘而望远海	deng gao qiu er wang yuan hai	1
+登高壮观天地间	deng gao zhuang guan tian di jian	1
+灯火钱塘三五夜	deng huo qian tang san wu ye	1
+登即相许和	deng ji xiang xu he	1
+登江中孤屿	deng jiang zhong gu yu	1
+登九峰楼	deng jiu feng lou	1
+登乐游原	deng le you yuan	1
+登临不惜更沾衣	deng lin bu xi geng zhan yi	1
+登临出世界	deng lin chu shi jie	1
+登临吴蜀横分地	deng lin wu shu heng fen di	1
+登垄课儿锄	deng long ke er chu	1
+登楼寄王卿	deng lou ji wang qing	1
+邓肃	deng su	1
+登太白峰	deng tai bai feng	1
+灯下白头人	deng xia bai tou ren	1
+灯下草虫鸣	deng xia cao chong ming	1
+邓倚	deng yi	1
+邓攸无子寻知命	deng you wu zi xun zhi ming	1
+灯月交辉	deng yue jiao hui	1
+邓陟	deng zhi	1
+登舟望秋月	deng zhou wang qiu yue	1
+地白风色寒	di bai feng se han	1
+地崩山摧壮士死	di beng shan cui zhuang shi si	1
+地不得不广	di bu de bu guang	1
+帝臣不蔽	di chen bu bi	1
+涤除玄鉴	di chu xuan jian	1
+帝春台	di chun tai	1
+帝得圣相相曰度	di de sheng xiang xiang yue du	1
+地得一以宁	di de yi yi ning	1
+滴滴金	di di jin	1
+底底切切	di di qie qie	1
+蝃蝀	di dong	1
+地动三河铁臂摇	di dong san he tie bi yao	1
+地方千里	di fang qian li	1
+帝高阳之苗裔兮	di gao yang zhi miao yi xi	1
+地静人闲月自妍	di jing ren xian yue zi yan	1
+敌军围困万千重	di jun wei kun wan qian zhong	1
+敌可摧	di ke cui	1
+低空有断云	di kong you duan yun	1
+地脉象牙东	di mai xiang ya dong	1
+笛弄晚风三四声	di nong wan feng san si sheng	1
+地气郁结	di qi yu jie	1
+帝遣银河一派垂	di qian yin he yi pai chui	1
+地若不爱酒	di ruo bu ai jiu	1
+低头共耳语	di tou gong er yu	1
+低头向暗壁	di tou xiang an bi	1
+地无不载	di wu bu zai	1
+地无私载	di wu si zai	1
+地无为以之宁	di wu wei yi zhi ning	1
+地下若逢陈后主	di xia ruo feng chen hou zhu	1
+帝乡不可期	di xiang bu ke qi	1
+帝乡明日到	di xiang ming ri dao	1
+弟兄姐妹舞翩跹	di xiong jie mei wu pian xian	1
+低眼佯行	di yan yang xing	1
+第一花	di yi hua	1
+第一湘江雨	di yi xiang jiang yu	1
+地应无酒泉	di ying wu jiu quan	1
+地犹鄹氏邑	di you zou shi yi	1
+堤远意相随	di yuan yi xiang sui	1
+帝曰汝度功第一	di yue ru du gong di yi	1
+笛在月明楼	di zai yue ming lou	1
+笛中闻折柳	di zhong wen zhe liu	1
+第中无一物	di zhong wu yi wu	1
+地主重重压迫	di zhu chong chong ya po	1
+帝子乘风下翠微	di zi cheng feng xia cui wei	1
+弟子服其劳	di zi fu qi lao	1
+弟子韩干早入室	di zi han gan zao ru shi	1
+弟子记之	di zi ji zhi	1
+弟子入则孝	di zi ru ze xiao	1
+弟子孰为好学	di zi shu wei hao xue	1
+笛奏龙吟水	di zou long yin shui	1
+滇池水	dian chi shui	1
+颠倒思予	dian dao si yu	1
+颠倒衣裳	dian dao yi chang	1
+点点楼头细雨	dian dian lou tou xi yu	1
+点点是	dian dian shi	1
+颠而不扶	dian er bu fu	1
+簟翻寒江浪	dian fan han jiang lang	1
+殿阁生微凉	dian ge sheng wei liang	1
+点画信手烦推求	dian hua xin shou fan tui qiu	1
+典籍开书府	dian ji kai shu fu	1
+点降唇	dian jiang chun	1
+颠连直接东溟	dian lian zhi jie dong ming	1
+颠沛必于是	dian pei bi yu shi	1
+殿前欢	dian qian huan	1
+钿头银篦击节碎	dian tou yin bi ji jie sui	1
+点溪荷叶叠青钱	dian xi he ye die qing qian	1
+点樱桃	dian ying tao	1
+颠之倒之	dian zhi dao zhi	1
+电子版说明	dian zi ban shuo ming	1
+钓罢归来不系船	diao ba gui lai bu xi chuan	1
+吊白居易	diao bai ju yi	1
+凋此红芳年	diao ci hong fang nian	1
+雕弓写明月	diao gong xie ming yue	1
+吊古战场文	diao gu zhan chang wen	1
+调角断清秋	diao jiao duan qing qiu	1
+雕阑玉砌应犹在	diao lan yu qi ying you zai	1
+吊罗荣桓同志	diao luo rong huan tong zhi	1
+貂裘换酒	diao qiu huan jiu	1
+雕声带晚悲	diao sheng dai wan bei	1
+吊严陵	diao yan ling	1
+钓鱼闲处	diao yu xian chu	1
+蝶翻轻粉双飞	die fan qing fen shuang fei	1
+蝶恋花答李淑一	die lian hua da li shu yi	1
+迭为宾主	die wei bin zhu	1
+蝶舞已无多	die wu yi wu duo	1
+鼎铛玉石	ding cheng yu shi	1
+丁丁漏水夜何长	ding ding lou shui ye he chang	1
+定定住天涯	ding ding zhu tian ya	1
+丁督护歌	ding du hu ge	1
+丁儿	ding er	1
+定风流	ding feng liu	1
+丁亥岁云暮	ding hai sui yun mu	1
+鼎湖流水清且闲	ding hu liu shui qing qie xian	1
+定乎内外之分	ding hu nei wai zhi fen	1
+定计于鲜也	ding ji yu xian ye	1
+丁居晦	ding ju hui	1
+订了三家条约	ding le san jia tiao yue	1
+丁棱	ding leng	1
+丁默	ding mo	1
+定如拱北极	ding ru gong bei ji	1
+定僧	ding seng	1
+定是风光牵宿醉	ding shi feng guang qian su zui	1
+定水迥分晖	ding shui jiong fen hui	1
+丁位	ding wei	1
+丁谓	ding wei	1
+定西番	ding xi fan	1
+丁仙芝	ding xian zhi	1
+丁香结	ding xiang jie	1
+丁香空结雨中愁	ding xiang kong jie yu zhong chou	1
+丁泽	ding ze	1
+定之方中	ding zhi fang zhong	1
+丁注	ding zhu	1
+东壁图书府	dong bi tu shu fu	1
+东船西舫悄无言	dong chuan xi fang qiao wu yan	1
+动刀甚微	dong dao shen wei	1
+董德元	dong de yuan	1
+侗而不愿	dong er bu yuan	1
+东方白	dong fang bai	1
+洞房洞房环佩冷	dong fang dong fang huan pei leng	1
+东方风来满眼春	dong fang feng lai man yan chun	1
+东方虬	dong fang qiu	1
+东方未明	dong fang wei ming	1
+东方未晞	dong fang wei xi	1
+东方欲晓	dong fang yu xiao	1
+东方云海空复空	dong fang yun hai kong fu kong	1
+东方之日	dong fang zhi ri	1
+洞房昨夜春风起	dong fang zuo ye chun feng qi	1
+洞房昨夜停红烛	dong fang zuo ye ting hong zhu	1
+东风不为吹愁去	dong feng bu wei chui chou qu	1
+东风吹水日衔山	dong feng chui shui ri xian shan	1
+东风寒	dong feng han	1
+东风袅袅泛崇光	dong feng niao niao fan chong guang	1
+东风洒雨露	dong feng sa yu lu	1
+东风送暖入屠苏	dong feng song nuan ru tu su	1
+东风随春归	dong feng sui chun gui	1
+东风未肯入东门	dong feng wei ken ru dong men	1
+东风已绿瀛洲草	dong feng yi lv ying zhou cao	1
+东风知我欲山行	dong feng zhi wo yu shan xing	1
+董夫子	dong fu zi	1
+东冈	dong gang	1
+东皋薄暮望	dong gao bo mu wang	1
+东皋刈黍归	dong gao yi shu gui	1
+冬歌	dong ge	1
+东割膏腴之地	dong ge gao yu zhi di	1
+东归在洛阳	dong gui zai luo yang	1
+东还海道	dong hai hai dao	1
+东海黄公	dong hai huang gong	1
+洞壑当门前	dong he dang men qian	1
+东湖月	dong hu yue	1
+东家老女嫁不售	dong jia lao nv jia bu shou	1
+东家有贤女	dong jia you xian nv	1
+东郊	dong jiao	1
+冬尽今宵促	dong jin jin xiao cu	1
+东京发使臣	dong jing fa shi chen	1
+东来紫气满函关	dong lai zi qi man han guan	1
+东林怀我师	dong lin huai wo shi	1
+东临碣石有遗篇	dong lin jie shi you yi pian	1
+董龙更是何鸡狗	dong long geng shi he ji gou	1
+东门酤酒饮我曹	dong men gu jiu yin wo cao	1
+东门之墠	dong men zhi chan	1
+东门之池	dong men zhi chi	1
+东门之枌	dong men zhi fen	1
+东门之杨	dong men zhi yang	1
+东面而视	dong mian er shi	1
+东坡七集	dong po qi ji	1
+东坡题跋	dong po ti ba	1
+冬青树上挂凌霄	dong qing shu shang gua ling xiao	1
+动取无妄疾	dong qu wu wang ji	1
+东犬西吠	dong quan xi fei	1
+动人春色不须多	dong ren chun se bu xu duo	1
+冬日归旧山	dong ri gui jiu shan	1
+动如参与商	dong ru can yu shang	1
+东山高卧时起来	dong shan gao wo shi qi lai	1
+冻死苍蝇未足奇	dong si cang ying wei zu qi	1
+董思恭	dong si gong	1
+东台去	dong tai qu	1
+洞天石扇	dong tian shi shan	1
+洞庭波涌连天雪	dong ting bo yong lian tian xue	1
+洞庭春色	dong ting chun se	1
+洞庭西望楚江分	dong ting xi wang chu jiang fen	1
+洞庭一夜无穷雁	dong ting yi ye wu qiong yan	1
+洞庭之东江水西	dong ting zhi dong jiang shui xi	1
+东望武昌	dong wang wu chang	1
+东望西望路迷	dong wang xi wang lu mi	1
+东武吟	dong wu yin	1
+董武子	dong wu zi	1
+东西道	dong xi dao	1
+东西南北	dong xi nan bei	1
+动息如有情	dong xi ru you qing	1
+东西随势倾	dong xi sui shi qing	1
+东西跳梁	dong xi tiao liang	1
+东西消息稀	dong xi xiao xi xi	1
+东西值松柏	dong xi zhi song bai	1
+东仙	dong xian	1
+洞仙词	dong xian ci	1
+东阳歌	dong yang ge	1
+动摇风满怀	dong yao feng man huai	1
+动摇山水影	dong yao shan shui ying	1
+冬夜夜寒觉夜长	dong ye ye han jue ye chang	1
+冬夜杂咏	dong ye za yong	1
+董乂	dong yi	1
+东园垂柳径	dong yuan chui liu jing	1
+东原乐	dong yuan le	1
+洞在清溪何处边	dong zai qing xi he chu bian	1
+动之不以礼	dong zhi bu yi li	1
+动枝生乱影	dong zhi sheng luan ying	1
+冬之夜	dong zhi ye	1
+洞中开宴会	dong zhong kai yan hui	1
+洞中仙	dong zhong xian	1
+斗鹌鹑	dou an chun	1
+斗百草	dou bai cao	1
+斗百花	dou bai hua	1
+窦参	dou can	1
+斗婵娟	dou chan juan	1
+窦常	dou chang	1
+窦夫人	dou fu ren	1
+窦弘余	dou hong yu	1
+窦冀	dou ji	1
+都镜净	dou jing jing	1
+斗酒十千恣欢谑	dou jiu shi qian zi huan xue	1
+窦蒙	dou meng	1
+窦牟	dou mou	1
+窦群	dou qun	1
+都是人间城郭	dou shi ren jian cheng guo	1
+窦叔向	dou shu xiang	1
+窦威	dou wei	1
+窦希玠	dou xi jie	1
+窦庠	dou xiang	1
+豆叶黄	dou ye huang	1
+窦裕	dou yu	1
+杜安道	du an dao	1
+杜安世	du an shi	1
+读罢泪沾襟	du ba lei zhan jin	1
+独伴梨花影	du ban li hua ying	1
+独步闲庭逐夜凉	du bu xian ting zhu ye liang	1
+杜常	du chang	1
+独成其天	du cheng qi tian	1
+独出冠时	du chu guan shi	1
+独旦	du dan	1
+杜东	du dong	1
+杜羔	du gao	1
+杜工部蜀中离席	du gong bu shu zhong li xi	1
+渡海十年归	du hai shi nian gui	1
+独鹤归何晚	du he gui he wan	1
+都护军书至	du hu jun shu zhi	1
+都护铁衣冷犹著	du hu tie yi leng you zhu	1
+独见晓焉	du jian xiao yan	1
+读尽床头几卷书	du jin chuang tou ji juan shu	1
+独居三年	du ju san nian	1
+渡口水流宽	du kou shui liu kuan	1
+杜兰香去未移时	du lan xiang qu wei yi shi	1
+独乐其身	du le qi shen	1
+杜耒	du lei	1
+独立东风看牡丹	du li dong feng kan mu dan	1
+独立寒秋	du li han qiu	1
+独立濛濛细雨中	du li meng meng xi yu zhong	1
+独立三边静	du li san bian jing	1
+独立天地间	du li tian di jian	1
+独立小楼风满袖	du li xiao lou feng man xiu	1
+独立扬新令	du li yang xin ling	1
+独怜京国人南窜	du lian jing guo ren nan cuan	1
+杜良臣	du liang chen	1
+渡辽水	du liao shui	1
+度岭方辞国	du ling fang ci guo	1
+杜陵有布衣	du ling you bu yi	1
+独留青冢向黄昏	du liu qing zhong xiang huang hun	1
+独漉篇	du lu pian	1
+读陆游咏梅词	du lu you yong mei ci	1
+独寐寤歌	du mei wu ge	1
+独寐寤言	du mei wu yan	1
+度门寺	du men si	1
+渡陌临流不自持	du mo lin liu bu zi chi	1
+独敲初夜磬	du qiao chu ye qing	1
+杜秋娘	du qiu niang	1
+独上高楼望吴越	du shang gao lou wang wu yue	1
+独上洛阳桥	du shang luo yang qiao	1
+妒深情却疏	du shen qing que shu	1
+杜审言	du shen yan	1
+赌胜马蹄下	du sheng ma ti xia	1
+读书贵能疑	du shu gui neng yi	1
+读书即未成名	du shu ji wei cheng ming	1
+独树老夫家	du shu lao fu jia	1
+独戍临江夜泊船	du shu lin jiang ye bo chuan	1
+读书破万卷	du shu po wan juan	1
+读书万卷不读律	du shu wan juan bu du lv	1
+读书万卷始通神	du shu wan juan shi tong shen	1
+度水逢胡说	du shui feng hu shuo	1
+独速短蓑舞	du su duan suo wu	1
+独宿江城蜡炬残	du su jiang cheng la ju can	1
+独宿空帘归梦长	du su kong lian gui meng chang	1
+渡头馀落日	du tou yu luo ri	1
+独往独来	du wang du lai	1
+读未见书	du wei jian shu	1
+杜韦娘	du wei niang	1
+独闻和焉	du wen he yan	1
+度我至军中	du wo zhi jun zhong	1
+独无外物牵	du wu wai wu qian	1
+独息	du xi	1
+独向溪山廉	du xiang xi shan lian	1
+独携天上小团月	du xie tian shang xiao tuan yue	1
+笃信好学	du xin hao xue	1
+杜荀鹤	du xun he	1
+杜俨	du yan	1
+杜淹	du yan	1
+渡扬子江	du yang zi jiang	1
+独夜三更月	du ye san geng yue	1
+独夜忆秦关	du ye yi qin guan	1
+杜奕	du yi	1
+杜易简	du yi jian	1
+独倚楼	du yi lou	1
+独有凤凰池上客	du you feng huang chi shang ke	1
+独有豪情	du you hao qing	1
+独有宦游人	du you huan you ren	1
+独有南山桂花发	du you nan shan gui hua fa	1
+独有英雄驱虎豹	du you ying xiong qu hu bao	1
+杜宇	du yu	1
+杜于皇	du yu huang	1
+笃于时也	du yu shi ye	1
+杜元颖	du yuan ying	1
+独照长门宫里人	du zhao chang men gong li ren	1
+渡浙江问舟中人	du zhe jiang wen zhou zhong ren	1
+杜正伦	du zheng lun	1
+独自下寒烟	du zi xia han yan	1
+独自倚阑干	du zi yi lan gan	1
+独自在家长似客	du zi zai jia chang si ke	1
+独醉	du zui	1
+独坐池塘如虎踞	du zuo chi tang ru hu ju	1
+断肠春色在江南	duan chang chun se zai jiang nan	1
+段丞	duan cheng	1
+段成式	duan cheng shi	1
+短服改胡衣	duan fu gai hu yi	1
+段谷	duan gu	1
+断碣残碑	duan jie can bei	1
+断绝胡儿恋母声	duan jue hu er lian mu sheng	1
+断头今日意如何	duan tou jin ri yi ru he	1
+段文昌	duan wen chang	1
+端午临中夏	duan wu lin zhong xia	1
+断无消息石榴红	duan wu xiao xi shi liu hong	1
+断弦离柱箭脱手	duan xian li zhu jian tuo shou	1
+断续寒砧断续风	duan xu han zhen duan xu feng	1
+断雁警愁眠	duan yan jing chou mian	1
+段倚	duan yi	1
+短者不为不足	duan zhe bu wei bu zu	1
+断之则悲	duan zhi ze bei	1
+对楚王问	dui chu wang wen	1
+对此间	dui ci jian	1
+对此结中肠	dui ci jie zhong chang	1
+对此欲倒东南倾	dui ci yu dao dong nan qing	1
+对敌慈悲对友刁	dui di ci bei dui you diao	1
+对酒不觉暝	dui jiu bu jue ming	1
+对酒当歌歌不成	dui jiu dang ge ge bu cheng	1
+对酒行	dui jiu hang	1
+对酒卷帘邀明月	dui jiu juan lian yao ming yue	1
+对客挥毫秦少游	dui ke hui hao qin shao you	1
+堆来枕上愁何状	dui lai zhen shang chou he zhuang	1
+对棋陪谢傅	dui qi pei xie fu	1
+对青山	dui qing shan	1
+对雪二首	dui xue er shou	1
+对玉环	dui yu huan	1
+敦煌曲子	dun huang qu zi	1
+顿使别离难	dun shi bie li nan	1
+顿失滔滔	dun shi tao tao	1
+敦兮其若朴	dun xi qi ruo pu	1
+多病故人疏	duo bing gu ren shu	1
+多藏必厚亡	duo cang bi hou wang	1
+杕杜	duo du	1
+多见而识之	duo jian er shi zhi	1
+夺锦标	duo jin biao	1
+多愧鲁连生	duo kui lu lian sheng	1
+多丽	duo li	1
+多难识君迟	duo nan shi jun chi	1
+多歧路今安在	duo qi lu jin an zai	1
+多情应笑	duo qing ying xiao	1
+多如牛毛	duo ru niu mao	1
+多少长安名利客	duo shao chang an ming li ke	1
+夺席谈经非五鹿	duo xi tan jing fei wu lu	1
+多谢后世人	duo xie hou shi ren	1
+多于机上之工女	duo yu ji shang zhi gong nv	1
+多于九土之城郭	duo yu jiu tu zhi cheng guo	1
+多于南亩之农夫	duo yu nan mu zhi nong fu	1
+多于市人之言语	duo yu shi ren zhi yan yu	1
+多于在庾之粟粒	duo yu zai yu zhi su li	1
+多于周身之帛缕	duo yu zhou shen zhi bo lv	1
+恶不仁者	e bu ren zhe	1
+恶称人之恶者	e cheng ren zhi e zhe	1
+恶乎成名	e hu cheng ming	1
+恶勇而无礼者	e yong er wu li zhe	1
+恶紫之夺朱也	e zi zhi duo zhu ye	1
+恩荣变苦辛	en rong bian ku xin	1
+尔爱其羊	er ai qi yang	1
+二八泉扉掩	er ba quan fei yan	1
+尔辈苦无恃	er bei ku wu shi	1
+而本无形	er ben wu xing	1
+而必为之辞	er bi wei zhi ci	1
+尔卜尔筮	er bu er shi	1
+而不见舆薪	er bu jian yu xin	1
+耳不能两听而聪	er bu neng liang ting er cong	1
+而不能至者	er bu neng zhi zhe	1
+二不孝也	er bu xiao ye	1
+而不与立也	er bu yu li ye	1
+而不知其然	er bu zhi qi ran	1
+而不知其所以然	er bu zhi qi suo yi ran	1
+而不知其所止	er bu zhi qi suo zhi	1
+而耻恶衣恶食者	er chi e yi e shi zhe	1
+而耻学于师	er chi xue yu shi	1
+二川溶溶	er chuan rong rong	1
+而待将军	er dai jiang jun	1
+耳得之而为声	er de zhi er wei sheng	1
+二冬	er dong	1
+尔独如玉	er du ru yu	1
+二更酒醒船初发	er geng jiu xing chuan chu fa	1
+而贵食母	er gui shi mu	1
+而国危矣	er guo wei yi	1
+而后和之	er hou he zhi	1
+而后乃今将图南	er hou nai jin jiang tu nan	1
+而后乃今培风	er hou nai jin pei feng	1
+而后人毁之	er hou ren hui zhi	1
+而记游者甚众	er ji you zhe shen zhong	1
+而见者远	er jian zhe yuan	1
+而今迈步从头越	er jin mai bu cong tou yue	1
+而今我谓昆仑	er jin wo wei kun lun	1
+而绝江河	er jue jiang he	1
+而可大受也	er ke da shou ye	1
+而况精神	er kuang jing shen	1
+而况人乎	er kuang ren hu	1
+而况我乎	er kuang wo hu	1
+而况于明哲乎	er kuang yu ming zhe hu	1
+而况于人乎	er kuang yu ren hu	1
+尔来四万八千岁	er lai si wan ba qian sui	1
+二陵风雨自东来	er ling feng yu zi dong lai	1
+而刘夙婴疾病	er liu su ying ji bing	1
+而乱臣贼子惧	er luan chen zei zi ju	1
+而乱大伦	er luan da lun	1
+而美之者	er mei zhi zhe	1
+而民不争	er min bu zheng	1
+而民弥贫	er min mi pin	1
+而民乃始	er min nai shi	1
+而民自富	er min zi fu	1
+而民自化	er min zi hua	1
+而民自朴	er min zi pu	1
+而民自正	er min zi zheng	1
+而母立于兹	er mu li yu zi	1
+尔鸟	er niao	1
+儿女忽成行	er nv hu cheng xing	1
+儿女罗酒浆	er nv luo jiu jiang	1
+而气候不齐	er qi hou bu qi	1
+而其见愈奇	er qi jian yu qi	1
+而人居其一焉	er ren ju qi yi yan	1
+而人死亦次之	er ren si yi ci zhi	1
+而人之所罕至焉	er ren zhi suo han zhi yan	1
+二三其德	er san qi de	1
+二色莲	er se lian	1
+而神明自得	er shen ming zi de	1
+二十八宿罗心胸	er shi ba xiu luo xin xiong	1
+二十时	er shi shi	1
+二十四日	er shi si ri	1
+二十万军重入赣	er shi wan jun chong ru gan	1
+二十五径	er shi wu jing	1
+二十一个	er shi yi ge	1
+二十有八载	er shi you ba zai	1
+而世之奇伟	er shi zhi qi wei	1
+而庶几乎	er shu ji hu	1
+而谁以易之	er shui yi yi zhi	1
+二水中分白鹭洲	er shui zhong fen bai lu zhou	1
+二宋	er song	1
+尔所不知	er suo bu zhi	1
+尔所谓达者	er suo wei da zhe	1
+而所欲问者	er suo yu wen zhe	1
+二桃杀三士	er tao sha san shi	1
+而天下平	er tian xia ping	1
+而听	er ting	1
+而听细说	er ting xi shuo	1
+儿童强不睡	er tong qiang bu shui	1
+而万物与我为一	er wan wu yu wo wei yi	1
+而往拜之	er wang bai zhi	1
+而往来者	er wang lai zhe	1
+而王先生	er wang xian sheng	1
+而望幸焉	er wang xing yan	1
+而未尝往也	er wei chang wang ye	1
+而闻者彰	er wen zhe zhang	1
+而我独若遗	er wo du ruo yi	1
+而无不在也	er wu bu zai ye	1
+耳无所闻	er wu suo wen	1
+而无望兮	er wu wang xi	1
+二萧	er xiao	1
+儿已薄禄相	er yi bo lu xiang	1
+而亦何常师之有	er yi he chang shi zhi you	1
+而以身轻天下	er yi shen qing tian xia	1
+而用之或不盈	er yong zhi huo bu ying	1
+而又不随以怠	er you bu sui yi dai	1
+而又害之	er you hai zhi	1
+而又何羡乎	er you he xian hu	1
+而游乎四海之外	er you hu si hai zhi wai	1
+而犹浸灌	er you jin guan	1
+而由人乎哉	er you ren hu zai	1
+而有斯疾也	er you si ji ye	1
+而有宋朝之美	er you song chao zhi mei	1
+而有天下	er you tian xia	1
+二与一为三	er yu yi wei san	1
+而愚之始	er yu zhi shi	1
+二月垂杨未挂丝	er yue chui yang wei gua si	1
+二月二日江上行	er yue er ri jiang shang xing	1
+二月二十二	er yue er shi er	1
+二月湖水清	er yue hu shui qing	1
+二月黄鹂飞上林	er yue huang li fei shang lin	1
+而在己为有悔	er zai ji wei you hui	1
+而在萧墙之内也	er zai xiao qiang zhi nei ye	1
+而之楚游者	er zhi chu you zhe	1
+而致千里	er zhi qian li	1
+迩之事父	er zhi shi fu	1
+二肿	er zhong	1
+而众星共之	er zhong xing gong zhi	1
+耳著明月璫	er zhu ming yue dang	1
+二子乘舟	er zi cheng zhou	1
+而子证之	er zi zheng zhi	1
+而卒莫消长也	er zu mo xiao zhang ye	1
+而卒葬之	er zu zang zhi	1
+发白马	fa bai ma	1
+发而不中	fa er bu zhong	1
+发愤忘食	fa fen wang shi	1
+伐鼓渊渊	fa gu yuan yuan	1
+发皓齿	fa hao chi	1
+发乎天光	fa hu tian guang	1
+伐柯	fa ke	1
+伐柯伐柯	fa ke fa ke	1
+伐柯如何	fa ke ru he	1
+伐木丁丁	fa mu ding ding	1
+伐木许许	fa mu xu xu	1
+发人深省	fa ren shen xing	1
+伐树于宋	fa shu yu song	1
+发我枝上花	fa wo zhi shang hua	1
+发言盈庭	fa yan ying ting	1
+法语之言	fa yu zhi yan	1
+泛爱众而亲仁	fan ai zhong er qin ren	1
+凡百君子	fan bai jun zi	1
+凡百三十篇	fan bai san shi pian	1
+凡百元首	fan bai yuan shou	1
+泛彼柏舟	fan bi bai zhou	1
+范朝	fan chao	1
+樊忱	fan chen	1
+樊迟问仁	fan chi wen ren	1
+樊迟问知	fan chi wen zhi	1
+范传正	fan chuan zheng	1
+范灯	fan deng	1
+翻动扶摇羊角	fan dong fu yao yang jiao	1
+犯而不校	fan er bu jiao	1
+反而求之	fan er qiu zhi	1
+泛泛其景	fan fan qi jing	1
+泛泛其逝	fan fan qi shi	1
+泛泛入烟雾	fan fan ru yan wu	1
+范飞	fan fei	1
+樊夫人	fan fu ren	1
+反复终始	fan fu zhong shi	1
+犯孤平	fan gu ping	1
+帆过浪无痕	fan guo lang wu hen	1
+反乎尔者也	fan hu er zhe ye	1
+犯花	fan hua	1
+繁华事散逐香尘	fan hua shi san zhu xiang chen	1
+凡今之人	fan jin zhi ren	1
+烦君最相警	fan jun zui xiang jing	1
+烦疴近消散	fan ke jin xiao san	1
+翻空白鸟时时见	fan kong bai niao shi shi jian	1
+樊哙从良坐	fan kuai cong liang zuo	1
+泛兰舟	fan lan zhou	1
+翻浪惊飞鸟	fan lang jing fei niao	1
+凡六百一十六言	fan liu bai yi shi liu yan	1
+范梦龙	fan meng long	1
+凡民有丧	fan min you sang	1
+蕃女怨	fan nv yuan	1
+繁钦	fan qin	1
+翻身向天仰射云	fan shen xiang tian yang she yun	1
+反是不思	fan shi bu si	1
+反是生女好	fan shi sheng nv hao	1
+反是者败	fan shi zhe bai	1
+翻手覆手不可期	fan shou fu shou bu ke qi	1
+翻手作云覆手雨	fan shou zuo yun fu shou yu	1
+凡外重者内拙	fan wai zhong zhe nei zhuo	1
+凡物各自有根本	fan wu ge zi you gen ben	1
+凡物无成与毁	fan wu wu cheng yu hui	1
+翻香令	fan xiang ling	1
+繁星宿故关	fan xing su gu guan	1
+樊珣	fan xun	1
+范炎	fan yan	1
+范夜	fan ye	1
+翻疑梦里逢	fan yi meng li feng	1
+翻与扇俱团	fan yu shan ju tuan	1
+范元凯	fan yuan kai	1
+翻云覆雨等闲间	fan yun fu yu deng xian jian	1
+凡再变矣	fan zai bian yi	1
+凡在故老	fan zai gu lao	1
+范增数目项王	fan zeng shu mu xiang wang	1
+反者道之动	fan zhe dao zhi dong	1
+繁枝容易纷纷落	fan zhi rong yi fen fen luo	1
+范周	fan zhou	1
+樊宗师	fan zong shi	1
+范祖禹	fan zu yu	1
+房白	fang bai	1
+方不可方可	fang bu ke fang ke	1
+芳草	fang cao	1
+芳草年年与恨长	fang cao nian nian yu hen chang	1
+芳草已云暮	fang cao yi yun mu	1
+方存乎见少	fang cun hu jian shao	1
+放荡齐赵间	fang dang qi zhao jian	1
+防范胜于救灾	fang fan sheng yu jiu zai	1
+芳菲君不见	fang fei jun bu jian	1
+方干	fang gan	1
+房琯	fang guan	1
+方衡	fang heng	1
+放乎四海	fang hu si hai	1
+方涣涣兮	fang huan huan xi	1
+方今之时	fang jin zhi shi	1
+访旧半为鬼	fang jiu ban wei gui	1
+方可方不可	fang ke fang bu ke	1
+方里而井	fang li er jing	1
+方六七十	fang liu qi shi	1
+防露	fang lu	1
+放马天山雪中草	fang ma tian shan xue zhong cao	1
+放辟邪侈	fang pi xie chi	1
+方其梦也	fang qi meng ye	1
+方七十里	fang qi shi li	1
+方千里	fang qian li	1
+房融	fang rong	1
+房孺复	fang ru fu	1
+方如行义	fang ru xing yi	1
+放生鱼鳖逐人来	fang sheng yu bie zhu ren lai	1
+芳树	fang shu	1
+芳树笼秦栈	fang shu long qin zhan	1
+方死方生	fang si fang sheng	1
+方显出英雄本色	fang xian chu ying xiong ben se	1
+芳心向春尽	fang xin xiang chun jin	1
+防有鹊巢	fang you que chao	1
+方愚	fang yu	1
+放于利而行	fang yu li er xing	1
+方宅十余亩	fang zhai shi yu mu	1
+方知大蕃地	fang zhi da fan di	1
+方之舟之	fang zhi zhou zhi	1
+方资	fang zi	1
+匪报也	fei bao ye	1
+非彼无我	fei bi wu wo	1
+非不能也	fei bu neng ye	1
+非不说子之道	fei bu shuo zi zhi dao	1
+非常之观	fei chang zhi guan	1
+飞沉理自隔	fei chen li zi ge	1
+非崇德与	fei chong de yu	1
+非大愚也	fei da yu ye	1
+非道也哉	fei dao ye zai	1
+废嫡立庶	fei di li shu	1
+非尔所及也	fei er suo ji ye	1
+匪风	fei feng	1
+匪斧不克	fei fu bu ke	1
+非敢为佞也	fei gan wei ning ye	1
+非关癖爱轻模样	fei guan pi ai qing mu yang	1
+飞花搅独愁	fei hua jiao du chou	1
+飞花两岸照船红	fei hua liang an zhao chuan hong	1
+飞花满四邻	fei hua man si lin	1
+非及向时之士也	fei ji xiang shi zhi shi ye	1
+飞剑决浮云	fei jian jue fu yun	1
+飞将军自重霄入	fei jiang jun zi chong xiao ru	1
+非君子也	fei jun zi ye	1
+飞来飞来	fei lai fei lai	1
+飞来飞去落谁家	fei lai fei qu luo shui jia	1
+飞来峰	fei lai feng	1
+匪来贸丝	fei lai mao si	1
+非醴泉不饮	fei li quan bu yin	1
+非礼之礼	fei li zhi li	1
+非利足也	fei li zu ye	1
+非练实不食	fei lian shi bu shi	1
+匪媒不得	fei mei bu de	1
+飞鸣镝	fei ming di	1
+飞鸣声念群	fei ming sheng nian qun	1
+肥男有母送	fei nan you mu song	1
+非能水也	fei neng shui ye	1
+飞鸟没何处	fei niao mei he chu	1
+飞鸟千里不敢来	fei niao qian li bu gan lai	1
+匪女之为美	fei nv zhi wei mei	1
+飞蓬各自远	fei peng ge zi yuan	1
+妃嫔媵嫱	fei pin ying qiang	1
+非其鬼而祭之	fei qi gui er ji zhi	1
+飞起玉龙三百万	fei qi yu long san bai wan	1
+非其罪也	fei qi zui ye	1
+非求益者也	fei qiu yi zhe ye	1
+飞泉挂碧峰	fei quan gua bi feng	1
+斐然成章	fei ran cheng zhang	1
+非人磨墨墨磨人	fei ren mo mo mo mo ren	1
+非人之所能为也	fei ren zhi suo neng wei ye	1
+飞沈理自隔	fei shen li zi ge	1
+非世之人	fei shi zhi ren	1
+肥水之战	fei shui zhi zhan	1
+非天下也	fei tian xia ye	1
+非徒无形也	fei tu wu xing ye	1
+非徒无益	fei tu wu yi	1
+飞湍瀑流争喧豗	fei tuan pu liu zheng xuan hui	1
+非谓其闻彼也	fei wei qi wen bi ye	1
+非谓文墨	fei wei wen mo	1
+非为织作迟	fei wei zhi zuo chi	1
+匪我愆期	fei wo qian qi	1
+匪我思且	fei wo si qie	1
+非我无所取	fei wo wu suo qu	1
+非无江海志	fei wu jiang hai zhi	1
+非梧桐不止	fei wu tong bu zhi	1
+非吾徒也	fei wu tu ye	1
+非先王之道	fei xian wang zhi dao	1
+非心服也	fei xin fu ye	1
+非行仁义也	fei xing ren yi ye	1
+飞絮飞花何处是	fei xu fei hua he chu shi	1
+飞絮落花	fei xu luo hua	1
+飞雪	fei xue	1
+飞雪带春风	fei xue dai chun feng	1
+飞雪满群山	fei xue man qun shan	1
+飞雪似杨花	fei xue si yang hua	1
+非言非默	fei yan fei mo	1
+飞燕皇后轻身舞	fei yan huang hou qing shen wu	1
+飞扬跋扈为谁雄	fei yang ba hu wei shui xiong	1
+非以明民	fei yi ming min	1
+非以鸟养养鸟也	fei yi niao yang yang niao ye	1
+非以其无私邪	fei yi qi wu si xie	1
+非义之义	fei yi zhi yi	1
+非阴非阳	fei yin fei yang	1
+非有仲尼	fei you zhong ni	1
+非曰能之	fei yue neng zhi	1
+飞月向南端	fei yue xiang nan duan	1
+飞在白云端	fei zai bai yun duan	1
+妃之	fei zhi	1
+非至强之人	fei zhi qiang zhi ren	1
+非助我者也	fei zhu wo zhe ye	1
+焚百家之言	fen bai jia zhi yan	1
+分曹限紫微	fen cao xian zi wei	1
+粉蝶儿慢	fen die er man	1
+纷纷泊泊夜飞鸦	fen fen bo bo ye fei ya	1
+纷纷开且落	fen fen kai qie luo	1
+纷纷轻薄何须数	fen fen qing bo he xu shu	1
+纷纷扰扰十年间	fen fen rao rao shi nian jian	1
+纷纷射杀五单于	fen fen she sha wu chan yu	1
+焚椒兰也	fen jiao lan ye	1
+汾沮洳	fen ju ru	1
+分裂山河	fen lie shan he	1
+奋六世之余烈	fen liu shi zhi yu lie	1
+分流水	fen liu shui	1
+焚驴志	fen lv zhi	1
+分明怨恨曲中论	fen ming yuan hen qu zhong lun	1
+分明在眼前	fen ming zai yan qian	1
+分明照	fen ming zhao	1
+坟墓在万里	fen mu zai wan li	1
+纷墙丹柱动光彩	fen qiang dan zhu dong guang cai	1
+焚烧杀掠	fen shao sha lue	1
+分身千百亿	fen shen qian bai yi	1
+分手脱相赠	fen shou tuo xiang zeng	1
+汾水之阳	fen shui zhi yang	1
+分司东都	fen si dong du	1
+分田分地真忙	fen tian fen di zhen mang	1
+粪土当年万户侯	fen tu dang nian wan hu hou	1
+分外妖娆	fen wai yao rao	1
+分我一杯羹	fen wo yi bei geng	1
+分野中峰变	fen ye zhong feng bian	1
+焚之已成灰	fen zhi yi cheng hui	1
+封敖	feng ao	1
+封闭宫室	feng bi gong shi	1
+逢彼之怒	feng bi zhi nu	1
+风波不信菱枝弱	feng bo bu xin ling zhi ruo	1
+逢场作戏三昧俱	feng chang zuo xi san mei ju	1
+凤巢西隔九重门	feng chao xi ge jiu chong men	1
+风尘何处期	feng chen he chu qi	1
+风尘何所期	feng chen he suo qi	1
+风尘荏苒音书绝	feng chen ren ran yin shu jue	1
+风尘三尺剑	feng chen san chi jian	1
+凤城寒尽怕春宵	feng cheng han jin pa chun xiao	1
+凤城何处有花枝	feng cheng he chu you hua zhi	1
+凤池吟	feng chi yin	1
+风船解与月徘徊	feng chuan jie yu yue pai huai	1
+风吹柳花满店香	feng chui liu hua man dian xiang	1
+凤吹声如隔彩霞	feng chui sheng ru ge cai xia	1
+风吹细细香	feng chui xi xi xiang	1
+风吹仙袂飘飘举	feng chui xian mei piao piao ju	1
+风吹雨	feng chui yu	1
+讽刺诗	feng ci shi	1
+奉答固道	feng da gu dao	1
+风灯照夜欲三更	feng deng zhao ye yu san geng	1
+蜂蝶纷纷过墙去	feng die fen fen guo qiang qu	1
+风蝶令	feng die ling	1
+风多响易沉	feng duo xiang yi chen	1
+凤飞九千仞	feng fei jiu qian ren	1
+风赋	feng fu	1
+丰干	feng gan	1
+风高大夫树	feng gao dai fu shu	1
+凤歌笑孔丘	feng ge xiao kong qiu	1
+风骨超常伦	feng gu chao chang lun	1
+凤孤飞	feng gu fei	1
+风光好	feng guang hao	1
+风归云	feng gui yun	1
+冯衮	feng gun	1
+风乎舞雩	feng hu wu yu	1
+风华正茂	feng hua zheng mao	1
+凤凰池对青琐门	feng huang chi dui qing suo men	1
+凤凰初下紫泥诏	feng huang chu xia zi ni zhao	1
+凤凰和鸣	feng huang he ming	1
+凤凰间	feng huang jian	1
+凤凰曲	feng huang qu	1
+凤凰山上雨初晴	feng huang shan shang yu chu qing	1
+凤凰台上凤凰游	feng huang tai shang feng huang you	1
+冯晖	feng hui	1
+烽火被冈峦	feng huo bei gang luan	1
+烽火城西百尺楼	feng huo cheng xi bai chi lou	1
+封寄泪空潸	feng ji lei kong shan	1
+风兼残雪起	feng jian can xue qi	1
+风将衡桂接	feng jiang heng gui jie	1
+风劲角弓鸣	feng jin jiao gong ming	1
+风景这边独好	feng jing zhe bian du hao	1
+冯涓	feng juan	1
+风卷红旗过大关	feng juan hong qi guo da guan	1
+冯伉	feng kang	1
+凤来朝	feng lai chao	1
+风来花自舞	feng lai hua zi wu	1
+丰乐楼	feng le lou	1
+风雷动	feng lei dong	1
+锋棱瘦骨成	feng leng shou gu cheng	1
+风帘残烛隔霜清	feng lian can zhu ge shuang qing	1
+风流才子多春思	feng liu cai zi duo chun si	1
+风流贵公子	feng liu gui gong zi	1
+风流肯落他人后	feng liu ken luo ta ren hou	1
+风流儒雅亦吾师	feng liu ru ya yi wu shi	1
+风流扫地尽	feng liu sao di jin	1
+风流少年时	feng liu shao nian shi	1
+风流天下闻	feng liu tian xia wen	1
+凤楼春	feng lou chun	1
+凤楼吟	feng lou yin	1
+风露透窗纱	feng lu tou chuang sha	1
+枫落吴江冷	feng luo wu jiang leng	1
+风马儿	feng ma er	1
+风鸣静夜琴	feng ming jing ye qin	1
+风鸣两岸叶	feng ming liang an ye	1
+丰年瑞	feng nian rui	1
+凤鸟不至	feng niao bu zhi	1
+风飘素影寒	feng piao su ying han	1
+风飘万点正愁人	feng piao wan dian zheng chou ren	1
+风其吹女	feng qi chui nv	1
+风凄凄	feng qi qi	1
+凤栖梧	feng qi wu	1
+风樯动	feng qiang dong	1
+风轻花自落	feng qing hua zi luo	1
+风清露白	feng qing lou bai	1
+风清晓漏闻	feng qing xiao lou wen	1
+凤求凰	feng qiu huang	1
+冯去非	feng qu fei	1
+凤去台空江自流	feng qu tai kong jiang zi liu	1
+风泉满清听	feng quan man qing ting	1
+风入罗衣贴体寒	feng ru luo yi tie ti han	1
+风入四蹄轻	feng ru si ti qing	1
+风生云起	feng sheng yun qi	1
+封书	feng shu	1
+风霜其奈何	feng shuang qi nai he	1
+风送宫嫔笑语和	feng song gong pin xiao yu he	1
+冯宿	feng su	1
+凤台曲	feng tai qu	1
+凤吐流苏带晚霞	feng tu liu su dai wan xia	1
+风为裳	feng wei shang	1
+凤尾香罗薄几重	feng wei xiang luo bo ji chong	1
+风物凄凄宿雨收	feng wu qi qi su yu shou	1
+风物岂无情	feng wu qi wu qing	1
+缝舞衣	feng wu yi	1
+凤兮凤兮非无凰	feng xi feng xi fei wu huang	1
+凤栖梧桐	feng xi wu tong	1
+凤仙引	feng xian yin	1
+风萧萧兮转清	feng xiao xiao xi zhuan qing	1
+凤萧吟	feng xiao yin	1
+冯涯	feng ya	1
+风压轻云贴水飞	feng ya qing yun tie shui fei	1
+风烟滚滚来天半	feng yan gun gun lai tian ban	1
+枫叶荻花秋瑟瑟	feng ye di hua qiu se se	1
+枫叶落	feng ye luo	1
+枫叶落纷纷	feng ye luo fen fen	1
+冯应瑞	feng ying rui	1
+风雨	feng yu	1
+风雨各自异	feng yu ge zi yi	1
+风雨凄凄	feng yu qi qi	1
+风雨如晦	feng yu ru hui	1
+风雨潇潇	feng yu xiao xiao	1
+风雨兴焉	feng yu xing yan	1
+风雨攸除	feng yu you chu	1
+风月相知	feng yue xiang zhi	1
+风云常为护储胥	feng yun chang wei hu chu xu	1
+风云四海生	feng yun si hai sheng	1
+风云突变	feng yun tu bian	1
+风展红旗如画	feng zhan hong qi ru hua	1
+风之积也不厚	feng zhi ji ye bu hou	1
+风枝惊暗鹊	feng zhi jing an que	1
+风中柳	feng zhong liu	1
+奉帚平明金殿开	feng zhou ping ming jin dian kai	1
+冯著	feng zhu	1
+夫哀莫大于心死	fu ai mo da yu xin si	1
+伏波惟愿裹尸还	fu bo wei yuan guo shi hai	1
+夫不自见而见彼	fu bu zi jian er jian bi	1
+抚长剑	fu chang jian	1
+扶持自是神明力	fu chi zi shi shen ming li	1
+附词一首	fu ci yi shou	1
+夫大块载我以形	fu da kuai zai wo yi xing	1
+夫达也者	fu da ye zhe	1
+复道行空	fu dao heng kong	1
+复道交窗作合欢	fu dao jiao chuang zuo he huan	1
+复道殊方礼	fu dao shu fang li	1
+赋得浣纱石	fu de huan sha shi	1
+赋得暮雨送李胄	fu de mu yu song li zhou	1
+赋得沙际路	fu de sha ji lu	1
+赴敌甘负戈	fu di gan fu ge	1
+夫读书诗	fu du shu shi	1
+富而好礼者也	fu er hao li zhe ye	1
+富而可求也	fu er ke qiu ye	1
+富而无骄易	fu er wu jiao yi	1
+扶风豪士歌	fu feng hao shi ge	1
+夫妇有别	fu fu you bie	1
+弗鼓弗考	fu gu fu kao	1
+妇姑相唤浴蚕去	fu gu xiang huan yu can qu	1
+富贵必从勤苦得	fu gui bi cong qin ku de	1
+富贵不相忘	fu gui bu xiang wang	1
+浮桂动丹芳	fu gui dong dan fang	1
+复归其明	fu gui qi ming	1
+复归于朴	fu gui yu pu	1
+复归于物	fu gui yu wu	1
+复归于无极	fu gui yu wu ji	1
+复归于婴儿	fu gui yu ying er	1
+夫何为哉	fu he wei zai	1
+夫何忧何惧	fu he you he ju	1
+夫何远之有	fu he yuan zhi you	1
+夫环而攻之	fu huan er gong zhi	1
+抚剑夜吟啸	fu jian ye yin xiao	1
+抚剑增感慨	fu jian zeng gan kai	1
+夫将不欲	fu jiang bu yu	1
+斧斤以时入山林	fu jin yi shi ru shan lin	1
+府吏得闻之	fu li de wen zhi	1
+府吏见丁宁	fu li jian ding ning	1
+府吏马在前	fu li ma zai qian	1
+府吏闻此变	fu li wen ci bian	1
+府吏闻此事	fu li wen ci shi	1
+赋料扬雄敌	fu liao yang xiong di	1
+夫列子御风而行	fu lie zi yu feng er xing	1
+复令识者久叹嗟	fu ling shi zhe jiu tan jie	1
+福履成之	fu lv cheng zhi	1
+福履将之	fu lv jiang zhi	1
+福履绥之	fu lv sui zhi	1
+福马郎	fu ma lang	1
+赋梅	fu mei	1
+赴密州	fu mi zhou	1
+复命曰常	fu ming yue chang	1
+福莫长于无祸	fu mo chang yu wu huo	1
+父母生我	fu mu sheng wo	1
+父母之年	fu mu zhi nian	1
+父母之心	fu mu zhi xin	1
+负你残春泪几行	fu ni can chun lei ji hang	1
+拂霓裳	fu ni chang	1
+抚念益慈柔	fu nian yi ci rou	1
+妇女解放	fu nv jie fang	1
+妇女无所幸	fu nv wu suo xing	1
+富平少侯	fu ping shao hou	1
+夫千里之远	fu qian li zhi yuan	1
+富且贵焉	fu qie gui yan	1
+福轻乎羽	fu qing hu yu	1
+夫轻诺必寡信	fu qing nuo bi gua xin	1
+夫然后行	fu ran hou xing	1
+夫人不言	fu ren bu yan	1
+妇人见之	fu ren jian zhi	1
+妇人在军中	fu ren zai jun zhong	1
+芙蓉不及美人妆	fu rong bu ji mei ren zhuang	1
+芙蓉国里尽朝晖	fu rong guo li jin zhao hui	1
+芙蓉曲	fu rong qu	1
+芙蓉塘外有轻雷	fu rong tang wai you qing lei	1
+芙蓉向脸两边开	fu rong xiang lian liang bian kai	1
+芙蓉月	fu rong yue	1
+夫三年之丧	fu san nian zhi sang	1
+扶桑已成薪	fu sang yi cheng xin	1
+浮生共憔悴	fu sheng gong qiao cui	1
+浮生聚散云相似	fu sheng ju san yun xiang si	1
+浮生恰似冰底水	fu sheng qia si bing di shui	1
+浮生如梦能几何	fu sheng ru meng neng ji he	1
+浮世本来多聚散	fu shi ben lai duo ju san	1
+父师检责惊走书	fu shi jian ze jing zou shu	1
+抚事慷慨	fu shi kang kai	1
+伏尸数万	fu shi shu wan	1
+复守其母	fu shou qi mu	1
+肤受之诉	fu shou zhi su	1
+妇叹于室	fu tan yu shi	1
+甫田	fu tian	1
+浮天沧海远	fu tian cang hai yuan	1
+俯听闻惊风	fu ting wen jing feng	1
+复通为一	fu tong wei yi	1
+复往邀之	fu wang yao zhi	1
+夫妄意室中之藏	fu wang yi shi zhong zhi cang	1
+夫唯不可识	fu wei bu ke shi	1
+夫唯不盈	fu wei bu ying	1
+夫唯灵修之故也	fu wei ling xiu zhi gu ye	1
+伏惟启阿母	fu wei qi a mu	1
+伏惟圣朝	fu wei sheng chao	1
+夫为天下者	fu wei tian xia zhe	1
+父为子隐	fu wei zi yin	1
+夫闻也者	fu wen ye zhe	1
+夫我乃行之	fu wo nai xing zhi	1
+夫我则不暇	fu wo ze bu xia	1
+复我诸兄	fu wo zhu xiong	1
+复无极也	fu wu ji ye	1
+夫物芸芸	fu wu yun yun	1
+父兮生我	fu xi sheng wo	1
+浮想联翩	fu xiang lian pian	1
+浮香绕曲岸	fu xiang rao qu an	1
+夫婿轻薄儿	fu xu qing bo er	1
+覆压三百余里	fu ya san bai yu li	1
+夫言非吹也	fu yan fei chui ye	1
+俯仰人间今古	fu yang ren jian jin gu	1
+俯仰天地间	fu yang tian di jian	1
+俯仰昔人非	fu yang xi ren fei	1
+芣苡	fu yi	1
+复忆襄阳孟浩然	fu yi xiang yang meng hao ran	1
+俯饮一杯酒	fu yin yi bei jiu	1
+腹犹果然	fu you guo ran	1
+浮游乎万物之祖	fu you hu wan wu zhi zu	1
+蜉蝣掘阅	fu you jue yue	1
+蜉蝣之翼	fu you zhi yi	1
+蜉蝣之羽	fu you zhi yu	1
+父曰	fu yue	1
+浮云不共此山齐	fu yun bu gong ci shan qi	1
+浮云连海岱	fu yun lian hai dai	1
+浮云一别后	fu yun yi bie hou	1
+浮云终日行	fu yun zhong ri xing	1
+符载	fu zai	1
+覆载天地	fu zai tian di	1
+覆载万物者也	fu zai wan wu zhe ye	1
+富哉言乎	fu zai yan hu	1
+复值接舆醉	fu zhi jie yu zui	1
+夫埴木之性	fu zhi mu zhi xing	1
+夫至人者	fu zhi ren zhe	1
+夫知亦有之	fu zhi yi you zhi	1
+腹中无一物	fu zhong wu yi wu	1
+腹中贮书一万卷	fu zhong zhu shu yi wan juan	1
+服周之冕	fu zhou zhi mian	1
+夫子奔逸绝尘	fu zi ben yi jue chen	1
+夫子步亦步	fu zi bu yi bu	1
+傅自得	fu zi de	1
+夫子何哂由也	fu zi he shen you ye	1
+夫子何为者	fu zi he wei zhe	1
+夫子加齐之卿相	fu zi jia qi zhi qing xiang	1
+夫子喟然叹曰	fu zi kui ran tan yue	1
+夫子趋亦趋	fu zi qu yi qu	1
+夫子哂之	fu zi shen zhi	1
+夫子圣者与	fu zi sheng zhe yu	1
+父子相亲	fu zi xiang qin	1
+夫子焉不学	fu zi yan bu xue	1
+夫子言之	fu zi yan zhi	1
+夫子欲之	fu zi yu zhi	1
+夫子之不可及也	fu zi zhi bu ke ji ye	1
+夫子之道	fu zi zhi dao	1
+夫子之得邦家者	fu zi zhi de bang jia zhe	1
+夫子之墙数仞	fu zi zhi qiang shu ren	1
+夫子之谓也	fu zi zhi wei ye	1
+夫子之文章	fu zi zhi wen zhang	1
+夫子至于是邦也	fu zi zhi yu shi bang ye	1
+夫子之云	fu zi zhi yun	1
+夫子自道也	fu zi zi dao ye	1
+俯足以畜妻子	fu zu yi chu qi zi	1
+改革内政	gai ge nei zheng	1
+盖均无贫	gai jun wu pin	1
+盖其又深	gai qi you shen	1
+盖阙如也	gai que ru ye	1
+盖十世希不失矣	gai shi shi xi bu shi yi	1
+盖闻善摄生者	gai wen shan she sheng zhe	1
+改邑不改名	gai yi bu gai ming	1
+盖亦反其本矣	gai yi fan qi ben yi	1
+盖亦勿思	gai yi wu si	1
+盖音谬也	gai yin miu ye	1
+盖有之矣	gai you zhi yi	1
+盖余所至	gai yu suo zhi	1
+改之为贵	gai zhi wei gui	1
+盖竹柏影也	gai zhu bai ying ye	1
+甘草子	gan cao zi	1
+感此怀故人	gan ci huai gu ren	1
+感此伤妾心	gan ci shang qie xin	1
+感恩多	gan en duo	1
+感而后应	gan er hou ying	1
+敢告云山从此始	gan gao yun shan cong ci shi	1
+干戈犹未定	gan ge you wei ding	1
+干荷叶	gan he ye	1
+赣江风雪迷漫处	gan jiang feng xue mi man chu	1
+敢将十指夸针巧	gan jiang shi zhi kua zhen qiao	1
+敢教日月换新天	gan jiao ri yue huan xin tian	1
+感君恩重许君命	gan jun en zhong xu jun ming	1
+感君区区怀	gan jun qu qu huai	1
+甘苦与共	gan ku yu gong	1
+干旄	gan mao	1
+感梦	gan meng	1
+感时抚事增惋伤	gan shi fu shi zeng wan shang	1
+感时思报国	gan shi si bao guo	1
+赣水苍茫闽山碧	gan shui cang mang min shan bi	1
+赣水那边红一角	gan shui na bian hong yi jiao	1
+感斯人言	gan si ren yan	1
+敢问何故	gan wen he gu	1
+敢问何谓也	gan wen he wei ye	1
+敢问其次	gan wen qi ci	1
+甘心首疾	gan xin shou ji	1
+敢用玄牡	gan yong xuan mu	1
+感遇四首	gan yu si shou	1
+感遇四首之二	gan yu si shou zhi er	1
+感遇四首之三	gan yu si shou zhi san	1
+感遇四首之四	gan yu si shou zhi si	1
+感遇四首之一	gan yu si shou zhi yi	1
+感征戍之事	gan zheng shu zhi shi	1
+甘州遍	gan zhou bian	1
+甘州歌	gan zhou ge	1
+甘州令	gan zhou ling	1
+甘州曲	gan zhou qu	1
+甘州子	gan zhou zi	1
+感子故意长	gan zi gu yi chang	1
+刚道有雌雄	gang dao you ci xiong	1
+刚健含婀娜	gang jian han e nuo	1
+刚毅木讷	gang yi mu ne	1
+高才何得混妍媸	gao cai he de hun yan chi	1
+高才脱略名与利	gao cai tuo lue ming yu li	1
+高蟾	gao chan	1
+高崇文	gao chong wen	1
+高第后归道	gao di hou gui dao	1
+高低冥迷	gao di ming mi	1
+高低顺过风	gao di shun guo feng	1
+高帝子孙尽隆准	gao di zi sun jin long zhun	1
+高风汉阳渡	gao feng han yang du	1
+告夫三子	gao fu san zi	1
+杲杲出日	gao gao chu ri	1
+高高正北飞	gao gao zheng bei fei	1
+高阁高阁	gao ge gao ge	1
+高阁客竟去	gao ge ke jing qu	1
+高歌取醉欲自慰	gao ge qu zui yu zi wei	1
+告归常局促	gao gui chang ju cu	1
+高乎视低	gao hu shi di	1
+高怀见物理	gao huai jian wu li	1
+高节人相重	gao jie ren xiang zhong	1
+高句骊	gao ju li	1
+高楼当此夜	gao lou dang ci ye	1
+高楼风雨感斯文	gao lou feng yu gan si wen	1
+高路入云端	gao lu ru yun duan	1
+高论怨诽	gao lun yuan fei	1
+高明逼神恶	gao ming bi shen e	1
+高辇	gao nian	1
+高峤	gao qiao	1
+羔裘	gao qiu	1
+高丘怀宋玉	gao qiu huai song yu	1
+羔裘逍遥	gao qiu xiao yao	1
+高衢	gao qu	1
+高山安可仰	gao shan an ke yang	1
+高山流水	gao shan liu shui	1
+高绍	gao shao	1
+高适	gao shi	1
+高树晓还密	gao shu xiao hai mi	1
+高树早凉归	gao shu zao liang gui	1
+缟素漠漠开风沙	gao su mo mo kai feng sha	1
+高堂明镜悲白发	gao tang ming jing bei bai fa	1
+高蹄战马三千匹	gao ti zhan ma san qian pi	1
+高天滚滚寒流急	gao tian gun gun han liu ji	1
+高卧南斋时	gao wo nan zhai shi	1
+高峡出平湖	gao xia chu ping hu	1
+高下相盈	gao xia xiang ying	1
+高下与云平	gao xia yu yun ping	1
+槁项黄馘	gao xiang huang guo	1
+缟衣綦巾	gao yi qi jin	1
+高以下为基	gao yi xia wei ji	1
+高者十八九	gao zhe shi ba jiu	1
+高拯	gao zheng	1
+高正臣	gao zheng chen	1
+高铢	gao zhu	1
+告诸往而知来者	gao zhu wang er zhi lai zhe	1
+高子芳	gao zi fang	1
+告子未尝知义	gao zi wei chang zhi yi	1
+高宗谅阴	gao zong liang yin	1
+戈壁舟	ge bi zhou	1
+歌吹是扬州	ge chui shi yang zhou	1
+各党各界	ge dang ge jie	1
+阁道二神过	ge dao er shen guo	1
+阁道回看上苑花	ge dao hui kan shang yuan hua	1
+各复归其根	ge fu gui qi gen	1
+各复其根	ge fu qi gen	1
+各各还家门	ge ge hai jia men	1
+歌管风轻度	ge guan feng qing du	1
+隔户杨柳弱袅袅	ge hu yang liu ruo niao niao	1
+戈挥日回	ge hui ri hui	1
+葛屦	ge ju	1
+葛藟	ge lei	1
+葛藟荒之	ge lei huang zhi	1
+隔篱呼取尽馀杯	ge li hu qu jin yu bei	1
+隔篱娇语络丝娘	ge li jiao yu luo si niang	1
+隔离天日	ge li tian ri	1
+隔帘听	ge lian ting	1
+歌令	ge ling	1
+个侬	ge nong	1
+隔浦莲近拍	ge pu lian jin pai	1
+隔墙如隔山	ge qiang ru ge shan	1
+歌且谣	ge qie yao	1
+葛覃	ge qin	1
+歌曲动寒川	ge qu dong han chuan	1
+隔山望南斗	ge shan wang nan dou	1
+葛生	ge sheng	1
+歌声唱彻月儿圆	ge sheng chang che yue er yuan	1
+葛胜仲	ge sheng zhong	1
+葛氏女	ge shi nv	1
+哥舒歌	ge shu ge	1
+哥舒夜带刀	ge shu ye dai dao	1
+隔水问樵夫	ge shui wen qiao fu	1
+歌未竟	ge wei jing	1
+歌舞入长安	ge wu ru chang an	1
+隔溪梅令	ge xi mei ling	1
+隔溪猿哭瘴溪藤	ge xi yuan ku zhang xi teng	1
+葛鸦儿	ge ya er	1
+歌窈窕之章	ge yao tiao zhi zhang	1
+阁夜	ge ye	1
+歌一曲	ge yi qu	1
+歌以赠之	ge yi zeng zhi	1
+各有稻粱谋	ge you dao liang mou	1
+歌有声	ge you sheng	1
+各于其党	ge yu qi dang	1
+各在天一方	ge zai tian yi fang	1
+各在一处	ge zai yi chu	1
+葛之覃兮	ge zhi qin xi	1
+阁中帝子今何在	ge zhong di zi jin he zai	1
+各自东西流	ge zi dong xi liu	1
+各自双双	ge zi shuang shuang	1
+更持红烛赏残花	geng chi hong zhu shang can hua	1
+更复何忧	geng fu he you	1
+更隔蓬山一万重	geng ge peng shan yi wan chong	1
+耿耿不寐	geng geng bu mei	1
+更加郁郁葱葱	geng jia yu yu cong cong	1
+更加众志成城	geng jia zhong zhi cheng cheng	1
+更教明月照流黄	geng jiao ming yue zhao liu huang	1
+更结人间未了因	geng jie ren jian wei liao yin	1
+更堪江上鼓鼙声	geng kan jiang shang gu pi sheng	1
+更看金谷骑	geng kan jin gu qi	1
+更立西江石壁	geng li xi jiang shi bi	1
+更漏促春宵	geng lou cu chun xiao	1
+更那堪凄然相向	geng na kan qi ran xiang xiang	1
+更请君王猎一围	geng qing jun wang lie yi wei	1
+更上一重楼	geng shang yi chong lou	1
+更稍强者	geng shao qiang zhe	1
+耿湋	geng wei	1
+耿玮	geng wei	1
+耿纬	geng wei	1
+更闻桑田变成海	geng wen sang tian bian cheng hai	1
+更无豪杰怕熊罴	geng wu hao jie pa xiong pi	1
+更无人处帘垂地	geng wu ren chu lian chui di	1
+更喜岷山千里雪	geng xi min shan qian li xue	1
+更相为命	geng xiang wei ming	1
+哽咽不能语	geng ye bu neng yu	1
+更有潺潺流水	geng you chan chan liu shui	1
+更有明朝恨	geng you ming chao hen	1
+耕者枪然得其间	geng zhe qiang ran de qi jian	1
+更值夜萤飞	geng zhi ye ying fei	1
+耕种从此起	geng zhong cong ci qi	1
+更作风檐夜雨声	geng zuo feng yan ye yu sheng	1
+弓背霞明剑照霜	gong bei xia ming jian zhao shuang	1
+宫车过也	gong che guo ye	1
+功成不退皆殒身	gong cheng bu tui jie yun shen	1
+功成而不居	gong cheng er bu ju	1
+功成而不有	gong cheng er bu you	1
+功成拂衣去	gong cheng fu yi qu	1
+公乘亿	gong cheng yi	1
+宫词	gong ci	1
+共此灯烛光	gong ci deng zhu guang	1
+公从何处得纸本	gong cong he chu de zhi ben	1
+公等在	gong deng zai	1
+共滴长门一夜长	gong di chang men yi ye chang	1
+恭而无礼则劳	gong er wu li ze lao	1
+共分一日光	gong fen yi ri guang	1
+公服贵貂蝉	gong fu gui diao chan	1
+工夫在诗外	gong fu zai shi wai	1
+功盖三分国	gong gai san fen guo	1
+宫馆何玲珑	gong guan he ling long	1
+公贵干蛊高巾冠	gong gui gan gu gao jin guan	1
+公侯之事	gong hou zhi shi	1
+宫花寂寞红	gong hua ji mo hong	1
+公见人被暴害	gong jian ren bei bao hai	1
+恭俭推让	gong jian tui rang	1
+恭近于礼	gong jin yu li	1
+共君此夜须沉醉	gong jun ci ye xu chen zui	1
+共看明月皆如此	gong kan ming yue jie ru ci	1
+恭宽信敏惠	gong kuan xin min hui	1
+共来百越文身地	gong lai bai yue wen shen di	1
+共怜时世俭梳妆	gong lian shi shi jian shu zhuang	1
+功名富贵两蜗角	gong ming fu gui liang wo jiao	1
+功名富贵若长在	gong ming fu gui ruo zhang zai	1
+功名万里外	gong ming wan li wai	1
+功名夏后商周	gong ming xia hou shang zhou	1
+功名只向马上取	gong ming zhi xiang ma shang qu	1
+宫女如花满春殿	gong nv ru hua man chun dian	1
+宫嫔	gong pin	1
+躬亲抚养	gong qin fu yang	1
+攻亲戚之所畔	gong qin qi zhi suo pan	1
+共赏一轮明月	gong shang yi lun ming yue	1
+共说此年丰	gong shuo ci nian feng	1
+公私仓廪俱丰实	gong si cang lin ju feng shi	1
+弓嗣初	gong si chu	1
+公孙丑上	gong sun chou shang	1
+公孙丑下	gong sun chou xia	1
+公孙剑器初第一	gong sun jian qi chu di yi	1
+公孙龙口	gong sun long kou	1
+公为我献之	gong wei wo xian zhi	1
+公无渡河	gong wu du he	1
+公西华曰	gong xi hua yue	1
+躬行君子	gong xing jun zi	1
+公冶长第五	gong ye chang di wu	1
+功业相反也	gong ye xiang fan ye	1
+宫衣亦有名	gong yi yi you ming	1
+共迎中使望乡台	gong ying zhong shi wang xiang tai	1
+共有樽中好	gong you zun zhong hao	1
+共约重芳日	gong yue zhong fang ri	1
+恭则不侮	gong ze bu wu	1
+宫中调笑	gong zhong tiao xiao	1
+公主琵琶幽怨多	gong zhu pi pa you yuan duo	1
+躬自悼矣	gong zi dao yi	1
+公子南桥应尽兴	gong zi nan qiao ying jin xing	1
+公子王孙芳树下	gong zi wang sun fang shu xia	1
+共醉重阳节	gong zui chong yang jie	1
+共作游冶盘	gong zuo you ye pan	1
+狗不以善吠为良	gou bu yi shan fei wei liang	1
+狗吠深巷中	gou fei shen xiang zhong	1
+苟非吾之所有	gou fei wu zhi suo you	1
+苟患失之	gou huan shi zhi	1
+苟能制侵陵	gou neng zhi qin ling	1
+苟无恒心	gou wu heng xin	1
+苟无饥渴	gou wu ji ke	1
+钩心斗角	gou xin dou jiao	1
+沟引新流几曲声	gou yin xin liu ji qu sheng	1
+苟有用我者	gou you yong wo zhe	1
+构造出了	gou zao chu le	1
+苟正其身矣	gou zheng qi shen yi	1
+苟志于仁矣	gou zhi yu ren yi	1
+苟子之不欲	gou zi zhi bu yu	1
+古柏行	gu bai xing	1
+孤壁野僧邻	gu bi ye seng lin	1
+故别	gu bie	1
+故不登高山	gu bu deng gao shan	1
+故不积跬步	gu bu ji kui bu	1
+谷不可胜食也	gu bu ke sheng shi ye	1
+固不如也	gu bu ru ye	1
+故不为也	gu bu wei ye	1
+固不知子矣	gu bu zhi zi yi	1
+孤臣霜发三千丈	gu chen shuang fa san qian zhang	1
+孤城背岭寒吹角	gu cheng bei ling han chui jiao	1
+孤城当落晖	gu cheng dang luo hui	1
+孤城落日斗兵稀	gu cheng luo ri dou bing xi	1
+古城旁	gu cheng pang	1
+孤城山谷间	gu cheng shan gu jian	1
+古祠高树两茫然	gu ci gao shu liang mang ran	1
+古从军行	gu cong jun xing	1
+古道连绵走西京	gu dao lian mian zou xi jing	1
+孤灯不明思欲绝	gu deng bu ming si yu jue	1
+孤灯寒照雨	gu deng han zhao yu	1
+孤灯未灭梦难成	gu deng wei mie meng nan cheng	1
+孤灯闻楚角	gu deng wen chu jiao	1
+鼓笛慢	gu di man	1
+古调虽自爱	gu diao sui zi ai	1
+故多能鄙事	gu duo neng bi shi	1
+固而近于费	gu er jin yu fei	1
+顾非熊	gu fei xiong	1
+孤飞一片雪	gu fei yi pian xue	1
+孤飞自可疑	gu fei zi ke yi	1
+孤愤	gu fen	1
+鼓峰	gu feng	1
+孤凤竟不至	gu feng jing bu zhi	1
+故夫知效一官	gu fu zhi xiao yi guan	1
+孤高几百寻	gu gao ji bai xun	1
+孤高耸天宫	gu gao song tian gong	1
+孤馆灯青	gu guan deng qing	1
+故关衰草遍	gu guan shuai cao bian	1
+故贵以身为天下	gu gui yi shen wei tian xia	1
+故国平居有所思	gu guo ping ju you suo si	1
+故国三千里	gu guo san qian li	1
+孤鸿海上来	gu hong hai shang lai	1
+孤鸿既高举	gu hong ji gao ju	1
+故混而为一	gu hun er wei yi	1
+孤魂久客间	gu hun jiu ke jian	1
+古记	gu ji	1
+古今词话	gu jin ci hua	1
+古今来许多世家	gu jin lai xu duo shi jia	1
+古今一体	gu jin yi ti	1
+故旧不遗	gu jiu bu yi	1
+沽酒市脯不食	gu jiu shi pu bu shi	1
+故九万里	gu jiu wan li	1
+沽酒与何人	gu jiu yu he ren	1
+古决绝词	gu jue jue ci	1
+故君子有不战	gu jun zi you bu zhan	1
+估客乐	gu ke le	1
+估客昼眠知浪静	gu ke zhou mian zhi lang jing	1
+谷口春残黄鸟稀	gu kou chun can huang niao xi	1
+顾况	gu kuang	1
+古来白骨无人收	gu lai bai gu wu ren shou	1
+古来材大难为用	gu lai cai da nan wei yong	1
+古来存老马	gu lai cun lao ma	1
+古来得意不相负	gu lai de yi bu xiang fu	1
+古来青史谁不见	gu lai qing shi shui bu jian	1
+古来圣贤皆寂寞	gu lai sheng xian jie ji mo	1
+古来万事东流水	gu lai wan shi dong liu shui	1
+孤兰生幽园	gu lan sheng you yuan	1
+故垒西边人道是	gu lei xi bian ren dao shi	1
+孤鸾	gu luan	1
+沽美酒	gu mei jiu	1
+古庙杉松巢水鹤	gu miao shan song chao shui he	1
+故民之从之也轻	gu min zhi cong zhi ye qing	1
+故木受绳则直	gu mu shou sheng ze zhi	1
+钴鉧潭记	gu mu tan ji	1
+钴鉧潭西小丘记	gu mu tan xi xiao qiu ji	1
+古木无人径	gu mu wu ren jing	1
+故能长生	gu neng chang sheng	1
+故能成器长	gu neng cheng qi chang	1
+故能为百谷王	gu neng wei bai gu wang	1
+谷鸟惊棋响	gu niao jing qi xiang	1
+谷鸟一声幽	gu niao yi sheng you	1
+顾盼自雄	gu pan zi xiong	1
+孤平	gu ping	1
+故遣将守关者	gu qian jiang shou guan zhe	1
+故遣来贵门	gu qian lai gui men	1
+故强为之容	gu qiang wei zhi rong	1
+孤琴候萝径	gu qin hou luo jing	1
+古倾杯	gu qing bei	1
+故去彼取此	gu qu bi qu ci	1
+故群于人	gu qun yu ren	1
+故绕池边树	gu rao chi bian shu	1
+故人不见	gu ren bu jian	1
+故人不用赋招魂	gu ren bu yong fu zhao hun	1
+故人重分携	gu ren chong fen xie	1
+故人家在桃花岸	gu ren jia zai tao hua an	1
+故人江海别	gu ren jiang hai bie	1
+古人今人若流水	gu ren jin ren ruo liu shui	1
+故人入我梦	gu ren ru wo meng	1
+故人殊未来	gu ren shu wei lai	1
+古人无复洛城东	gu ren wu fu luo cheng dong	1
+故人相逢耐醉倒	gu ren xiang feng nai zui dao	1
+古人有之	gu ren you zhi	1
+古人之观於天地	gu ren zhi guan yu tian di	1
+骨弱筋柔而握固	gu ruo jin rou er wo gu	1
+固若是芒乎	gu ruo shi mang hu	1
+鼓瑟鼓琴	gu se gu qin	1
+故善人者	gu shan ren zhe	1
+孤山寺	gu shan si	1
+古社	gu she	1
+谷神不死	gu shen bu si	1
+故圣人云	gu sheng ren yun	1
+故声闻过情	gu sheng wen guo qing	1
+故失道而后德	gu shi dao er hou de	1
+故是非不得于身	gu shi fei bu de yu shen	1
+顾视无可置者	gu shi wu ke zhi zhe	1
+谷食之所生	gu shi zhi suo sheng	1
+古戍	gu shu	1
+古戍苍苍烽火寒	gu shu cang cang feng huo han	1
+古树倒江横	gu shu dao jiang heng	1
+故述往事	gu shu wang shi	1
+故说诗者	gu shuo shi zhe	1
+姑苏台上乌栖时	gu su tai shang wu qi shi	1
+姑苏台上宴吴王	gu su tai shang yan wu wang	1
+故岁今宵尽	gu sui jin xiao jin	1
+古台摇落后	gu tai yao luo hou	1
+古调笑	gu tiao xiao	1
+故往见之	gu wang jian zhi	1
+古往今来只如此	gu wang jin lai zhi ru ci	1
+故王之不王	gu wang zhi bu wang	1
+故为天下贵	gu wei tian xia gui	1
+顾我复我	gu wo fu wo	1
+顾我无衣搜荩箧	gu wo wu yi sou jin qie	1
+顾我则笑	gu wo ze xiao	1
+故无弃人	gu wu qi ren	1
+故无弃物	gu wu qi wu	1
+谷无以盈	gu wu yi ying	1
+故乡不可见	gu xiang bu ke jian	1
+故乡今夜思千里	gu xiang jin ye si qian li	1
+故乡无此好湖山	gu xiang wu ci hao hu shan	1
+故幸来告良	gu xing lai gao liang	1
+顾夐	gu xiong	1
+孤雁不饮啄	gu yan bu yin zhuo	1
+孤雁儿	gu yan er	1
+古阳关	gu yang guan	1
+故以身观身	gu yi shen guan shen	1
+固一世之雄也	gu yi shi zhi xiong ye	1
+顾影无如白发何	gu ying wu ru bai fa he	1
+故有之以为利	gu you zhi yi wei li	1
+汩余若将不及兮	gu yu ruo jiang bu ji xi	1
+故寓诸无竟	gu yu zhu wu jing	1
+故远人不服	gu yuan ren bu fu	1
+故园三十二年前	gu yuan san shi er nian qian	1
+故园芜已平	gu yuan wu yi ping	1
+故园杨柳今摇落	gu yuan yang liu jin yao luo	1
+孤月沧浪河汉清	gu yue cang lang he han qing	1
+孤云将野鹤	gu yun jiang ye he	1
+觚哉觚哉	gu zai gu zai	1
+顾朝阳	gu zhao yang	1
+古者民有三疾	gu zhe min you san ji	1
+古者世称大手笔	gu zhe shi cheng da shou bi	1
+古者言之不出	gu zhe yan zhi bu chu	1
+古之道也	gu zhi dao ye	1
+古之善为道者	gu zhi shan wei dao zhe	1
+古之伤心人	gu zhi shang xin ren	1
+古之所谓	gu zhi suo wei	1
+古之贤人也	gu zhi xian ren ye	1
+古之学者必有师	gu zhi xue zhe bi you shi	1
+古之学者为己	gu zhi xue zhe wei ji	1
+古之愚也直	gu zhi yu ye zhi	1
+古之真人	gu zhi zhen ren	1
+古之至人	gu zhi zhi ren	1
+故知足之足	gu zhi zu zhi zu	1
+固众芳之所在	gu zhong fang zhi suo zai	1
+故终无难矣	gu zhong wu nan yi	1
+孤舟一系故园心	gu zhou yi xi gu yuan xin	1
+孤烛异乡人	gu zhu yi xiang ren	1
+故作不良计	gu zuo bu liang ji	1
+故作此词	gu zuo ci ci	1
+寡不道以欢成	gua bu dao yi huan cheng	1
+寡妇起彷徨	gua fu qi pang huang	1
+瓜茉莉	gua mo li	1
+寡人读书	gua ren du shu	1
+寡人好货	gua ren hao huo	1
+寡人好色	gua ren hao se	1
+寡人愿安承教	gua ren yuan an cheng jiao	1
+寡人之民不加多	gua ren zhi min bu jia duo	1
+寡人之于国也	gua ren zhi yu guo ye	1
+寡人之於国也	gua ren zhi yu guo ye	1
+瓜熟子离离	gua shu zi li li	1
+瓜田不纳履	gua tian bu na lv	1
+挂席几千里	gua xi ji qian li	1
+怪力乱神	guai li luan shen	1
+观巴黎油画记	guan ba li you hua ji	1
+关城树色催寒近	guan cheng shu se cui han jin	1
+官非督护贵	guan fei du hu gui	1
+冠盖非新里	guan gai fei xin li	1
+冠盖何辉赫	guan gai he hui he	1
+冠盖满京华	guan gai man jing hua	1
+官高何足论	guan gao he zu lun	1
+管鉴	guan jian	1
+关雎之乱	guan ju zhi luan	1
+管领春风总不如	guan ling chun feng zong bu ru	1
+关门令尹谁能识	guan men ling yin shui neng shi	1
+关内阻饥	guan nei zu ji	1
+关盼盼	guan pan pan	1
+观其眸子	guan qi mou zi	1
+管却自家身与心	guan que zi jia shen yu xin	1
+关塞萧条行路难	guan sai xiao tiao xing lu nan	1
+关山阵阵苍	guan shan zhen zhen cang	1
+官事不摄	guan shi bu she	1
+管氏而知礼	guan shi er zhi li	1
+惯弹琵琶解歌舞	guan tan pi pa jie ge wu	1
+观天地生物气象	guan tian di sheng wu qi xiang	1
+管弦呕哑	guan xian ou ya	1
+官因老病休	guan yin lao bing xiu	1
+观音妙智力	guan yin miao zhi li	1
+官应老病休	guan ying lao bing xiu	1
+关咏	guan yong	1
+观于大海	guan yu da hai	1
+观鱼胜过富春江	guan yu sheng guo fu chun jiang	1
+关月冷相随	guan yue leng xiang sui	1
+管乐有才原不忝	guan yue you cai yuan bu tian	1
+关张无命欲何如	guan zhang wu ming yu he ru	1
+观者如山色沮丧	guan zhe ru shan se ju sang	1
+冠者五六人	guan zhe wu liu ren	1
+官至礼部尚书	guan zhi li bu shang shu	1
+官知止而神欲行	guan zhi zhi er shen yu xing	1
+管仲不死	guan zhong bu si	1
+关中昔丧乱	guan zhong xi sang luan	1
+管仲相桓公	guan zhong xiang huan gong	1
+管仲有病	guan zhong you bing	1
+管仲之力也	guan zhong zhi li ye	1
+光被遐荒	guang bei xia huang	1
+光彩露沾湿	guang cai lu zhan shi	1
+广昌路上	guang chang lu shang	1
+广成子曰	guang cheng zi yue	1
+广德若不足	guang de ruo bu zu	1
+光而不耀	guang er bu yao	1
+广寒秋	guang han qiu	1
+广寒枝	guang han zhi	1
+广乎其似世也	guang hu qi si shi ye	1
+光景不待人	guang jing bu dai ren	1
+光禄池台开锦绣	guang lu chi tai kai jin xiu	1
+广莫之野	guang mo zhi ye	1
+光阴迫	guang yin po	1
+广泽生明月	guang ze sheng ming yue	1
+光照手	guang zhao shou	1
+归鞍竞带青丝笼	gui an jing dai qing si long	1
+归朝欢	gui chao huan	1
+贵大患若身	gui da huan ruo shen	1
+归登	gui deng	1
+桂殿秋	gui dian qiu	1
+桂殿入西秦	gui dian ru xi qin	1
+归飞体更轻	gui fei ti geng qing	1
+归飞哑哑枝上啼	gui fei ya ya zhi shang ti	1
+桧风	gui feng	1
+归根曰静	gui gen yue jing	1
+归国谣	gui guo yao	1
+归国遥	gui guo yao	1
+归酣歌大风	gui han ge da feng	1
+归化	gui hua	1
+桂华明	gui hua ming	1
+桂华秋皎洁	gui hua qiu jiao jie	1
+归客千里至	gui ke qian li zhi	1
+归孔子豚	gui kong zi tun	1
+归来饱饭黄昏后	gui lai bao fan huang hun hou	1
+贵来方悟稀	gui lai fang wu xi	1
+归来归去来	gui lai gui qu lai	1
+归来看取明镜前	gui lai kan qu ming jing qian	1
+归来每日斜	gui lai mei ri xie	1
+归来且闭关	gui lai qie bi guan	1
+归来视幼女	gui lai shi you nv	1
+归来头白还戍边	gui lai tou bai hai shu bian	1
+归来无人识	gui lai wu ren shi	1
+归来已不见	gui lai yi bu jian	1
+归来展转到五更	gui lai zhan zhuan dao wu geng	1
+归来煮白石	gui lai zhu bai shi	1
+归老江湖边	gui lao jiang hu bian	1
+桂林风景异	gui lin feng jing yi	1
+归路满尘埃	gui lu man chen ai	1
+归路晚风清	gui lu wan feng qing	1
+归马识残旗	gui ma shi can qi	1
+癸卯岁	gui mao sui	1
+归梦不宜秋	gui meng bu yi qiu	1
+归梦隔狼河	gui meng ge lang he	1
+桂魄初生秋露微	gui po chu sheng qiu lu wei	1
+归去难	gui qu nan	1
+归去越王家	gui qu yue wang jia	1
+归塞北	gui sai bei	1
+鬼三台	gui san tai	1
+归山深浅去	gui shan shen qian qu	1
+龟蛇静	gui she jing	1
+龟蛇锁大江	gui she suo da jiang	1
+跪双膝	gui shuang xi	1
+归思欲沾巾	gui si yu zhan jin	1
+归嵩山作	gui song shan zuo	1
+贵为天子	gui wei tian zi	1
+归卧南山陲	gui wo nan shan chui	1
+鬼物守护烦撝呵	gui wu shou hu fan hui he	1
+归兮归兮	gui xi gui xi	1
+归心折大刀	gui xin zhe da dao	1
+归休乎君	gui xiu hu jun	1
+桂叶双眉久不描	gui ye shuang mei jiu bu miao	1
+桂影斑驳	gui ying ban bo	1
+龟玉毁于椟中	gui yu hui yu du zhong	1
+归于其居	gui yu qi ju	1
+归于其室	gui yu qi shi	1
+闺怨	gui yuan	1
+归哉归哉	gui zai gui zai	1
+归棹洛阳人	gui zhao luo yang ren	1
+桂棹兮兰桨	gui zhao xi lan jiang	1
+闺中少妇不曾愁	gui zhong shao fu bu ceng chou	1
+闺中少妇不知愁	gui zhong shao fu bu zhi chou	1
+闺中只独看	gui zhong zhi du kan	1
+归字谣	gui zi yao	1
+归自谣	gui zi yao	1
+桂子月中落	gui zi yue zhong luo	1
+滚绣球	gun xiu qiu	1
+衮衣绣裳	gun yi xiu shang	1
+国必自伐	guo bi zi fa	1
+果不如先愿	guo bu ru xian yuan	1
+国朝盛文章	guo chao sheng wen zhang	1
+国耻未雪	guo chi wei xue	1
+国初以来画鞍马	guo chu yi lai hua an ma	1
+过崔八丈水亭	guo cui ba zhang shui ting	1
+郭澹	guo dan	1
+过而不改	guo er bu gai	1
+果而勿骄	guo er wu jiao	1
+国风	guo feng	1
+郭恭	guo gong	1
+虢国夫人承主恩	guo guo fu ren cheng zhu en	1
+国际悲歌歌一曲	guo ji bei ge ge yi qu	1
+国家成败吾岂敢	guo jia cheng bai wu qi gan	1
+国家昏乱	guo jia hun luan	1
+国家无事	guo jia wu shi	1
+国家滋昏	guo jia zi hun	1
+过江龙	guo jiang long	1
+过晋阳宫	guo jin yang gong	1
+过了黄洋界	guo le huang yang jie	1
+过骊山作	guo li shan zuo	1
+郭利贞	guo li zhen	1
+郭良骥	guo liang ji	1
+过龙门	guo long men	1
+蜾蠃负之	guo luo fu zhi	1
+郭门临渡头	guo men lin du tou	1
+过蒙拔擢	guo meng ba zhuo	1
+过七里滩	guo qi li tan	1
+过前后厅	guo qian hou ting	1
+过勤政楼	guo qin zheng lou	1
+郭求	guo qiu	1
+过去已过去	guo qu yi guo qu	1
+国人皆曰可杀	guo ren jie yue ke sha	1
+过沙溪急	guo sha xi ji	1
+郭绍兰	guo shao lan	1
+郭受	guo shou	1
+过四皓墓	guo si hao mu	1
+过温汤	guo wen tang	1
+郭向	guo xiang	1
+过香积寺	guo xiang ji si	1
+国学生	guo xue sheng	1
+过眼滔滔云共雾	guo yan tao tao yun gong wu	1
+郭应祥	guo ying xiang	1
+过犹不及	guo you bu ji	1
+国有疑难可问谁	guo you yi nan ke wen shui	1
+过雨看松色	guo yu kan song se	1
+郭圆	guo yuan	1
+郭郧	guo yun	1
+国运兴衰	guo yun xing shuai	1
+过则改之	guo ze gai zhi	1
+过则勿惮改	guo ze wu dan gai	1
+郭章	guo zhang	1
+郭正一	guo zheng yi	1
+国之本在家	guo zhi ben zai jia	1
+郭子正	guo zi zheng	1
+郭遵	guo zun	1
+还必相迎取	hai bi xiang ying qu	1
+还从物外起田园	hai cong wu wai qi tian yuan	1
+孩儿立志出乡关	hai er li zhi chu xiang guan	1
+海风吹不断	hai feng chui bu duan	1
+海哥	hai ge	1
+还归长安去	hai gui chang an qu	1
+害浣害否	hai huan hai fou	1
+还将两行泪	hai jiang liang hang lei	1
+还京乐	hai jing le	1
+还军霸上	hai jun ba shang	1
+还看今朝	hai kan jin zhao	1
+海客乘天风	hai ke cheng tian feng	1
+海客谈瀛洲	hai ke tan ying zhou	1
+海录碎事	hai lu sui shi	1
+海门深不见	hai men shen bu jian	1
+海内风尘诸弟隔	hai nei feng chen zhu di ge	1
+海鸥何事更相疑	hai ou he shi geng xiang yi	1
+海畔云山拥蓟城	hai pan yun shan yong ji cheng	1
+海气湿蛰熏腥臊	hai qi shi zhe xun xing sao	1
+还寝梦佳期	hai qin meng jia qi	1
+海色晴看雨	hai se qing kan yu	1
+海山仙子国	hai shan xian zi guo	1
+海上风雨至	hai shang feng yu zhi	1
+海上谣	hai shang yao	1
+海上有仙山	hai shang you xian shan	1
+海神来过恶风回	hai shen lai guo e feng hui	1
+还是读书	hai shi du shu	1
+还睡	hai shui	1
+还似旧时游上苑	hai si jiu shi you shang yuan	1
+海棠不惜胭脂色	hai tang bu xi yan zhi se	1
+海棠春	hai tang chun	1
+海棠花	hai tang hua	1
+海天愁思正茫茫	hai tian chou si zheng mang mang	1
+海天阔处	hai tian kuo chu	1
+海外徒闻更九州	hai wai tu wen geng jiu zhou	1
+还相随	hai xiang sui	1
+还掩故园扉	hai yan gu yuan fei	1
+海燕双栖玳瑁梁	hai yan shuang qi dai mao liang	1
+还应酿老春	hai ying niang lao chun	1
+还有吃的	hai you chi de	1
+还与星河次	hai yu xing he ci	1
+还在人间否	hai zai ren jian fou	1
+还作江南会	hai zuo jiang nan hui	1
+韩碑	han bei	1
+汉兵奋迅如霹雳	han bing fen xun ru pi li	1
+汉兵屯在轮台北	han bing tun zai lun tai bei	1
+寒波澹澹起	han bo dan dan qi	1
+韩察	han cha	1
+汉朝公卿忌贾生	han chao gong qing ji jia sheng	1
+韩垂	han chui	1
+韩琮	han cong	1
+菡萏发荷花	han dan fa he hua	1
+菡萏金芙蓉	han dan jin fu rong	1
+邯郸先震惊	han dan xian zhen jing	1
+菡萏香销翠叶残	han dan xiang xiao cui ye can	1
+汉道昌	han dao chang	1
+含德之厚	han de zhi hou	1
+寒灯独可亲	han deng du ke qin	1
+寒灯独夜人	han deng du ye ren	1
+寒灯思旧事	han deng si jiu shi	1
+汉帝金茎云外直	han di jin jing yun wai zhi	1
+汉帝重阿娇	han di zhong a jiao	1
+寒冬十二月	han dong shi er yue	1
+韩非囚秦	han fei qiu qin	1
+汉宫春慢	han gong chun man	1
+汉宫词	han gong ci	1
+寒姑	han gu	1
+汉广	han guang	1
+含光混世贵无名	han guang hun shi gui wu ming	1
+汗光珠点点	han guang zhu dian dian	1
+韩翃	han hong	1
+寒花葬志	han hua zang zhi	1
+韩璜	han huang	1
+汉家秦地月	han jia qin di yue	1
+汉家青史上	han jia qing shi shang	1
+汉家山东二百州	han jia shan dong er bai zhou	1
+汉家烟尘在东北	han jia yan chen zai dong bei	1
+汉奸何多	han jian he duo	1
+韩绛	han jiang	1
+汉将辞家破残贼	han jiang ci jia po can zei	1
+汉将归来虏塞空	han jiang gui lai lu sai kong	1
+汉江临眺	han jiang lin tiao	1
+寒江雪柳日新晴	han jiang xue liu ri xin qing	1
+韩驹	han ju	1
+韩濬	han jun	1
+寒林空见日斜时	han lin kong jian ri xie shi	1
+寒柳	han liu	1
+寒梅最堪恨	han mei zui kan hen	1
+汗牛充栋	han niu chong dong	1
+汉女输橦布	han nv shu tong bu	1
+寒禽与衰草	han qin yu shuai cao	1
+寒磬满空林	han qing man kong lin	1
+含情欲说宫中事	han qing yu shuo gong zhong shi	1
+寒山	han shan	1
+寒山吹笛唤春归	han shan chui di huan chun gui	1
+寒山转苍翠	han shan zhuan cang cui	1
+韩生画马真是马	han sheng hua ma zhen shi ma	1
+寒声一夜传刁斗	han sheng yi ye chuan diao dou	1
+寒食词	han shi ci	1
+汉使断肠对归客	han shi duan chang dui gui ke	1
+寒食寄京师诸弟	han shi ji jing shi zhu di	1
+寒树依微远天外	han shu yi wei yuan tian wai	1
+汉水接天回	han shui jie tian hui	1
+汉水亦应西北流	han shui yi ying xi bei liu	1
+韩思复	han si fu	1
+寒随一夜去	han sui yi ye qu	1
+寒塘欲下迟	han tang yu xia chi	1
+撼庭秋	han ting qiu	1
+韩魏之经营	han wei zhi jing ying	1
+汉文皇帝有高台	han wen huang di you gao tai	1
+汉文有道恩犹薄	han wen you dao en you bo	1
+含曦	han xi	1
+韩熙载	han xi zai	1
+汉下白登道	han xia bai deng dao	1
+韩仙姑	han xian gu	1
+含笑看吴钩	han xiao kan wu gou	1
+含笑问檀郎	han xiao wen tan lang	1
+寒心未肯随春态	han xin wei ken sui chun tai	1
+韩休	han xiu	1
+寒雪梅中尽	han xue mei zhong jin	1
+寒鸦栖复惊	han ya qi fu jing	1
+含烟惹雾每依依	han yan re wu mei yi yi	1
+寒夜天光白	han ye tian guang bai	1
+韩仪	han yi	1
+寒衣处处催刀尺	han yi chu chu cui dao chi	1
+汉有游女	han you you nv	1
+韩屿	han yu	1
+寒月悲笳	han yue bei jia	1
+寒云路几层	han yun lu ji ceng	1
+韩昭	han zhao	1
+汉之广矣	han zhi guang yi	1
+韩准	han zhun	1
+行当封侯归	hang dang feng hou gui	1
+行当浮桂棹	hang dang fu gui zhao	1
+行名失己	hang ming shi ji	1
+杭州等地	hang zhou deng di	1
+豪荡感激	hao dang gan ji	1
+浩荡及关愁	hao dang ji guan chou	1
+浩荡寄南征	hao dang ji nan zheng	1
+号东坡居士	hao dong po ju shi	1
+好鹅寻道士	hao e xun dao shi	1
+好风襟袖知	hao feng jin xiu zhi	1
+好刚不好学	hao gang bu hao xue	1
+浩歌待明月	hao ge dai ming yue	1
+豪歌急鼓送寒来	hao ge ji gu song han lai	1
+好观音	hao guan yin	1
+浩浩风起波	hao hao feng qi bo	1
+浩浩观湖江	hao hao guan hu jiang	1
+好花时	hao hua shi	1
+好客见当时	hao ke jian dang shi	1
+好乐何如	hao le he ru	1
+好乐无荒	hao le wu huang	1
+好离乡	hao li xiang	1
+毫毛不敢有所近	hao mao bu gan you suo jin	1
+好梦惊回	hao meng jing hui	1
+好谋而成者也	hao mou er cheng zhe ye	1
+好女儿	hao nv er	1
+浩然离故关	hao ran li gu guan	1
+浩然天地间	hao ran tian di jian	1
+好仁不好学	hao ren bu hao xue	1
+豪圣凋枯	hao sheng diao ku	1
+好是春风湖上亭	hao shi chun feng hu shang ting	1
+好时光	hao shi guang	1
+好是行春野望中	hao shi xing chun ye wang zhong	1
+好是正直	hao shi zheng zhi	1
+昊天罔极	hao tian wang ji	1
+好为庐山谣	hao wei lu shan yao	1
+号物之数谓之万	hao wu zhi shu wei zhi wan	1
+好信不好学	hao xin bu hao xue	1
+好行小慧	hao xing xiao hui	1
+好勇不好学	hao yong bu hao xue	1
+好勇疾贫	hao yong ji pin	1
+好直不好学	hao zhi bu hao xue	1
+好知不好学	hao zhi bu hao xue	1
+好竹连山觉笋香	hao zhu lian shan jue sun xiang	1
+好自相扶将	hao zi xiang fu jiang	1
+郝子直	hao zi zhi	1
+何必待之子	he bi dai zhi zi	1
+何必读书	he bi du shu	1
+何必改作	he bi gai zuo	1
+何必高宗	he bi gao zong	1
+何必金与钱	he bi jin yu qian	1
+何必劳神苦思	he bi lao shen ku si	1
+何必龙山好	he bi long shan hao	1
+何彼襛矣	he bi nong yi	1
+何必求神仙	he bi qiu shen xian	1
+何必求知音	he bi qiu zhi yin	1
+何必曰利	he bi yue li	1
+何必珍珠慰寂寥	he bi zhen zhu wei ji liao	1
+何不改乎此度	he bu gai hu ci du	1
+曷不肃雍	he bu su yong	1
+和不欲出	he bu yu chu	1
+贺朝	he chao	1
+鹤巢松树遍	he chao song shu bian	1
+何处哀筝随急管	he chu ai zheng sui ji guan	1
+何处飞来双白鹭	he chu fei lai shuang bai lu	1
+何处还相遇	he chu hai xiang yu	1
+何处何服则安道	he chu he fu ze an dao	1
+何处浣纱人	he chu huan sha ren	1
+何处寄相思	he chu ji xiang si	1
+何处青山是越中	he chu qing shan shi yue zhong	1
+何处闻灯不看来	he chu wen deng bu kan lai	1
+何处无竹柏	he chu wu zhu bai	1
+何处西南任好风	he chu xi nan ren hao feng	1
+何处寻行迹	he chu xun xing ji	1
+何从何道则得道	he cong he dao ze de dao	1
+何待来年	he dai lai nian	1
+何当重相见	he dang chong xiang jian	1
+何当击凡鸟	he dang ji fan niao	1
+何当施教化	he dang shi jiao hua	1
+何当一来游	he dang yi lai you	1
+何当载酒来	he dang zai jiu lai	1
+何德之衰	he de zhi shuai	1
+河东凶亦然	he dong xiong yi ran	1
+荷动知鱼散	he dong zhi yu san	1
+河渎神	he du shen	1
+和而不唱	he er bu chang	1
+何妨吮短毫	he fang shun duan hao	1
+荷风送香气	he feng song xiang qi	1
+何敢助妇语	he gan zhu fu yu	1
+盍各言尔志	he ge yan er zhi	1
+河广	he guang	1
+何光远	he guang yuan	1
+和郭沫若同志	he guo mo ruo tong zhi	1
+赫赫师尹	he he shi yin	1
+赫赫始祖	he he shi zu	1
+荷花娇欲语	he hua jiao yu yu	1
+荷花媚	he hua mei	1
+荷花羞玉颜	he hua xiu yu yan	1
+荷花夜开风露香	he hua ye kai feng lu xiang	1
+合欢	he huan	1
+合昏尚知时	he hun shang zhi shi	1
+贺及	he ji	1
+何敬	he jing	1
+何竟日默默在此	he jing ri mo mo zai ci	1
+鹤胫虽长	he jing sui chang	1
+何可废也	he ke fei ye	1
+何可胜道也哉	he ke sheng dao ye zai	1
+何可胜言	he ke sheng yan	1
+何可一日无此君	he ke yi ri wu ci jun	1
+贺兰进明	he lan jin ming	1
+贺兰山下阵如云	he lan shan xia zhen ru yun	1
+何劳荆棘始堪伤	he lao jing ji shi kan shang	1
+和乐且湛	he le qie zhan	1
+和泪试严妆	he lei shi yan zhuang	1
+和泪折残红	he lei zhe can hong	1
+何理不可得	he li bu ke de	1
+荷笠带夕阳	he li dai xi yang	1
+河流入断山	he liu ru duan shan	1
+和柳亚子先生	he liu ya zi xian sheng	1
+何鸾	he luan	1
+河满子	he man zi	1
+鹤鸣于九皋	he ming yu jiu gao	1
+何莫学夫诗	he mo xue fu shi	1
+何莫由斯道也	he mo you si dao ye	1
+何乃太区区	he nai tai qu qu	1
+河难凭	he nan ping	1
+何年致此身	he nian zhi ci shen	1
+和凝	he ning	1
+何频瑜	he pin yu	1
+何其多能也	he qi duo neng ye	1
+何其久也	he qi jiu ye	1
+曷其有佸	he qi you huo	1
+曷其有极	he qi you ji	1
+合气于漠	he qi yu mo	1
+何弃之有	he qi zhi you	1
+河桥不相送	he qiao bu xiang song	1
+何情不诉	he qing bu su	1
+贺卿得高迁	he qing de gao qian	1
+何求美人折	he qiu mei ren zhe	1
+何人到白云	he ren dao bai yun	1
+何忍独为醒	he ren du wei xing	1
+何人斯	he ren si	1
+何人倚剑白云天	he ren yi jian bai yun tian	1
+何日大刀头	he ri da dao tou	1
+何日复归来	he ri fu gui lai	1
+何日平胡虏	he ri ping hu lu	1
+何日是归年	he ri shi gui nian	1
+何日是归期	he ri shi gui qi	1
+何日忘之	he ri wang zhi	1
+何如北地春	he ru bei di chun	1
+何如薄幸锦衣郎	he ru bo xing jin yi lang	1
+何如德之衰也	he ru de zhi shuai ye	1
+何如其知也	he ru qi zhi ye	1
+河润九里	he run jiu li	1
+河山北枕秦关险	he shan bei zhen qin guan xian	1
+河上仙翁去不回	he shang xian weng qu bu hui	1
+贺圣朝	he sheng chao	1
+禾生陇亩无东西	he sheng long mu wu dong xi	1
+河声入海遥	he sheng ru hai yao	1
+何事不可为	he shi bu ke wei	1
+何事不语	he shi bu yu	1
+何时旦	he shi dan	1
+何时返旆勒燕然	he shi fan pei le yan ran	1
+何时缚住苍龙	he shi fu zhu cang long	1
+何时更杯酒	he shi geng bei jiu	1
+何事偏向别时圆	he shi pian xiang bie shi yuan	1
+何事入罗帏	he shi ru luo wei	1
+何时石门路	he shi shi men lu	1
+何时一杯酒	he shi yi bei jiu	1
+何时倚虚幌	he shi yi xu huang	1
+何事于仁	he shi yu ren	1
+何时照我还	he shi zhao wo hai	1
+河水龙门	he shui long men	1
+河水清且涟猗	he shui qing qie lian yi	1
+河水洋洋	he shui yang yang	1
+何思何虑则知道	he si he lv ze zhi dao	1
+何似人间	he si ren jian	1
+何斯违斯	he si wei si	1
+何所慰吾诚	he suo wei wu cheng	1
+何为不仁	he wei bu ren	1
+何谓宠辱若惊	he wei chong ru ruo jing	1
+何谓贵大患若身	he wei gui da huan ruo shen	1
+何为其然也	he wei qi ran ye	1
+何谓仁义	he wei ren yi	1
+何谓四恶	he wei si e	1
+何谓五美	he wei wu mei	1
+何为则民服	he wei ze min fu	1
+何谓真人	he wei zhen ren	1
+何惜醉流霞	he xi zui liu xia	1
+和岘	he xian	1
+贺新凉	he xin liang	1
+何须身后千载名	he xu shen hou qian zai ming	1
+何须生入玉门关	he xu sheng ru yu men guan	1
+何言复来还	he yan fu lai hai	1
+河阳诗	he yang shi	1
+和杨元素	he yang yuan su	1
+荷叶枯时秋恨成	he ye ku shi qiu hen cheng	1
+荷叶罗裙一色裁	he ye luo qun yi se cai	1
+荷叶生时春恨生	he ye sheng shi chun hen sheng	1
+何夜无月	he ye wu yue	1
+何以拜姑嫜	he yi bai gu zhang	1
+何以报仇	he yi bao chou	1
+何以报德	he yi bao de	1
+何以别乎	he yi bie hu	1
+何意出此言	he yi chu ci yan	1
+何以穿我屋	he yi chuan wo wu	1
+何以穿我墉	he yi chuan wo yong	1
+何以待之	he yi dai zhi	1
+何以伐为	he yi fa wei	1
+何以解忧思	he yi jie you si	1
+何以利吾国	he yi li wu guo	1
+何以利吾家	he yi li wu jia	1
+何以利吾身	he yi li wu shen	1
+何异飘飘托此身	he yi piao piao tuo ci shen	1
+和以天倪	he yi tian ni	1
+何以文为	he yi wen wei	1
+何以有羽翼	he yi you yu yi	1
+何以赠之	he yi zeng zhi	1
+何意致不厚	he yi zhi bu hou	1
+何因北归去	he yin bei gui qu	1
+何用别寻方外去	he yong bie xun fang wai qu	1
+何用不臧	he yong bu zang	1
+何用草书夸神速	he yong cao shu kua shen su	1
+何用浮名绊此身	he yong fu ming ban ci shen	1
+何用孤高比云月	he yong gu gao bi yun yue	1
+何由成名	he you cheng ming	1
+何有何亡	he you he wang	1
+何有于我哉	he you yu wo zai	1
+何由知吾可也	he you zhi wu ke ye	1
+和雨和烟两不胜	he yu he yan liang bu sheng	1
+合于桑林之舞	he yu sang lin zhi wu	1
+和云翥	he yun zhu	1
+何赞	he zan	1
+合葬华山傍	he zang hua shan bang	1
+合则成体	he ze cheng ti	1
+和之以天倪	he zhi yi tian ni	1
+曷至哉	he zhi zai	1
+贺知章	he zhi zhang	1
+和之至也	he zhi zhi ye	1
+何仲举	he zhong ju	1
+和周士钊同志	he zhou shi zhao tong zhi	1
+合从缔交	he zong di jiao	1
+何足怪乎	he zu guai hu	1
+曷足贵乎	he zu gui hu	1
+何足算也	he zu suan ye	1
+黑白太分明	hei bai tai fen ming	1
+黑漆弩	hei qi nu	1
+黑手高悬霸主鞭	hei shou gao xuan ba zhu bian	1
+恨不移封向酒泉	hen bu yi feng xiang jiu quan	1
+恨春宵	hen chun xiao	1
+恨分明	hen fen ming	1
+恨赋	hen fu	1
+恨恨那可论	hen hen na ke lun	1
+恨来迟	hen lai chi	1
+恨私心有所不尽	hen si xin you suo bu jin	1
+恨无知音赏	hen wu zhi yin shang	1
+横放杰出	heng fang jie chu	1
+横过幽林尚独游	heng guo you lin shang du you	1
+横空出世	heng kong chu shi	1
+横空盘硬语	heng kong pan ying yu	1
+衡门	heng men	1
+衡门之下	heng men zhi xia	1
+横槊赋诗	heng shuo fu shi	1
+横塘路	heng tang lu	1
+衡阳归雁几封书	heng yang gui yan ji feng shu	1
+横云	heng yun	1
+红窗迥	hong chuang jiong	1
+红窗听	hong chuang ting	1
+鸿飞冥冥日月白	hong fei ming ming ri yue bai	1
+鸿飞那复计东西	hong fei na fu ji dong xi	1
+红粉楼中应计日	hong fen lou zhong ying ji ri	1
+洪皓	hong hao	1
+薨薨兮	hong hong xi	1
+红荆	hong jing	1
+红军不怕远征难	hong jun bu pa yuan zheng nan	1
+红蜡泪	hong la lei	1
+红莲池里白莲开	hong lian chi li bai lian kai	1
+红莲落故衣	hong lian luo gu yi	1
+红楼隔雨相望冷	hong lou ge yu xiang wang leng	1
+红楼引	hong lou yin	1
+红罗复斗帐	hong luo fu dou zhang	1
+红罗帐里不胜情	hong luo zhang li bu sheng qing	1
+红罗著压逐时新	hong luo zhu ya zhu shi xin	1
+红梅不屈服	hong mei bu qu fu	1
+红泥小火炉	hong ni xiao huo lu	1
+红娘子	hong niang zi	1
+红旗卷起农奴戟	hong qi juan qi nong nu ji	1
+红旗漫卷西风	hong qi man juan xi feng	1
+红旗跃过汀江	hong qi yue guo ting jiang	1
+红情	hong qing	1
+红情绿意	hong qing lv yi	1
+红蕖何事亦离披	hong qu he shi yi li pi	1
+红裙妒杀石榴花	hong qun du sha shi liu hua	1
+訇然中开	hong ran zhong kai	1
+红入桃花嫩	hong ru tao hua nen	1
+红芍药	hong shao yao	1
+洪适	hong shi	1
+红树花迎晓露开	hong shu hua ying xiao lu kai	1
+洪水横流	hong shui heng liu	1
+红桃绿柳垂檐向	hong tao lv liu chui yan xiang	1
+红霞万朵百重衣	hong xia wan duo bai zhong yi	1
+红星乱紫烟	hong xing luan zi yan	1
+红颜白发云泥改	hong yan bai fa yun ni gai	1
+鸿雁不堪愁里听	hong yan bu kan chou li ting	1
+鸿雁几时到	hong yan ji shi dao	1
+鸿雁那从北地来	hong yan na cong bei di lai	1
+红颜弃轩冕	hong yan qi xuan mian	1
+红颜未相识	hong yan wei xiang shi	1
+鸿雁于飞	hong yan yu fei	1
+鸿雁之什	hong yan zhi shen	1
+红叶晚萧萧	hong ye wan xiao xiao	1
+红衣浅复深	hong yi qian fu shen	1
+红雨随心翻作浪	hong yu sui xin fan zuo lang	1
+红紫不以为亵服	hong zi bu yi wei xie fu	1
+宏兹九德	hong zi jiu de	1
+后悔遁而有他	hou hui dun er you ta	1
+后来鞍马何逡巡	hou lai an ma he qun xun	1
+侯冽	hou lie	1
+侯蒙	hou meng	1
+后身缘	hou shen yuan	1
+后生可畏	hou sheng ke wei	1
+后生可畏吾衰矣	hou sheng ke wei wu shuai yi	1
+后生可畏吾知子	hou sheng ke wei wu zhi zi	1
+后世必为子孙忧	hou shi bi wei zi sun you	1
+后庭花	hou ting hua	1
+后庭花破子	hou ting hua po zi	1
+后庭宴	hou ting yan	1
+侯王将相望久绝	hou wang jiang xiang wang jiu jue	1
+侯王若能守之	hou wang ruo neng shou zhi	1
+侯置	hou zhi	1
+后重前轻	hou zhong qian qing	1
+忽报人间曾伏虎	hu bao ren jian ceng fu hu	1
+忽奔走以先后兮	hu ben zou yi xian hou xi	1
+胡不遄死	hu bu chuan si	1
+胡曾	hu ceng	1
+胡传美	hu chuan mei	1
+忽到窗前疑是君	hu dao chuang qian yi shi jun	1
+忽到庞公栖隐处	hu dao pang gong qi yin chu	1
+胡德芳	hu de fang	1
+胡得焉	hu de yan	1
+蝴蝶儿	hu die er	1
+蝴蝶梦中飞	hu die meng zhong fei	1
+呼儿将出换美酒	hu er jiang chu huan mei jiu	1
+胡儿能唱琵琶篇	hu er neng chang pi pa pian	1
+胡儿十岁能骑马	hu er shi sui neng qi ma	1
+胡儿眼泪双双落	hu er yan lei shuang shuang luo	1
+胡玢	hu fen	1
+忽逢青鸟使	hu feng qing niao shi	1
+忽复隔淮海	hu fu ge huai hai	1
+胡杲	hu gao	1
+虎鼓瑟兮鸾回车	hu gu se xi luan hui che	1
+胡浩然	hu hao ran	1
+忽魂悸以魄动	hu hun ji yi po dong	1
+胡笳一声愁绝	hu jia yi sheng chou jue	1
+忽见寒梅树	hu jian han mei shu	1
+忽见陌头杨柳色	hu jian mo tou yang liu se	1
+忽见千帆隐映来	hu jian qian fan yin ying lai	1
+壶浆半成土	hu jiang ban cheng tu	1
+扈江离与辟芷兮	hu jiang li yu pi zhi xi	1
+虎距龙盘今胜昔	hu ju long pan jin sheng xi	1
+虎踞龙盘今胜昔	hu ju long pan jin sheng xi	1
+虎可搏	hu ke bo	1
+胡窥青海湾	hu kui qing hai wan	1
+胡令能	hu ling neng	1
+胡马大宛名	hu ma da wan ming	1
+胡能有定	hu neng you ding	1
+忽念山中客	hu nian shan zhong ke	1
+胡骑长驱五六年	hu qi chang qu wu liu nian	1
+胡骑凭陵杂风雨	hu qi ping ling za feng yu	1
+狐裘以朝	hu qiu yi chao	1
+胡取禾三百廛兮	hu qu he san bai chan xi	1
+忽然而已	hu ran er yi	1
+忽然更作渔阳掺	hu ran geng zuo yu yang chan	1
+忽然浪起	hu ran lang qi	1
+忽然一夜春风来	hu ran yi ye chun feng lai	1
+忽然遭时变	hu ran zao shi bian	1
+胡人落泪沾边草	hu ren luo lei zhan bian cao	1
+湖山信是东南美	hu shan xin shi dong nan mei	1
+湖上一回首	hu shang yi hui shou	1
+虎视何雄哉	hu shi he xiong zai	1
+胡世将	hu shi jiang	1
+虎兕出于柙	hu si chu yu xia	1
+胡松年	hu song nian	1
+胡宿	hu su	1
+壶天晓	hu tian xiao	1
+户庭无尘杂	hu ting wu chen za	1
+户外一峰秀	hu wai yi feng xiu	1
+胡为乎来哉	hu wei hu lai zai	1
+胡为乎泥中	hu wei hu ni zhong	1
+胡为乎中露	hu wei hu zhong lu	1
+胡为劳其生	hu wei lao qi sheng	1
+忽闻歌古调	hu wen ge gu diao	1
+忽闻河东狮子吼	hu wen he dong shi zi hou	1
+忽闻江上弄哀筝	hu wen jiang shang nong ai zheng	1
+胡文卿	hu wen qing	1
+胡无人	hu wu ren	1
+惚兮恍兮	hu xi huang xi	1
+胡雄	hu xiong	1
+胡旋女	hu xuan nv	1
+胡雁哀鸣夜夜飞	hu yan ai ming ye ye fei	1
+胡雁鸣	hu yan ming	1
+忽焉在后	hu yan zai hou	1
+胡翼龙	hu yi long	1
+胡于	hu yu	1
+湖月照我影	hu yue zhao wo ying	1
+扈载	hu zai	1
+胡仔	hu zai	1
+胡证	hu zheng	1
+壶中天	hu zhong tian	1
+胡州	hu zhou	1
+画地而趋	hua di er qu	1
+画栋朝飞南浦云	hua dong chao fei nan pu yun	1
+画娥眉	hua e mei	1
+化而为鸟	hua er wei niao	1
+化而欲作	hua er yu zuo	1
+花犯念奴	hua fan nian nu	1
+画阁朱楼尽相望	hua ge zhu lou jin xiang wang	1
+画工如山貌不同	hua gong ru shan mao bu tong	1
+花红柳绿宴浮桥	hua hong liu lv yan fu qiao	1
+花间意	hua jian yi	1
+画角声中	hua jiao sheng zhong	1
+画锦堂	hua jin tang	1
+花开花落几春风	hua kai hua luo ji chun feng	1
+花开花落人如旧	hua kai hua luo ren ru jiu	1
+花开堪折直须折	hua kai kan zhe zhi xu zhe	1
+画梁斜	hua liang xie	1
+画楼初满月	hua lou chu man yue	1
+花路入溪口	hua lu ru xi kou	1
+花落家童未扫	hua luo jia tong wei sao	1
+花满洛阳城	hua man luo yang cheng	1
+花蔓宜阳春	hua man yi yang chun	1
+花满自然秋	hua man zi ran qiu	1
+画眉深浅入时无	hua mei shen qian ru shi wu	1
+花明柳暗绕天愁	hua ming liu an rao tian chou	1
+花明月暗笼轻雾	hua ming yue an long qing wu	1
+花飘万家雪	hua piao wan jia xue	1
+花气薰人欲破禅	hua qi xun ren yu po chan	1
+花前失却游春侣	hua qian shi que you chun lv	1
+花前饮	hua qian yin	1
+花强妾貌强	hua qiang qie mao qiang	1
+华清宫	hua qing gong	1
+华清引	hua qing yin	1
+划然变轩昂	hua ran bian xuan ang	1
+花上月令	hua shang yue ling	1
+花深深	hua shen shen	1
+画松	hua song	1
+华亭鹤唳讵可闻	hua ting he li ju ke wen	1
+画图麒麟阁	hua tu qi lin ge	1
+画图省识春风面	hua tu sheng shi chun feng mian	1
+花褪残红青杏小	hua tui can hong qing xing xiao	1
+华佗无奈小虫何	hua tuo wu nai xiao chong he	1
+化为狼与豺	hua wei lang yu chai	1
+化为绕指柔	hua wei rao zhi rou	1
+花无百日开	hua wu bai ri kai	1
+花舞大唐春	hua wu da tang chun	1
+花溪碧	hua xi bi	1
+华夏文明	hua xia wen ming	1
+花下醉	hua xia zui	1
+花相容	hua xiang rong	1
+花心愁欲断	hua xin chou yu duan	1
+花心动	hua xin dong	1
+花须连夜发	hua xu lian ye fa	1
+华胥引	hua xu yin	1
+花隐掖垣暮	hua yin ye yuan mu	1
+花迎剑佩星初落	hua ying jian pei xing chu luo	1
+化育万物	hua yu wan wu	1
+花月正春风	hua yue zheng chun feng	1
+花枝欲动春风寒	hua zhi yu dong chun feng han	1
+花自落	hua zi luo	1
+化作啼鹃带血归	hua zuo ti juan dai xue gui	1
+坏壁无由见旧题	huai bi wu you jian jiu ti	1
+怀楚	huai chu	1
+怀古钦英风	huai gu qin ying feng	1
+怀归人自急	huai gui ren zi ji	1
+怀归伤暮秋	huai gui shang mu qiu	1
+怀旧游	huai jiu you	1
+怀君属秋夜	huai jun shu qiu ye	1
+怀民亦未寝	huai min yi wei qin	1
+淮南木落楚山多	huai nan mu luo chu shan duo	1
+淮南一叶下	huai nan yi ye xia	1
+淮上对秋山	huai shang dui qiu shan	1
+淮上女	huai shang nv	1
+淮阴市井笑韩信	huai yin shi jing xiao han xin	1
+患不知人也	huan bu zhi ren ye	1
+换巢鸾凤	huan chao luan feng	1
+环而攻之而不胜	huan er gong zhi er bu sheng	1
+桓公方读书	huan gong fang du shu	1
+桓公杀公子纠	huan gong sha gong zi jiu	1
+还家草露晞	huan jia cao lu xi	1
+还家少欢趣	huan jia shao huan qu	1
+换了人间	huan le ren jian	1
+环佩空归月下魂	huan pei kong gui yue xia hun	1
+环佩空归月夜魂	huan pei kong gui yue ye hun	1
+患其不能也	huan qi bu neng ye	1
+唤起工农千百万	huan qi gong nong qian bai wan	1
+患其无用	huan qi wu yong	1
+环球同此凉热	huan qiu tong ci liang re	1
+浣纱明月下	huan sha ming yue xia	1
+浣沙溪	huan sha xi	1
+患所以立	huan suo yi li	1
+还我河山	huan wo he shan	1
+幻想和现实	huan xiang he xian shi	1
+欢笑情如旧	huan xiao qing ru jiu	1
+欢言得所憩	huan yan de suo qi	1
+幻者衫来作主人	huan zhe shan lai zuo zhu ren	1
+欢醉中	huan zui zhong	1
+黄尘足今古	huang chen zu jin gu	1
+荒城古道	huang cheng gu dao	1
+荒城临古渡	huang cheng lin gu du	1
+黄诚之	huang cheng zhi	1
+黄崇嘏	huang chong gu	1
+黄帝得之	huang di de zhi	1
+黄幡绰	huang fan chuo	1
+皇甫曾	huang fu ceng	1
+皇甫冉	huang fu ran	1
+黄夫人	huang fu ren	1
+皇甫松	huang fu song	1
+黄格	huang ge	1
+黄革	huang ge	1
+黄公度	huang gong du	1
+黄鹤高楼已捶碎	huang he gao lou yi chui sui	1
+黄鹤楼前春水阔	huang he lou qian chun shui kuo	1
+黄鹤楼中吹玉笛	huang he lou zhong chui yu di	1
+黄河落天走东海	huang he luo tian zou dong hai	1
+黄河如丝天际来	huang he ru si tian ji lai	1
+黄河西来决昆仑	huang he xi lai jue kun lun	1
+黄鹤之飞尚不得	huang he zhi fei shang bu de	1
+黄鹤知何去	huang he zhi he qu	1
+黄河之水天上来	huang he zhi shui tian shang lai	1
+黄花寒后难逢蝶	huang hua han hou nan feng die	1
+皇皇三十载	huang huang san shi zai	1
+煌煌太宗业	huang huang tai zong ye	1
+皇皇者华	huang huang zhe hua	1
+黄昏到寺蝙蝠飞	huang hun dao si bian fu fei	1
+黄昏独上海风秋	huang hun du shang hai feng qiu	1
+黄昏独倚阑	huang hun du yi lan	1
+黄昏胡骑尘满城	huang hun hu qi chen man cheng	1
+黄昏饮马傍交河	huang hun yin ma bang jiao he	1
+黄机	huang ji	1
+黄金白璧买歌笑	huang jin bai bi mai ge xiao	1
+黄金缕	huang jin lv	1
+黄金燃桂尽	huang jin ran gui jin	1
+黄金锁子甲	huang jin suo zi jia	1
+恍惊起而长嗟	huang jing qi er chang jie	1
+黄静淑	huang jing shu	1
+荒居旧业贫	huang ju jiu ye pin	1
+黄麟	huang lin	1
+黄鸟黄鸟	huang niao huang niao	1
+黄鸟鸣园柳	huang niao ming yuan liu	1
+黄鸟时兼白鸟飞	huang niao shi jian bai niao fei	1
+黄鸟于飞	huang niao yu fei	1
+黄颇	huang po	1
+黄泉共为友	huang quan gong wei you	1
+黄泉下相见	huang quan xia xiang jian	1
+黄人杰	huang ren jie	1
+黄仁荣	huang ren rong	1
+黄山旧绕汉宫斜	huang shan jiu rao han gong xie	1
+黄裳元吉	huang shang yuan ji	1
+黄时龙	huang shi long	1
+黄师塔前江水东	huang shi ta qian jiang shui dong	1
+荒戍落黄叶	huang shu luo huang ye	1
+黄水村	huang shui cun	1
+黄舜英	huang shun ying	1
+黄损	huang sun	1
+黄谈	huang tan	1
+黄滔	huang tao	1
+皇天后土	huang tian hou tu	1
+皇天无老眼	huang tian wu lao yan	1
+黄庭坚	huang ting jian	1
+黄童	huang tong	1
+黄童白叟	huang tong bai sou	1
+黄洋界上	huang yang jie shang	1
+黄洋界上炮声隆	huang yang jie shang pao sheng long	1
+黄叶仍风雨	huang ye reng feng yu	1
+黄衣狐裘	huang yi hu qiu	1
+黄莺久住浑相识	huang ying jiu zhu hun xiang shi	1
+黄应武	huang ying wu	1
+黄云陇底白雪飞	huang yun long di bai xue fei	1
+黄云万里动风色	huang yun wan li dong feng se	1
+黄云萧条白日暗	huang yun xiao tiao bai ri an	1
+黄宰	huang zai	1
+黄载	huang zai	1
+黄钟乐	huang zhong le	1
+黄州寒食诗帖	huang zhou han shi shi tie	1
+黄州快哉亭记	huang zhou kuai zai ting ji	1
+黄铢	huang zhu	1
+黄铸	huang zhu	1
+黄竹歌声动地哀	huang zhu ge sheng dong di ai	1
+黄子行	huang zi xing	1
+晦庵	hui an	1
+嘒彼小星	hui bi xiao xing	1
+挥鞭且就胡姬饮	hui bian qie jiu hu ji yin	1
+回飙经画壁	hui biao jing hua bi	1
+回波词	hui bo ci	1
+回波乐	hui bo le	1
+会昌城外高峰	hui chang cheng wai gao feng	1
+挥斥八极	hui chi ba ji	1
+惠崇烟雨归雁	hui chong yan yu gui yan	1
+回到天上去	hui dao tian shang qu	1
+惠而好我	hui er hao wo	1
+蟪蛄不知春秋	hui gu bu zhi chun qiu	1
+挥毫落纸如云烟	hui hao luo zhi ru yun yan	1
+惠洪	hui hong	1
+虺虺其雷	hui hui qi lei	1
+慧寂	hui ji	1
+悔教夫婿觅封侯	hui jiao fu xu mi feng hou	1
+回看天际下中流	hui kan tian ji xia zhong liu	1
+会哭皆豪杰	hui ku jie hao jie	1
+回廊四合掩寂寞	hui lang si he yan ji mo	1
+回乐峰前沙似雪	hui le feng qian sha si xue	1
+会盟而谋弱秦	hui meng er mou ruo qin	1
+回梦旧鸳机	hui meng jiu yuan ji	1
+卉木萋萋	hui mu qi qi	1
+惠然肯来	hui ran ken lai	1
+回日楼台非甲帐	hui ri lou tai fei jia zhang	1
+诲汝知之乎	hui ru zhi zhi hu	1
+挥手从兹去	hui shou cong zi qu	1
+回首恨依依	hui shou hen yi yi	1
+挥手泪沾巾	hui shou lei zhan jin	1
+回首乱山横	hui shou luan shan heng	1
+回首彭城	hui shou peng cheng	1
+回首自纤纤	hui shou zi xian xian	1
+回虽不敏	hui sui bu min	1
+回头语小姑	hui tou yu xiao gu	1
+回望高城落晓河	hui wang gao cheng luo xiao he	1
+会向瑶台月下逢	hui xiang yao tai yue xia feng	1
+回心院	hui xin yuan	1
+会须一饮三百杯	hui xu yi yin san bai bei	1
+慧宣	hui xuan	1
+回崖沓障凌苍苍	hui ya ta zhang ling cang cang	1
+回也不改其乐	hui ye bu gai qi le	1
+回也不愚	hui ye bu yu	1
+回也其庶乎	hui ye qi shu hu	1
+会遭此祸	hui zao ci huo	1
+惠则足以使人	hui ze zu yi shi ren	1
+晦之	hui zhi	1
+讳之	hui zhi	1
+回舟不待月	hui zhou bu dai yue	1
+惠子吊之	hui zi diao zhi	1
+惠子相梁	hui zi xiang liang	1
+悔作商人妇	hui zuo shang ren fu	1
+魂返关塞黑	hun fan guan sai hei	1
+昏昏灯火话平生	hun hun deng huo hua ping sheng	1
+浑浑沌沌	hun hun dun dun	1
+混江龙	hun jiang long	1
+魂来枫林青	hun lai feng lin qing	1
+魂梦任悠扬	hun meng ren you yang	1
+魂去尸长留	hun qu shi chang liu	1
+魂随南翥鸟	hun sui nan zhu niao	1
+浑脱	hun tuo	1
+昏以为期	hun yi wei qi	1
+或百步而后止	huo bai bu er hou zhi	1
+或承之羞	huo cheng zhi xiu	1
+或从十五北防河	huo cong shi wu bei fang he	1
+惑而不从师	huo er bu cong shi	1
+祸福相生	huo fu xiang sheng	1
+或告之曰	huo gao zhi yue	1
+火聚开莲花	huo ju kai lian hua	1
+或恐是同乡	huo kong shi tong xiang	1
+或凭几学书	huo ping ji xue shu	1
+或强或羸	huo qiang huo lei	1
+或去或不去	huo qu huo bu qu	1
+霍如羿射九日落	huo ru yi she jiu ri luo	1
+火山五月行人少	huo shan wu yue xing ren shao	1
+火尚足以明也	huo shang zu yi ming ye	1
+火树银花合	huo shu yin hua he	1
+火维地荒足妖怪	huo wei di huang zu yao guai	1
+或谓惠子曰	huo wei hui zi yue	1
+或谓孔子曰	huo wei kong zi yue	1
+或问之曰	huo wen zhi yue	1
+或问子产	huo wen zi chan	1
+或五十步而后止	huo wu shi bu er hou zhi	1
+或笑邓艾吃	huo xiao deng ai chi	1
+或益之而损	huo yi zhi er sun	1
+或在于渚	huo zai yu zhu	1
+惑之不解	huo zhi bu jie	1
+霍总	huo zong	1
+获罪于天	huo zui yu tian	1
+激昂丹墀下	ji ang dan chi xia	1
+基本传统	ji ben chuan tong	1
+既辨	ji bian	1
+羁泊欲穷年	ji bo yu qiong nian	1
+骥不称其力	ji bu cheng qi li	1
+既不能令	ji bu neng ling	1
+季布无二诺	ji bu wu er nuo	1
+记承天寺夜游	ji cheng tian si ye you	1
+几处吹笳明月夜	ji chu chui jia ming yue ye	1
+鸡初鸣	ji chu ming	1
+即此羡闲逸	ji ci xian xian yi	1
+记得当年草上飞	ji de dang nian cao shang fei	1
+既得其母	ji de qi mu	1
+积德为厚地	ji de wei hou di	1
+既雕既琢	ji diao ji zhuo	1
+季冬除夜接新年	ji dong chu ye jie xin nian	1
+鸡斗始开笼	ji dou shi kai long	1
+几度隔山川	ji du ge shan chuan	1
+几度木兰舟上望	ji du mu lan zhou shang wang	1
+几度斜晖	ji du xie hui	1
+及尔颠覆	ji er dian fu	1
+及尔同死	ji er tong si	1
+及尔偕老	ji er xie lao	1
+肌肤若冰雪	ji fu ruo bing xue	1
+寄蜉蝣于天地	ji fu you yu tian di	1
+技盖至此乎	ji gai zhi ci hu	1
+击鼓吹箫	ji gu chui xiao	1
+机关用尽不如君	ji guan yong jin bu ru jun	1
+殛鲧於羽山	ji gun yu yu shan	1
+寄韩谏议	ji han jian yi	1
+既寒亦既清	ji han yi ji qing	1
+几行陈迹	ji hang chen ji	1
+几行归塞尽	ji hang gui sai jin	1
+寄贺方回	ji he fang hui	1
+芰荷香	ji he xiang	1
+籍何以至此	ji he yi zhi ci	1
+季桓子受之	ji huan zi shou zhi	1
+寄黄几复	ji huang ji fu	1
+几回梦里忆红颜	ji hui meng li yi hong yan	1
+积毁销金	ji hui xiao jin	1
+寂寂花时闭院门	ji ji hua shi bi yuan men	1
+饥籍家家米	ji ji jia jia mi	1
+寂寂江山摇落处	ji ji jiang shan yao luo chu	1
+寂寂竟何待	ji ji jing he dai	1
+寂寂寥寥扬子居	ji ji liao liao yang zi ju	1
+鸡既鸣矣	ji ji ming yi	1
+寂寂人定初	ji ji ren ding chu	1
+寂寂闻猿愁	ji ji wen yuan chou	1
+急击勿失	ji ji wu shi	1
+几家能彀	ji jia neng gou	1
+既见复关	ji jian fu guan	1
+既见君子	ji jian jun zi	1
+技兼于事	ji jian yu shi	1
+鸡叫子	ji jiao zi	1
+既竭吾才	ji jie wu cai	1
+几尽而去	ji jin er qu	1
+即今河畔冰开日	ji jin he pan bing kai ri	1
+技经肯綮之未尝	ji jing ken qing zhi wei chang	1
+汲井漱寒齿	ji jing shu han chi	1
+鸡聚族以争食	ji ju zu yi zheng shi	1
+季康子问	ji kang zi wen	1
+饥渴寒暑	ji ke han shu	1
+击空明兮泝流光	ji kong ming xi su liu guang	1
+疾雷破山	ji lei po shan	1
+寄李儋元锡	ji li dan yuan xi	1
+肌理细腻骨肉匀	ji li xi ni gu rou yun	1
+寄令狐郎中	ji ling hu lang zhong	1
+迹留伤堕屦	ji liu shang duo ju	1
+季路问事鬼神	ji lu wen shi gui shen	1
+羁旅长堪醉	ji lv chang kan zui	1
+吉梦维何	ji meng wei he	1
+鸡鸣不已	ji ming bu yi	1
+鸡鸣胶胶	ji ming jiao jiao	1
+鸡鸣喈喈	ji ming jie jie	1
+鸡鸣入机织	ji ming ru ji zhi	1
+鸡鸣桑树颠	ji ming sang shu dian	1
+鸡鸣外欲曙	ji ming wai yu shu	1
+鸡鸣紫陌曙光寒	ji ming zi mo shu guang han	1
+寂寞嫦娥舒广袖	ji mo chang e shu guang xiu	1
+寂寞开最晚	ji mo kai zui wan	1
+寂寞空庭春欲晚	ji mo kong ting chun yu wan	1
+寂寞山城人老也	ji mo shan cheng ren lao ye	1
+寂寞身后事	ji mo shen hou shi	1
+寂寞使人愁	ji mo shi ren chou	1
+寂寞天宝后	ji mo tian bao hou	1
+寂寞心自知	ji mo xin zi zhi	1
+寂寞掩柴扉	ji mo yan chai fei	1
+寂寞养残生	ji mo yang can sheng	1
+极目楚天舒	ji mu chu tian shu	1
+极目萧条三两家	ji mu xiao tiao san liang jia	1
+济南名士多	ji nan ming shi duo	1
+及其更也	ji qi geng ye	1
+及其老也	ji qi lao ye	1
+及其使人也	ji qi shi ren ye	1
+及其有事	ji qi you shi	1
+鸡栖于桀	ji qi yu jie	1
+鸡栖于埘	ji qi yu shi	1
+鸡栖于厅	ji qi yu ting	1
+及其壮也	ji qi zhuang ye	1
+即遣花开深造次	ji qian hua kai shen zao ci	1
+几千里	ji qian li	1
+及前王之踵武	ji qian wang zhi zhong wu	1
+寄全椒山中道士	ji quan jiao shan zhong dao shi	1
+鸡犬声相闻	ji quan sheng xiang wen	1
+几日到临洮	ji ri dao lin tao	1
+积善成德	ji shan cheng de	1
+寄上浮梁大兄	ji shang fu liang da xiong	1
+寄身且喜沧洲近	ji shen qie xi cang zhou jin	1
+极深研几	ji shen yan ji	1
+几声抽泣	ji sheng chou qi	1
+既生既育	ji sheng ji yu	1
+几声凄厉	ji sheng qi li	1
+几时杯重把	ji shi bei zhong ba	1
+季氏第十六	ji shi di shi liu	1
+季氏富于周公	ji shi fu yu zhou gong	1
+几时回	ji shi hui	1
+几世几年	ji shi ji nian	1
+季氏将伐颛臾	ji shi jiang fa zhuan yu	1
+季氏旅于泰山	ji shi lv yu tai shan	1
+祭石曼卿文	ji shi man qing wen	1
+济世岂邀名	ji shi qi yao ming	1
+吉事尚左	ji shi shang zuo	1
+及时相遣归	ji shi xiang qian gui	1
+嵇氏幼男犹可悯	ji shi you nan you ke min	1
+吉士诱之	ji shi you zhi	1
+寄书长不达	ji shu chang bu da	1
+几树惊秋	ji shu jing qiu	1
+积水成渊	ji shui cheng yuan	1
+积水得反壑	ji shui de fan he	1
+饥思河鲤与河鲂	ji si he li yu he fang	1
+纪叟黄泉里	ji sou huang quan li	1
+极天关塞云中	ji tian guan sai yun zhong	1
+祭天神	ji tian shen	1
+积土成山	ji tu cheng shan	1
+洎外供奉	ji wai gong feng	1
+既往不咎	ji wang bu jiu	1
+既往不可追	ji wang bu ke zhui	1
+积威约之渐也	ji wei yue zhi jian ye	1
+寄卧郊扉久	ji wo jiao fei jiu	1
+既无叔伯	ji wu shu bai	1
+寂兮寥兮	ji xi liao xi	1
+集贤宾	ji xian bin	1
+既相逢	ji xiang feng	1
+极相思	ji xiang si	1
+吉祥止止	ji xiang zhi zhi	1
+棘心夭夭	ji xin yao yao	1
+寄兄弟	ji xiong di	1
+积雪浮云端	ji xue fu yun duan	1
+急雪舞回风	ji xue wu hui feng	1
+寄雁传书谢不能	ji yan chuan shu xie bu neng	1
+寄言全盛红颜子	ji yan quan sheng hong yan zi	1
+激扬文字	ji yang wen zi	1
+寄扬州韩绰判官	ji yang zhou han chuo pan guan	1
+际夜转西壑	ji ye zhuan xi he	1
+既已为一矣	ji yi wei yi yi	1
+既诒我肄	ji yi wo yi	1
+及以至是	ji yi zhi shi	1
+寄友人	ji you ren	1
+己欲达而达人	ji yu da er da ren	1
+迹与孤云远	ji yu gu yun yuan	1
+集于灌木	ji yu guan mu	1
+系于教育	ji yu jiao yu	1
+积雨空林烟火迟	ji yu kong lin yan huo chi	1
+寄与陇头人	ji yu long tou ren	1
+寄语洛城风日道	ji yu luo cheng feng ri dao	1
+既欲其生	ji yu qi sheng	1
+积雨辋川庄作	ji yu wang chuan zhuang zuo	1
+急于星火	ji yu xing huo	1
+寄远人	ji yuan ren	1
+期月而已可也	ji yue er yi ke ye	1
+霁月光风	ji yue guang feng	1
+饥者易为食	ji zhe yi wei shi	1
+既至金门远	ji zhi jin men yuan	1
+及至始皇	ji zhi shi huang	1
+即之也温	ji zhi ye wen	1
+祭之以礼	ji zhi yi li	1
+吉中孚	ji zhong fu	1
+机中锦字论长恨	ji zhong jin zi lun chang hen	1
+机中织锦秦川女	ji zhong zhi jin qin chuan nv	1
+寄诸弟	ji zhu di	1
+击筑饮美酒	ji zhu yin mei jiu	1
+计拙是和亲	ji zhuo shi he qin	1
+棘子成曰	ji zi cheng yue	1
+及兹契幽绝	ji zi qi you jue	1
+既阻我德	ji zu wo de	1
+及罪至罔加	ji zui zhi wang jia	1
+既遵道而得路	ji zun dao er de lu	1
+寄左省杜拾遗	ji zuo sheng du shi yi	1
+驾彼四牡	jia bi si mu	1
+家必自毁	jia bi zi hui	1
+嘉宾复满堂	jia bin fu man tang	1
+贾曾	jia ceng	1
+贾昌朝	jia chang chao	1
+贾驰	jia chi	1
+贾岛	jia dao	1
+嫁得瞿塘贾	jia de qu tang jia	1
+甲第连青山	jia di lian qing shan	1
+驾鸿凌紫冥	jia hong ling zi ming	1
+家家春鸟鸣	jia jia chun niao ming	1
+嘉节迫吹帽	jia jie po chui mao	1
+佳节清明桃李笑	jia jie qing ming tao li xiao	1
+佳境千万曲	jia jing qian wan qu	1
+贾棱	jia leng	1
+架梁之椽	jia liang zhi chuan	1
+家临九江水	jia lin jiu jiang shui	1
+假令风歇时下来	jia ling feng xie shi xia lai	1
+嘉陵水	jia ling shui	1
+佳气满山川	jia qi man shan chuan	1
+佳人彩云里	jia ren cai yun li	1
+佳人一壶酒	jia ren yi hu jiu	1
+佳人醉	jia ren zui	1
+佳色	jia se	1
+嘉善而矜不能	jia shan er jin bu neng	1
+家山好	jia shan hao	1
+贾少卿	jia shao qing	1
+贾生才调更无伦	jia sheng cai tiao geng wu lun	1
+贾生年少虚垂泪	jia sheng nian shao xu chui lei	1
+佳时倍惜风光别	jia shi bei xi feng guang bie	1
+贾氏窥帘韩掾少	jia shi kui lian han yuan shao	1
+家书到隔年	jia shu dao ge nian	1
+家童鼻息已雷鸣	jia tong bi xi yi lei ming	1
+家徒四壁书侵坐	jia tu si bi shu qin zuo	1
+加我林壑清	jia wo lin he qing	1
+加我数年	jia wo shu nian	1
+驾言出游	jia yan chu you	1
+贾奕	jia yi	1
+加以订正	jia yi ding zheng	1
+贾谊上书忧汉室	jia yi shang shu you han shi	1
+驾一叶之扁舟	jia yi ye zhi pian zhou	1
+贾应	jia ying	1
+嘉佑进士	jia you jin shi	1
+家有老妪	jia you lao yu	1
+假舆马者	jia yu ma zhe	1
+嫁与弄潮儿	jia yu nong chao er	1
+家在梦中何日到	jia zai meng zhong he ri dao	1
+家在西南	jia zai xi nan	1
+贾至	jia zhi	1
+家之本在身	jia zhi ben zai shen	1
+加彘肩上	jia zhi jian shang	1
+加之以师旅	jia zhi yi shi lv	1
+假舟楫者	jia zhou ji zhe	1
+家住层城邻汉苑	jia zhu ceng cheng lin han yuan	1
+家住水东西	jia zhu shui dong xi	1
+贾宗	jia zong	1
+兼爱无私	jian ai wu si	1
+坚闭门而不出	jian bi men er bu chu	1
+饯别王十一南游	jian bie wang shi yi nan you	1
+坚冰一时合	jian bing yi shi he	1
+见不善如探汤	jian bu shan ru tan tang	1
+渐车帷裳	jian che wei shang	1
+坚持原则	jian chi yuan ze	1
+见此良人	jian ci liang ren	1
+建此伟业	jian ci wei ye	1
+见此邂逅	jian ci xie hou	1
+剪刀声	jian dao sheng	1
+建德非吾土	jian de fei wu tu	1
+建德若偷	jian de ruo tou	1
+涧底束荆薪	jian di shu jing xin	1
+涧底松	jian di song	1
+见尔当何秋	jian er dang he qiu	1
+剑非万人敌	jian fei wan ren di	1
+剑歌易水湄	jian ge yi shui mei	1
+剑阁峥嵘而崔嵬	jian ge zheng rong er cui wei	1
+剑河风急雪片阔	jian he feng ji xue pian kuo	1
+涧户寂无人	jian hu ji wu ren	1
+见几而作	jian ji er zuo	1
+简洁优美	jian jie you mei	1
+坚决抵抗	jian jue di kang	1
+渐觉伤春暮	jian jue shang chun mu	1
+见君绸缪思	jian jun chou mou si	1
+见君难	jian jun nan	1
+见君前日书	jian jun qian ri shu	1
+见客棹歌回	jian ke zhao ge hui	1
+见空髑髅	jian kong du lou	1
+艰苦斗争	jian ku dou zheng	1
+减兰	jian lan	1
+渐老逢春能几回	jian lao feng chun neng ji hui	1
+煎泪几千行	jian lei ji qian xing	1
+见利思义	jian li si yi	1
+见龙门	jian long men	1
+减米散同舟	jian mi san tong zhou	1
+见冕者与瞽者	jian mian zhe yu gu zhe	1
+剪牡丹	jian mu dan	1
+简能而任之	jian neng er ren zhi	1
+见牛未见羊也	jian niu wei jian yang ye	1
+见其二子焉	jian qi er zi yan	1
+剑气近	jian qi jin	1
+剑气射云天	jian qi she yun tian	1
+见齐衰者	jian qi shuai zhe	1
+贱日岂殊众	jian ri qi shu zhong	1
+健如黄犊走复来	jian ru huang du zou fu lai	1
+见身外身	jian shen wai shen	1
+见时少	jian shi shao	1
+检书烧烛短	jian shu shao zhu duan	1
+涧水东流复向西	jian shui dong liu fu xiang xi	1
+见说蚕丛路	jian shuo can cong lu	1
+见说风流极	jian shuo feng liu ji	1
+谏太宗十思疏	jian tai zong shi si shu	1
+鉴堂	jian tang	1
+剑外从军远	jian wai cong jun yuan	1
+见危授命	jian wei shou ming	1
+歼我良人	jian wo liang ren	1
+简兮	jian xi	1
+简兮简兮	jian xi jian xi	1
+见小曰明	jian xiao yue ming	1
+拣选撰刻留山阿	jian xuan zhuan ke liu shan e	1
+建业暮钟时	jian ye mu zhong shi	1
+见已读书	jian yi du shu	1
+鉴亦有光	jian yi you guang	1
+见与儿童邻	jian yu er tong lin	1
+渐与骨肉远	jian yu gu rou yuan	1
+剪朝霞	jian zhao xia	1
+见志不从	jian zhi bu cong	1
+间至军中	jian zhi jun zhong	1
+肩之所倚	jian zhi suo yi	1
+剪纸招我魂	jian zhi zhao wo hun	1
+见竹不见人	jian zhu bu jian ren	1
+减字浣溪沙	jian zi huan xi sha	1
+见子夏曰	jian zi xia yue	1
+将安将乐	jiang an jiang le	1
+将翱将翔	jiang ao jiang xiang	1
+江北江南水拍天	jiang bei jiang nan shui pai tian	1
+江北秋阴一半开	jiang bei qiu yin yi ban kai	1
+江碧鸟逾白	jiang bi niao yu bai	1
+江边柳	jiang bian liu	1
+江边一树垂垂发	jiang bian yi shu chui chui fa	1
+江表传	jiang biao chuan	1
+匠伯不顾	jiang bo bu gu	1
+江采萍	jiang cai ping	1
+蒋璨	jiang can	1
+江草江花处处鲜	jiang cao jiang hua chu chu xian	1
+江城白酒三杯酽	jiang cheng bai jiu san bei yan	1
+江城梅花引	jiang cheng mei hua yin	1
+江城如画里	jiang cheng ru hua li	1
+江城五月落梅花	jiang cheng wu yue luo mei hua	1
+将船买酒白云边	jiang chuan mai jiu bai yun bian	1
+绛唇珠袖两寂寞	jiang chun zhu xiu liang ji mo	1
+江村八九家	jiang cun ba jiu jia	1
+将村独归处	jiang cun du gui chu	1
+江村月落正堪眠	jiang cun yue luo zheng kan mian	1
+江东日暮云	jiang dong ri mu yun	1
+江东子弟今虽在	jiang dong zi di jin sui zai	1
+绛都春	jiang dou chun	1
+江儿水	jiang er shui	1
+江妃	jiang fei	1
+江风引雨入舟凉	jiang feng yin yu ru zhou liang	1
+蒋桂战争	jiang gui zhan zheng	1
+江国逾千里	jiang guo yu qian li	1
+江海翻波浪	jiang hai fan bo lang	1
+江汉曾为客	jiang han ceng wei ke	1
+江汉春风起	jiang han chun feng qi	1
+江汉江汉思归客	jiang han jiang han si gui ke	1
+江涵秋影雁初飞	jiang han qiu ying yan chu fei	1
+江汉西来	jiang han xi lai	1
+江河横溢	jiang he heng yi	1
+江湖多风波	jiang hu duo feng bo	1
+江湖秋水多	jiang hu qiu shui duo	1
+江湖夜雨十年灯	jiang hu ye yu shi nian deng	1
+江淮度寒食	jiang huai du han shi	1
+蒋涣	jiang huan	1
+江火似流萤	jiang huo si liu ying	1
+蒋吉	jiang ji	1
+将家就鱼麦	jiang jia jiu yu mai	1
+姜皎	jiang jiao	1
+江静潮初落	jiang jing chao chu luo	1
+将军得名三十载	jiang jun de ming san shi zai	1
+将军画善盖有神	jiang jun hua shan gai you shen	1
+将军兼领霍嫖姚	jiang jun jian ling huo piao yao	1
+将军猎渭城	jiang jun lie wei cheng	1
+将军楼阁画神仙	jiang jun lou ge hua shen xian	1
+将军魏武之子孙	jiang jun wei wu zhi zi sun	1
+将军下笔开生面	jiang jun xia bi kai sheng mian	1
+将军欲以巧伏人	jiang jun yu yi qiao fu ren	1
+将军战河北	jiang jun zhan he bei	1
+江开	jiang kai	1
+将老身反累	jiang lao shen fan lei	1
+蒋冽	jiang lie	1
+江岭作流人	jiang ling zuo liu ren	1
+江柳共风烟	jiang liu gong feng yan	1
+江流曲似九回肠	jiang liu qu si jiu hui chang	1
+江流石不转	jiang liu shi bu zhuan	1
+江路野梅香	jiang lu ye mei xiang	1
+江袤	jiang mao	1
+江梅引	jiang mei yin	1
+将命者出户	jiang ming zhe chu hu	1
+将奈之何	jiang nai zhi he	1
+江南春绝句	jiang nan chun jue ju	1
+江南怀古	jiang nan huai gu	1
+江南佳丽地	jiang nan jia li di	1
+江南江北旧家乡	jiang nan jiang bei jiu jia xiang	1
+江南江北青山多	jiang nan jiang bei qing shan duo	1
+江南江北送君归	jiang nan jiang bei song jun gui	1
+江南柳	jiang nan liu	1
+江南渌水多	jiang nan lu shui duo	1
+江南孟夏天	jiang nan meng xia tian	1
+江南弄	jiang nan nong	1
+江南有丹橘	jiang nan you dan ju	1
+江南瘴疠地	jiang nan zhang li di	1
+姜女庙	jiang nv miao	1
+江畔洲如月	jiang pan zhou ru yue	1
+江如练	jiang ru lian	1
+江山此夜寒	jiang shan ci ye han	1
+江山故宅空文藻	jiang shan gu zhai kong wen zao	1
+江山留胜迹	jiang shan liu sheng ji	1
+江山如此多娇	jiang shan ru ci duo jiao	1
+江山如有待	jiang shan ru you dai	1
+江山犹是昔人非	jiang shan you shi xi ren fei	1
+江上几人在	jiang shang ji ren zai	1
+江上流莺独坐听	jiang shang liu ying du zuo ting	1
+江上小堂巢翡翠	jiang shang xiao tang chao fei cui	1
+江上行	jiang shang xing	1
+江上雪	jiang shang xue	1
+江上吟	jiang shang yin	1
+江上月明胡雁过	jiang shang yue ming hu yan guo	1
+江上值水如海势	jiang shang zhi shui ru hai shi	1
+江神子	jiang shen zi	1
+江声夜听潮	jiang sheng ye ting chao	1
+匠石之齐	jiang shi zhi qi	1
+将数百之众	jiang shu bai zhi zhong	1
+江树远含情	jiang shu yuan han qing	1
+江水江花岂终极	jiang shui jiang hua qi zhong ji	1
+江水绿如蓝	jiang shui lv ru lan	1
+江水三峡	jiang shui san xia	1
+江水为竭	jiang shui wei jie	1
+姜特立	jiang te li	1
+江天水一泓	jiang tian shui yi hong	1
+蒋挺	jiang ting	1
+江头宫殿锁千门	jiang tou gong dian suo qian men	1
+江万里	jiang wan li	1
+将往复旋如有情	jiang wang fu xuan ru you qing	1
+江为	jiang wei	1
+江纬	jiang wei	1
+江无	jiang wu	1
+姜晞	jiang xi	1
+江夏行	jiang xia xing	1
+将心托明月	jiang xin tuo ming yue	1
+蒋兴祖女	jiang xing zu nv	1
+江衍	jiang yan	1
+将以反说约也	jiang yi fan shuo yue ye	1
+将以愚之	jiang yi yu zhi	1
+将因卧病解朝衣	jiang yin wo bing jie chao yi	1
+江有汜	jiang you si	1
+将欲辞君挂帆去	jiang yu ci jun gua fan qu	1
+将欲废之	jiang yu fei zhi	1
+将欲歙之	jiang yu she zhi	1
+江月令	jiang yue ling	1
+江月去人只数尺	jiang yue qu ren zhi shu chi	1
+江云欲变霞	jiang yun yu bian xia	1
+将炙啖朱亥	jiang zhi dan zhu hai	1
+降志辱身矣	jiang zhi ru shen yi	1
+江之永矣	jiang zhi yong yi	1
+将仲子兮	jiang zhong zi xi	1
+将子无怒	jiang zi wu nu	1
+蒋子云	jiang zi yun	1
+教吹箫	jiao chui xiao	1
+搅得周天寒彻	jiao de zhou tian han che	1
+教儿且覆掌中杯	jiao er qie fu zhang zhong bei	1
+骄儿诗	jiao er shi	1
+教诲之人	jiao hui zhi ren	1
+皎皎白驹	jiao jiao bai ju	1
+皎皎河汉女	jiao jiao he han nv	1
+交交黄鸟	jiao jiao huang niao	1
+胶胶角角鸡初鸣	jiao jiao jiao jiao ji chu ming	1
+矫矫珍木巅	jiao jiao zhen mu dian	1
+椒聊	jiao liao	1
+鹪鹩巢于深林	jiao liao chao yu shen lin	1
+蛟龙出没猩鼯号	jiao long chu mo xing wu hao	1
+蛟龙得云雨	jiao long de yun yu	1
+蛟龙生焉	jiao long sheng yan	1
+骄其妻妾	jiao qi qi qie	1
+教妾若为容	jiao qie ruo wei rong	1
+骄人好好	jiao ren hao hao	1
+佼人僚兮	jiao ren liao xi	1
+教人以善	jiao ren yi shan	1
+皎如飞镜临丹阙	jiao ru fei jing lin dan que	1
+矫如群帝骖龙翔	jiao ru qun di can long xiang	1
+皎如玉树临风前	jiao ru yu shu lin feng qian	1
+娇软不胜垂	jiao ruan bu sheng chui	1
+教使之然也	jiao shi zhi ran ye	1
+教授所著	jiao shou suo zhu	1
+狡童	jiao tong	1
+教以人伦	jiao yi ren lun	1
+教以慎于接物	jiao yi shen yu jie wu	1
+焦郁	jiao yu	1
+交语速装束	jiao yu su zhuang shu	1
+教育振兴	jiao yu zhen xing	1
+郊原血	jiao yuan xue	1
+教者必以正	jiao zhe bi yi zheng	1
+脚著谢公屐	jiao zhu xie gong ji	1
+解鞍欹枕绿杨桥	jie an qi zhen lv yang qiao	1
+节彼南山	jie bi nan shan	1
+街垂千步柳	jie chui qian bu liu	1
+解春风	jie chun feng	1
+解道醒来无味	jie dao xing lai wu wei	1
+截断巫山云雨	jie duan wu shan yun yu	1
+戒多言	jie duo yan	1
+介尔景福	jie er jing fu	1
+嗟尔君子	jie er jun zi	1
+嗟尔远道之人	jie er yuan dao zhi ren	1
+结发受长生	jie fa shou chang sheng	1
+结发授长生	jie fa shou chang sheng	1
+结发同枕席	jie fa tong zhen xi	1
+结发未识事	jie fa wei shi shi	1
+皆反求诸己	jie fan qiu zhu ji	1
+皆共尘沙老	jie gong chen sha lao	1
+接汉疑星落	jie han yi xing luo	1
+解红	jie hong	1
+节候看应晚	jie hou kan ying wan	1
+戒厚味	jie hou wei	1
+嗟乎	jie hu	1
+羯胡事主终无赖	jie hu shi zhu zhong wu lai	1
+嗟君此别意何如	jie jun ci bie yi he ru	1
+嗟君万里行	jie jun wan li xing	1
+解缆君已遥	jie lan jun yi yao	1
+解落三秋叶	jie luo san qiu ye	1
+节南山	jie nan shan	1
+皆能有养	jie neng you yang	1
+洁念乐空寂	jie nian le kong ji	1
+解佩令	jie pei ling	1
+皆入于机	jie ru yu ji	1
+戒奢以俭	jie she yi jian	1
+解绅宜就水	jie shen yi jiu shui	1
+解释春风无限恨	jie shi chun feng wu xian hen	1
+节使三河募年少	jie shi san he mu nian shao	1
+结束多红粉	jie shu duo hong fen	1
+借书满架	jie shu man jia	1
+借水开花自一奇	jie shui kai hua zi yi qi	1
+结袜子	jie wa zi	1
+解琬	jie wan	1
+皆为龙虎	jie wei long hu	1
+借问吹箫向紫烟	jie wen chui xiao xiang zi yan	1
+借问此何时	jie wen ci he shi	1
+借问汉宫谁得似	jie wen han gong shui de si	1
+借问君去何方	jie wen jun qu he fang	1
+借问苦心爱者谁	jie wen ku xin ai zhe shui	1
+借问路傍名利客	jie wen lu bang ming li ke	1
+借问瘟君欲何往	jie wen wen jun yu he wang	1
+借问新安吏	jie wen xin an li	1
+嗟我怀人	jie wo huai ren	1
+节物风光不相待	jie wu feng guang bu xiang dai	1
+皆物之情也	jie wu zhi qing ye	1
+揭傒斯	jie xi si	1
+阶下青苔与红树	jie xia qing tai yu hong shu	1
+皆向沙场老	jie xiang sha chang lao	1
+解心释神	jie xin shi shen	1
+皆兄弟也	jie xiong di ye	1
+皆雅言也	jie ya yan ye	1
+皆言夫婿殊	jie yan fu xu shu	1
+皆言四海同	jie yan si hai tong	1
+解衣欲睡	jie yi yu shui	1
+节用而爱人	jie yong er ai ren	1
+解冤结	jie yuan jie	1
+嗟哉吾党二三子	jie zai wu dang er san zi	1
+睫在眼前长不见	jie zai yan qian chang bu jian	1
+戒之戒之	jie zhi jie zhi	1
+皆知善之为善	jie zhi shan zhi wei shan	1
+戒之慎勿忘	jie zhi shen wu wang	1
+竭忠尽孝	jie zhong jin xiao	1
+谨拜表以闻	jin bai biao yi wen	1
+今拜乎上	jin bai hu shang	1
+金鞭断折九马死	jin bian duan zhe jiu ma si	1
+金鞭络绎向侯家	jin bian luo yi xiang hou jia	1
+锦缠道	jin chan dao	1
+金蟾啮锁烧香入	jin chan nie suo shao xiang ru	1
+金昌绪	jin chang xu	1
+今朝拜首临欲别	jin chao bai shou lin yu bie	1
+今臣亡国贱俘	jin chen wang guo jian fu	1
+今成断根草	jin cheng duan gen cao	1
+今成流泪泉	jin cheng liu lei quan	1
+锦城虽云乐	jin cheng sui yun le	1
+今春花鸟作边愁	jin chun hua niao zuo bian chou	1
+今春看又过	jin chun kan you guo	1
+晋祠流水如碧玉	jin ci liu shui ru bi yu	1
+金错刀	jin cuo dao	1
+金带连环束战袍	jin dai lian huan shu zhan pao	1
+晋代衣冠成古丘	jin dai yi guan cheng gu qiu	1
+近得归京邑	jin de gui jing yi	1
+金灯花	jin deng hua	1
+金地藏	jin di zang	1
+巾短情长	jin duan qing chang	1
+金多众中为上客	jin duo zhong zhong wei shang ke	1
+锦帆应是到天涯	jin fan ying shi dao tian ya	1
+金凤钩	jin feng gou	1
+今夫天下之人牧	jin fu tian xia zhi ren mu	1
+金浮图	jin fu tu	1
+今夫颛臾	jin fu zhuan yu	1
+金谷怀古	jin gu huai gu	1
+今古空名	jin gu kong ming	1
+筋骨之强	jin gu zhi qiang	1
+金棺葬寒灰	jin guan zang han hui	1
+金河秋半虏弦开	jin he qiu ban lu xian kai	1
+金猴奋起千钧棒	jin hou fen qi qian jun bang	1
+今花几开落	jin hua ji kai luo	1
+今见功名胜古人	jin jian gong ming sheng gu ren	1
+金蕉叶	jin jiao ye	1
+矜矜兢兢	jin jin jing jing	1
+金井梧桐秋叶黄	jin jing wu tong qiu ye huang	1
+金菊对芙蓉	jin ju dui fu rong	1
+金菊香	jin ju xiang	1
+今看两楹奠	jin kan liang ying dian	1
+矜夸紫骝好	jin kua zi liu hao	1
+今来典斯郡	jin lai dian si jun	1
+近来攀折苦	jin lai pan zhe ku	1
+近泪无干土	jin lei wu gan tu	1
+筋力交凋丧	jin li jiao diao sang	1
+锦里开芳宴	jin li kai fang yan	1
+禁里疏钟官舍晚	jin li shu zhong guan she wan	1
+锦里烟尘外	jin li yan chen wai	1
+金陵凤凰台	jin ling feng huang tai	1
+金陵凤凰台置酒	jin ling feng huang tai zhi jiu	1
+金陵津渡小山楼	jin ling jin du xiao shan lou	1
+金陵酒肆留别	jin ling jiu si liu bie	1
+金陵望汉江	jin ling wang han jiang	1
+金陵子弟来相送	jin ling zi di lai xiang song	1
+金炉香尽漏声残	jin lu xiang jin lou sheng can	1
+金缕词	jin lv ci	1
+金缕歌	jin lv ge	1
+禁门宫树月痕过	jin men gong shu yue hen guo	1
+仅免刑焉	jin mian xing yan	1
+金明春	jin ming chun	1
+今年春尽	jin nian chun jin	1
+今年花落颜色改	jin nian hua luo yan se gai	1
+今年花似去年好	jin nian hua si qu nian hao	1
+尽年年	jin nian nian	1
+今漂沦憔悴	jin piao lun qiao cui	1
+金叵罗	jin po luo	1
+金阙前开二峰长	jin que qian kai er feng chang	1
+金阙晓钟开万户	jin que xiao zhong kai wan hu	1
+今人不见古时月	jin ren bu jian gu shi yue	1
+今人多不弹	jin ren duo bu tan	1
+今人还对落花风	jin ren hai dui luo hua feng	1
+金人秋泪	jin ren qiu lei	1
+今人未可非商鞅	jin ren wei ke fei shang yang	1
+今日被驱遣	jin ri bei qu qian	1
+今日病矣	jin ri bing yi	1
+今日长缨在手	jin ri chang ying zai shou	1
+今日垂杨生左肘	jin ri chui yang sheng zuo zhou	1
+今日大风寒	jin ri da feng han	1
+今日得宽余	jin ri de kuan yu	1
+今日得宽馀	jin ri de kuan yu	1
+今日非昨日	jin ri fei zuo ri	1
+今日逢君君不识	jin ri feng jun jun bu shi	1
+今日俸钱过十万	jin ri feng qian guo shi wan	1
+今日还家去	jin ri hai jia qu	1
+今日花开又一年	jin ri hua kai you yi nian	1
+今日欢呼孙大圣	jin ri huan hu sun da sheng	1
+今日江头两三树	jin ri jiang tou liang san shu	1
+今日龙钟人共老	jin ri long zhong ren gong lao	1
+今日凄凉南浦	jin ri qi liang nan pu	1
+今日水犹寒	jin ri shui you han	1
+今日武将军	jin ri wu jiang jun	1
+今日向何方	jin ri xiang he fang	1
+今日之事	jin ri zhi shi	1
+今日之事何如	jin ri zhi shi he ru	1
+近入千家散花竹	jin ru qian jia san hua zhu	1
+浸润之谮	jin run zhi zen	1
+今若遣此妇	jin ruo qian ci fu	1
+锦瑟无端五十弦	jin se wu duan wu shi xian	1
+金沙水拍云崖暖	jin sha shui pai yun ya nuan	1
+尽善尽美	jin shan jin mei	1
+锦上花	jin shang hua	1
+今上岳阳楼	jin shang yue yang lou	1
+金声而玉振	jin sheng er yu zhen	1
+近时郭家狮子花	jin shi guo jia shi zi hua	1
+近试上张水部	jin shi shang zhang shui bu	1
+今事有急	jin shi you ji	1
+谨守而勿失	jin shou er wu shi	1
+津树多枫橘	jin shu duo feng ju	1
+锦水东北流	jin shui dong bei liu	1
+今四十年	jin si shi nian	1
+近死之心	jin si zhi xin	1
+金粟堆前松柏里	jin su dui qian song bai li	1
+今岁今宵尽	jin sui jin xiao jin	1
+尽态极妍	jin tai ji yan	1
+锦堂春	jin tang chun	1
+锦堂春慢	jin tang chun man	1
+今天之旋	jin tian zhi xuan	1
+进退无颜仪	jin tui wu yan yi	1
+今亡矣夫	jin wang yi fu	1
+今为羌笛出塞声	jin wei qiang di chu sai sheng	1
+今我不乐	jin wo bu le	1
+今我不乐思岳阳	jin wo bu le si yue yang	1
+今我游冥冥	jin wo you ming ming	1
+金吾不禁夜	jin wu bu jin ye	1
+金屋无人见泪痕	jin wu wu ren jian lei hen	1
+今吾于人也	jin wu yu ren ye	1
+尽吾志也	jin wu zhi ye	1
+今夕复何夕	jin xi fu he xi	1
+今夕亦何夕	jin xi yi he xi	1
+谨庠序之教	jin xiang xu zhi jiao	1
+今宵好向郎边去	jin xiao hao xiang lang bian qu	1
+今宵月	jin xiao yue	1
+尽心力而为之	jin xin li er wei zhi	1
+尽心焉耳矣	jin xin yan er yi	1
+金星妆成娇侍夜	jin xing zhuang cheng jiao shi ye	1
+进学解	jin xue jie	1
+禁烟	jin yan	1
+晋阳已陷休回顾	jin yang yi xian xiu hui gu	1
+今夜不知何处宿	jin ye bu zhi he chu su	1
+今夜残灯斜照处	jin ye can deng xie zhao chu	1
+今夜鄜州月	jin ye lu zhou yue	1
+今也则亡	jin ye ze wang	1
+今也制民之产	jin ye zhi min zhi chan	1
+尽意凄凉	jin yi qi liang	1
+今已亭亭如盖矣	jin yi ting ting ru gai yi	1
+今又重阳	jin you chong yang	1
+今由与求也	jin you yu qiu ye	1
+金舆不返倾城色	jin yu bu fan qing cheng se	1
+金玉满堂	jin yu man tang	1
+锦园春	jin yuan chun	1
+今月曾经照古人	jin yue ceng jing zhao gu ren	1
+今则不然	jin ze bu ran	1
+金盏子	jin zhan zi	1
+锦帐春	jin zhang chun	1
+今朝此为别	jin zhao ci wei bie	1
+今朝都到眼前来	jin zhao dou dao yan qian lai	1
+今朝风日好	jin zhao feng ri hao	1
+今朝歌管属檀郎	jin zhao ge guan shu tan lang	1
+今朝更好看	jin zhao geng hao kan	1
+今朝郡斋冷	jin zhao jun zhai leng	1
+今朝腊月春意动	jin zhao la yue chun yi dong	1
+今朝霜重东门路	jin zhao shuang zhong dong men lu	1
+今朝蟢子飞	jin zhao xi zi fei	1
+今朝杨柳半垂堤	jin zhao yang liu ban chui di	1
+今者项庄拔剑舞	jin zhe xiang zhuang ba jian wu	1
+今者有小人之言	jin zhe you xiao ren zhi yan	1
+今之从政者殆而	jin zhi cong zheng zhe dai er	1
+今之君子	jin zhi jun zi	1
+今之狂也荡	jin zhi kuang ye dang	1
+今之人也	jin zhi ren ye	1
+今之孝者	jin zhi xiao zhe	1
+今之新图有二马	jin zhi xin tu you er ma	1
+今之学者为人	jin zhi xue zhe wei ren	1
+近之则不孙	jin zhi ze bu sun	1
+今之众人	jin zhi zhong ren	1
+近种篱边菊	jin zhong li bian ju	1
+金字经	jin zi jing	1
+金樽对绮筵	jin zun dui qi yan	1
+径草踏还生	jing cao ta hai sheng	1
+景池	jing chi	1
+惊定还拭泪	jing ding hai shi lei	1
+经冬复立春	jing dong fu li chun	1
+经冬犹绿林	jing dong you lu lin	1
+精而又精	jing er you jing	1
+惊飞远映碧山去	jing fei yuan ying bi shan qu	1
+惊风乱飐芙蓉水	jing feng luan zhan fu rong shui	1
+荆歌艳楚腰	jing ge yan chu yao	1
+靖共尔位	jing gong er wei	1
+静故了群动	jing gu le qun dong	1
+惊呼热中肠	jing hu re zhong chang	1
+镜湖三百里	jing hu san bai li	1
+镜湖水如月	jing hu shui ru yue	1
+惊回首	jing hui shou	1
+荆棘生焉	jing ji sheng yan	1
+净境重阳节	jing jing chong yang jie	1
+菁菁者莪	jing jing zhe e	1
+井九百亩	jing jiu bai mu	1
+京口流江航	jing kou liu jiang hang	1
+净理了可悟	jing li le ke wu	1
+泾流之大	jing liu zhi da	1
+京洛多风尘	jing luo duo feng chen	1
+京洛缝春衣	jing luo feng chun yi	1
+荆门九派通	jing men jiu pai tong	1
+荆门送别	jing men song bie	1
+精妙世无双	jing miao shi wu shuang	1
+静女其娈	jing nv qi luan	1
+静女其姝	jing nv qi shu	1
+旌旆逶迤碣石间	jing pei wei yi jie shi jian	1
+惊破绿窗幽梦	jing po lv chuang you meng	1
+旌旗初下玉关东	jing qi chu xia yu guan dong	1
+旌旗奋	jing qi fen	1
+敬其事而后其食	jing qi shi er hou qi shi	1
+荆人	jing ren	1
+井上有李	jing shang you li	1
+井深冻不成	jing shen dong bu cheng	1
+敬事而信	jing shi er xin	1
+经始灵台	jing shi ling tai	1
+荆叔	jing shu	1
+井水为君盟	jing shui wei jun meng	1
+井税有常期	jing shui you chang qi	1
+京镗	jing tang	1
+经天纬地	jing tian wei di	1
+镜天无一毫	jing tian wu yi hao	1
+静听松风寒	jing ting song feng han	1
+静为躁君	jing wei zao jun	1
+惊闻俗客争来集	jing wen su ke zheng lai ji	1
+荆吴相接水为乡	jing wu xiang jie shui wei xiang	1
+竟夕起相思	jing xi qi xiang si	1
+竟夕自悲秋	jing xi zi bei qiu	1
+净显	jing xian	1
+径须沽取对君酌	jing xu gu qu dui jun zhuo	1
+静言思之	jing yan si zhi	1
+静夜四无邻	jing ye si wu lin	1
+井有仁焉	jing you ren yan	1
+净圆	jing yuan	1
+静曰复命	jing yue fu ming	1
+静者心多妙	jing zhe xin duo miao	1
+经之营之	jing zhi ying zhi	1
+精之至也	jing zhi zhi ye	1
+镜中人	jing zhong ren	1
+竞舟	jing zhou	1
+荆州歌	jing zhou ge	1
+荆州亭	jing zhou ting	1
+迥立阊阖生长风	jiong li chang he sheng zhang feng	1
+迥临村路傍溪桥	jiong lin cun lu bang xi qiao	1
+迥临飞鸟上	jiong lin fei niao shang	1
+久别离	jiu bie li	1
+久不见若影	jiu bu jian ruo ying	1
+就不欲入	jiu bu yu ru	1
+九重春色	jiu chong chun se	1
+九重谁省谏书函	jiu chong shui sheng jian shu han	1
+九雏鸣凤乱啾啾	jiu chu ming feng luan jiu jiu	1
+久读枯神	jiu du ku shen	1
+舅夺母志	jiu duo mu zhi	1
+久而敬之	jiu er jing zhi	1
+久而弥笃	jiu er mi du	1
+酒舫泛泛然	jiu fang fan fan ran	1
+旧风流	jiu feng liu	1
+旧谷既没	jiu gu ji mei	1
+旧国见青山	jiu guo jian qing shan	1
+救国良方	jiu guo liang fang	1
+九国之师	jiu guo zhi shi	1
+旧好隔良缘	jiu hao ge liang yuan	1
+九华山人	jiu hua shan ren	1
+九回肠	jiu hui chang	1
+九佳	jiu jia	1
+旧家燕子傍谁飞	jiu jia yan zi bang shui fei	1
+旧将军	jiu jiang jun	1
+究竟人高品雅	jiu jing ren gao pin ya	1
+久久莫相忘	jiu jiu mo xiang wang	1
+赳赳武夫	jiu jiu wu fu	1
+酒阑不必看茱萸	jiu lan bu bi kan zhu yu	1
+鹫翎金仆姑	jiu ling jin pu gu	1
+旧令尹之政	jiu ling yin zhi zheng	1
+九龙呵护玉莲房	jiu long he hu yu lian fang	1
+咎莫大于欲得	jiu mo da yu yu de	1
+九陌祥烟合	jiu mo xiang yan he	1
+樛木	jiu mu	1
+旧南阁子也	jiu nan ge zi ye	1
+九年面壁	jiu nian mian bi	1
+就其浅矣	jiu qi qian yi	1
+就其深矣	jiu qi shen yi	1
+九青	jiu qing	1
+酒倾愁不来	jiu qing chou bu lai	1
+酒泉子	jiu quan zi	1
+九人而已	jiu ren er yi	1
+九日登高望	jiu ri deng gao wang	1
+九日黄花酒	jiu ri huang hua jiu	1
+九日齐山登高	jiu ri qi shan deng gao	1
+九山郁峥嵘	jiu shan yu zheng rong	1
+旧时栏楯	jiu shi lan dun	1
+九十五字	jiu shi wu zi	1
+九死南荒吾不恨	jiu si nan huang wu bu hen	1
+九岁不行	jiu sui bu xing	1
+九泰	jiu tai	1
+九天阊阖开宫殿	jiu tian chang he kai gong dian	1
+九天开出一成都	jiu tian kai chu yi cheng du	1
+酒徒历历坐洲岛	jiu tu li li zuo zhou dao	1
+九万八千	jiu wan ba qian	1
+九万里	jiu wan li	1
+九微片片飞花琐	jiu wei pian pian fei hua suo	1
+久为簪组累	jiu wei zan zu lei	1
+久相待	jiu xiang dai	1
+九屑	jiu xie	1
+九蟹	jiu xie	1
+酒星不在天	jiu xing bu zai tian	1
+酒醒南望隔天涯	jiu xing nan wang ge tian ya	1
+旧业已随征战尽	jiu ye yi sui zheng zhan jin	1
+九嶷山上白云飞	jiu yi shan shang bai yun fei	1
+就有道而正焉	jiu you dao er zheng yan	1
+厩有肥马	jiu you fei ma	1
+久有凌云志	jiu you ling yun zhi	1
+旧友悉零落	jiu you xi ling luo	1
+九罭	jiu yu	1
+九渊	jiu yuan	1
+旧苑荒台杨柳新	jiu yuan huang tai yang liu xin	1
+九月初二日	jiu yue chu er ri	1
+九月初九日	jiu yue chu jiu ri	1
+九月寒砧催木叶	jiu yue han zhen cui mu ye	1
+九月九日	jiu yue jiu ri	1
+九月九日望乡台	jiu yue jiu ri wang xiang tai	1
+九月九日望遥空	jiu yue jiu ri wang yao kong	1
+九月三十日	jiu yue san shi ri	1
+九月在户	jiu yue zai hu	1
+救赵挥金槌	jiu zhao hui jin chui	1
+酒中堪累月	jiu zhong kan lei yue	1
+居必迁坐	ju bi qian zuo	1
+俱不得其死然	ju bu de qi si ran	1
+举臣秀才	ju chen xiu cai	1
+居处不安	ju chu bu an	1
+举动自专由	ju dong zi zhuan you	1
+句读之不知	ju dou zhi bu zhi	1
+举尔所知	ju er suo zhi	1
+具告沛公	ju gao pei gong	1
+具告以事	ju gao yi shi	1
+鞠歌行	ju ge xing	1
+鞠躬如也	ju gong ru ye	1
+据湖岸	ju hu an	1
+菊花何太苦	ju hua he tai ku	1
+菊花开菊花残	ju hua kai ju hua can	1
+菊花天	ju hua tian	1
+菊花新	ju hua xin	1
+俱怀鸿鹄志	ju huai hong hu zhi	1
+俱会大道口	ju hui da dao kou	1
+居简而行简	ju jian er xing jian	1
+居敬而行简	ju jing er xing jian	1
+举酒属客	ju jiu shu ke	1
+句句皆绝伦	ju ju jie jue lun	1
+讵肯感激徒媕婀	ju ken gan ji tu an e	1
+举匏樽以相属	ju pao zun yi xiang zhu	1
+距其院东五里	ju qi yuan dong wu li	1
+居人共住武陵源	ju ren gong zhu wu ling yuan	1
+居人未改秦衣服	ju ren wei gai qin yi fu	1
+举觞白眼望青天	ju shang bai yan wang qing tian	1
+居上不宽	ju shang bu kuan	1
+举身赴清池	ju shen fu qing chi	1
+居是邦也	ju shi bang ye	1
+俱是梦中人	ju shi meng zhong ren	1
+举手可近月	ju shou ke jin yue	1
+举手来相招	ju shou lai xiang zhao	1
+掬水月在手	ju shui yue zai shou	1
+居天下之广居	ju tian xia zhi guang ju	1
+举头望山月	ju tou wang shan yue	1
+举枉错诸直	ju wang cuo zhu zhi	1
+俱往矣	ju wang yi	1
+菊翁	ju weng	1
+居闲始自遣	ju xian shi zi qian	1
+剧辛乐毅感恩分	ju xin yue yi gan en fen	1
+居延城外猎天骄	ju yan cheng wai lie tian jiao	1
+举言谓新妇	ju yan wei xin fu	1
+俱邀侠客芙蓉剑	ju yao xia ke fu rong jian	1
+据亿丈之城	ju yi zhang zhi cheng	1
+拘于虚也	ju yu xu ye	1
+居域中之大	ju yu zhong zhi da	1
+聚则为生	ju ze wei sheng	1
+居之不疑	ju zhi bu yi	1
+举直错诸枉	ju zhi cuo zhu wang	1
+居之无倦	ju zhi wu juan	1
+聚之咸阳	ju zhi xian yang	1
+橘子洲头	ju zi zhou tou	1
+卷春空	juan chun kong	1
+娟娟戏蝶过闲幔	juan juan xi die guo xian man	1
+卷三九	juan san jiu	1
+卷上珠帘总不如	juan shang zhu lian zong bu ru	1
+卷舒自如	juan shu zi ru	1
+卷帷望月空长叹	juan wei wang yue kong chang tan	1
+倦寻芳	juan xun fang	1
+卷一百八十	juan yi bai ba shi	1
+卷一百八十二	juan yi bai ba shi er	1
+卷一百八十三	juan yi bai ba shi san	1
+卷一百八十一	juan yi bai ba shi yi	1
+卷一百六十八	juan yi bai liu shi ba	1
+卷一百六十五	juan yi bai liu shi wu	1
+卷一百七十九	juan yi bai qi shi jiu	1
+卷一百七十六	juan yi bai qi shi liu	1
+卷一百七十五	juan yi bai qi shi wu	1
+卷一百七十一	juan yi bai qi shi yi	1
+卷云山	juan yun shan	1
+狷者有所不为也	juan zhe you suo bu wei ye	1
+卷珠帘	juan zhu lian	1
+绝壁临巨川	jue bi lin ju chuan	1
+绝壁耸万仞	jue bi song wan ren	1
+绝代有佳人	jue dai you jia ren	1
+觉道资无穷	jue dao zi wu qiong	1
+绝顶一茅茨	jue ding yi mao ci	1
+绝壑开花界	jue he kai hua jie	1
+攫鸟不搏	jue niao bu bo	1
+绝巧弃利	jue qiao qi li	1
+绝仁弃义	jue ren qi yi	1
+绝圣弃智	jue sheng qi zhi	1
+爵位自高言尽废	jue wei zi gao yan jin fei	1
+厥有国语	jue you guo yu	1
+绝域苍茫更何有	jue yu cang mang geng he you	1
+君爱身后名	jun ai shen hou ming	1
+君安与项伯有故	jun an yu xiang bo you gu	1
+君不见青海头	jun bu jian qing hai tou	1
+君不闻	jun bu wen	1
+君不悟	jun bu wu	1
+君臣一梦	jun chen yi meng	1
+君臣已与时际会	jun chen yi yu shi ji hui	1
+君臣之义	jun chen zhi yi	1
+君宠益娇态	jun chong yi jiao tai	1
+君当作磐石	jun dang zuo pan shi	1
+君尔妾亦然	jun er qie yi ran	1
+军阀重开战	jun fa zhong kai zhan	1
+君歌且休听我歌	jun ge qie xiu ting wo ge	1
+君歌声酸辞且苦	jun ge sheng suan ci qie ku	1
+君还何所望	jun hai he suo wang	1
+君既若见录	jun ji ruo jian lu	1
+君既为府吏	jun ji wei fu li	1
+君家白碗胜霜雪	jun jia bai wan sheng shuang xue	1
+君家妇难为	jun jia fu nan wei	1
+君家何处住	jun jia he chu zhu	1
+军叫工农革命	jun jiao gong nong ge ming	1
+俊杰在位	jun jie zai wei	1
+君今不幸离人世	jun jin bu xing li ren shi	1
+君今在罗网	jun jin zai luo wang	1
+君看似花处	jun kan si hua chu	1
+君来路	jun lai lu	1
+君怜无是非	jun lian wu shi fei	1
+军旅之事	jun lv zhi shi	1
+君马黄	jun ma huang	1
+君门客如水	jun men ke ru shui	1
+君门深九重	jun men shen jiu chong	1
+君莫停	jun mo ting	1
+君起舞	jun qi wu	1
+君情与妾意	jun qing yu qie yi	1
+君去试看汾水上	jun qu shi kan fen shui shang	1
+君仁莫不仁	jun ren mo bu ren	1
+军声动至今	jun sheng dong zhi jin	1
+君使臣以礼	jun shi chen yi li	1
+君孰与不足	jun shu yu bu zu	1
+君孰与足	jun shu yu zu	1
+君王赐颜色	jun wang ci yan se	1
+君为东道主	jun wei dong dao zhu	1
+君为女萝草	jun wei nv luo cao	1
+君为我呼入	jun wei wo hu ru	1
+君问穷通理	jun wen qiong tong li	1
+郡县逼迫	jun xian bi po	1
+君行仁政	jun xing ren zheng	1
+君须记	jun xu ji	1
+君言不得意	jun yan bu de yi	1
+俊逸鲍参军	jun yi bao can jun	1
+郡邑浮前浦	jun yi fu qian pu	1
+君义莫不义	jun yi mo bu yi	1
+君曰	jun yue	1
+君之视臣如犬马	jun zhi shi chen ru quan ma	1
+君之视臣如手足	jun zhi shi chen ru shou zu	1
+君之视臣如土芥	jun zhi shi chen ru tu jie	1
+军中无以为乐	jun zhong wu yi wei le	1
+君子病无能焉	jun zi bing wu neng yan	1
+君子不齿	jun zi bu chi	1
+君子不可小知	jun zi bu ke xiao zhi	1
+君子不以言举人	jun zi bu yi yan ju ren	1
+君子不忧不惧	jun zi bu you bu ju	1
+君子不怨天	jun zi bu yuan tian	1
+君子不重则不威	jun zi bu zhong ze bu wei	1
+君子耻之	jun zi chi zhi	1
+君自此远矣	jun zi ci yuan yi	1
+君子淡以亲	jun zi dan yi qin	1
+君子道者三	jun zi dao zhe san	1
+君子笃于亲	jun zi du yu qin	1
+君子多乎哉	jun zi duo hu zai	1
+君子固穷	jun zi gu qiong	1
+君子和而不同	jun zi he er bu tong	1
+君子怀德	jun zi huai de	1
+君子惠而不费	jun zi hui er bu fei	1
+君子疾夫舍曰	jun zi ji fu she yue	1
+君子矜而不争	jun zi jin er bu zheng	1
+君子敬而无失	jun zi jing er wu shi	1
+君子居之	jun zi ju zhi	1
+君子可逝也	jun zi ke shi ye	1
+君子乐胥	jun zi le xu	1
+君子谋道不谋食	jun zi mou dao bu mou shi	1
+君子求诸己	jun zi qiu zhu ji	1
+君子去仁	jun zi qu ren	1
+君子人也	jun zi ren ye	1
+君子人与	jun zi ren yu	1
+君子上达	jun zi shang da	1
+君子尚勇乎	jun zi shang yong hu	1
+君子生非异也	jun zi sheng fei yi ye	1
+君子食无求饱	jun zi shi wu qiu bao	1
+君子思不出其位	jun zi si bu chu qi wei	1
+君子所依	jun zi suo yi	1
+君子泰而不骄	jun zi tai er bu jiao	1
+君子陶陶	jun zi tao tao	1
+君子无所争	jun zi wu suo zheng	1
+君子无众寡	jun zi wu zhong gua	1
+君子偕老	jun zi xie lao	1
+君子学道则爱人	jun zi xue dao ze ai ren	1
+君子学以致其道	jun zi xue yi zhi qi dao	1
+君子阳阳	jun zi yang yang	1
+君子以仁存心	jun zi yi ren cun xin	1
+君子意如何	jun zi yi ru he	1
+君子以文会友	jun zi yi wen hui you	1
+君子一言以为知	jun zi yi yan yi wei zhi	1
+君子义以为上	jun zi yi yi wei shang	1
+君子义以为质	jun zi yi yi wei zhi	1
+君子亦有穷乎	jun zi yi you qiong hu	1
+君子有酒	jun zi you jiu	1
+君子有九思	jun zi you jiu si	1
+君子有三变	jun zi you san bian	1
+君子有三戒	jun zi you san jie	1
+君子有三畏	jun zi you san wei	1
+君子有终身之忧	jun zi you zhong shen zhi you	1
+君子于其所不知	jun zi yu qi suo bu zhi	1
+君子于其言	jun zi yu qi yan	1
+君子哉若人	jun zi zai ruo ren	1
+君子者乎	jun zi zhe hu	1
+君子贞而不谅	jun zi zhen er bu liang	1
+君子正其衣冠	jun zi zheng qi yi guan	1
+君子之车	jun zi zhi che	1
+君子之道	jun zi zhi dao	1
+君子之德风	jun zi zhi de feng	1
+君子质而已矣	jun zi zhi er yi yi	1
+君子之过也	jun zi zhi guo ye	1
+君子之人	jun zi zhi ren	1
+君子之仕也	jun zi zhi shi ye	1
+君子之守	jun zi zhi shou	1
+君子之于天下也	jun zi zhi yu tian xia ye	1
+君子之泽	jun zi zhi ze	1
+君子之至于斯也	jun zi zhi zhi yu si ye	1
+君子周而不比	jun zi zhou er bu bi	1
+君子周急不继富	jun zi zhou ji bu ji fu	1
+君子作之	jun zi zuo zhi	1
+君醉留妾家	jun zui liu qie jia	1
+开成三年	kai cheng san nian	1
+岂弟君子	kai di jun zi	1
+凯风自南	kai feng zi nan	1
+凯歌	kai ge	1
+开国何茫然	kai guo he mang ran	1
+开过尚盈盈	kai guo shang ying ying	1
+开荒南野际	kai huang nan ye ji	1
+开揭磊砢	kai jie lei ke	1
+开帘见新月	kai lian jian xin yue	1
+开门复动竹	kai men fu dong zhu	1
+开门无犬吠	kai men wu quan fei	1
+开门雪满山	kai men xue man shan	1
+开箧泪沾臆	kai qie lei zhan yi	1
+慨然抚长剑	kai ran fu chang jian	1
+开塞随行变	kai sai sui xing bian	1
+开天辟地君真健	kai tian pi di jun zhen jian	1
+开拓词境	kai tuo ci jing	1
+开帷月初吐	kai wei yue chu tu	1
+开箱验取石榴裙	kai xiang yan qu shi liu qun	1
+开轩纳微凉	kai xuan na wei liang	1
+开轩卧闲敞	kai xuan wo xian chang	1
+开元二十六年	kai yuan er shi liu nian	1
+开元乐	kai yuan le	1
+开元之中常引见	kai yuan zhi zhong chang yin jian	1
+开妆镜也	kai zhuang jing ye	1
+看红妆素裹	kan hong zhuang su guo	1
+看花回	kan hua hui	1
+看花满眼泪	kan hua man yan lei	1
+看剑引杯长	kan jian yin bei chang	1
+看君击狂节	kan jun ji kuang jie	1
+看君马去疾如鸟	kan jun ma qu ji ru niao	1
+坎坎伐辐兮	kan kan fa fu xi	1
+坎坎伐檀兮	kan kan fa tan xi	1
+坎坎鼓我	kan kan gu wo	1
+侃侃如也	kan kan ru ye	1
+坎轲只得移荆蛮	kan ke zhi de yi jing man	1
+看来平常	kan lai ping chang	1
+看取汉家何事业	kan qu han jia he shi ye	1
+看取莲花净	kan qu lian hua jing	1
+看松露滴身	kan song lu di shen	1
+槛外长江空自流	kan wai chang jiang kong zi liu	1
+看万山红遍	kan wan shan hong bian	1
+堪笑兰台公子	kan xiao lan tai gong zi	1
+看余度石桥	kan yu du shi qiao	1
+看朱成碧思纷纷	kan zhu cheng bi si fen fen	1
+看竹何须问主人	kan zhu he xu wen zhu ren	1
+慷慨动颜魄	kang kai dong yan po	1
+康骈	kang pian	1
+康与之	kang yu zhi	1
+康子馈药	kang zi kui yao	1
+考槃	kao pan	1
+考槃在涧	kao pan zai jian	1
+可爱深红爱浅红	ke ai shen hong ai qian hong	1
+柯崇	ke chong	1
+可传而不可受	ke chuan er bu ke shou	1
+客从东方来	ke cong dong fang lai	1
+客从何处来	ke cong he chu lai	1
+可得而不可见	ke de er bu ke jian	1
+可得而闻也	ke de er wen ye	1
+可得见	ke de jian	1
+可得闻乎	ke de wen hu	1
+可得闻与	ke de wen yu	1
+客何为者	ke he wei zhe	1
+可恨年年赠离别	ke hen nian nian zeng li bie	1
+克己复礼为仁	ke ji fu li wei ren	1
+可怜春半不还家	ke lian chun ban bu huan jia	1
+可怜邓道士	ke lian deng dao shi	1
+可怜飞燕倚新妆	ke lian fei yan yi xin zhuang	1
+可怜闺里月	ke lian gui li yue	1
+可怜焦土	ke lian jiao tu	1
+可怜九马争神骏	ke lian jiu ma zheng shen jun	1
+可怜缭乱点	ke lian liao luan dian	1
+可怜体无比	ke lian ti wu bi	1
+可隆	ke long	1
+可名为大	ke ming wei da	1
+可名于小	ke ming yu xiao	1
+可奈情怀	ke nai qing huai	1
+可朋	ke peng	1
+客去波平槛	ke qu bo ping kan	1
+可容一人居	ke rong yi ren ju	1
+柯如青铜根如石	ke ru qing tong gen ru shi	1
+客散酒醒深夜后	ke san jiu xing shen ye hou	1
+可上九天揽月	ke shang jiu tian lan yue	1
+可使食无肉	ke shi shi wu rou	1
+可使有勇	ke shi you yong	1
+可使足民	ke shi zu min	1
+客思倍从来	ke si bei cong lai	1
+客思似杨柳	ke si si yang liu	1
+咳唾落九天	ke tuo luo jiu tian	1
+可望不可即	ke wang bu ke ji	1
+可望不可攀	ke wang bu ke pan	1
+可谓好学也已	ke wei hao xue ye yi	1
+可谓好学也已矣	ke wei hao xue ye yi yi	1
+可谓明矣	ke wei ming yi	1
+可谓仁乎	ke wei ren hu	1
+可谓仁矣	ke wei ren yi	1
+可谓仁之方也已	ke wei ren zhi fang ye yi	1
+可谓士矣	ke wei shi yi	1
+可为识者规	ke wei shi zhe gui	1
+可畏惟人	ke wei wei ren	1
+可谓孝矣	ke wei xiao yi	1
+可谓知乎	ke wei zhi hu	1
+可谓知矣	ke wei zhi yi	1
+客喜而笑	ke xi er xiao	1
+可惜一溪风月	ke xi yi xi feng yue	1
+可下五洋捉鳖	ke xia wu yang zhuo bie	1
+客心何事转凄然	ke xin he shi zhuan qi ran	1
+客心洗流水	ke xin xi liu shui	1
+客心争日月	ke xin zheng ri yue	1
+可言可意	ke yan ke yi	1
+可以保身	ke yi bao shen	1
+可以长久	ke yi chang jiu	1
+可以攻玉	ke yi gong yu	1
+可以横绝峨眉巅	ke yi heng jue e mei dian	1
+可以寄百里之命	ke yi ji bai li zhi ming	1
+可以荐嘉客	ke yi jian jia ke	1
+可以解忧	ke yi jie you	1
+可以尽年	ke yi jin nian	1
+可以全生	ke yi quan sheng	1
+刻意伤春复伤别	ke yi shang chun fu shang bie	1
+可以使能	ke yi shi neng	1
+可以仕则仕	ke yi shi ze shi	1
+可以托六尺之孤	ke yi tuo liu chi zhi gu	1
+可以为错	ke yi wei cuo	1
+可以为难矣	ke yi wei nan yi	1
+可以无大过矣	ke yi wu da guo yi	1
+可以无悔矣	ke yi wu hui yi	1
+可以休兮	ke yi xiu xi	1
+可以养亲	ke yi yang qin	1
+可以有国	ke yi you guo	1
+可以语上也	ke yi yu shang ye	1
+可以止则止	ke yi zhi ze zhi	1
+可以濯我缨	ke yi zhuo wo ying	1
+可以濯我足	ke yi zhuo wo zu	1
+可以卒千年	ke yi zu qian nian	1
+客有吹洞箫者	ke you chui dong xiao zhe	1
+可与共学	ke yu gong xue	1
+可与适道	ke yu shi dao	1
+柯原	ke yuan	1
+可者与之	ke zhe yu zhi	1
+客至	ke zhi	1
+客中行	ke zhong hang	1
+克终者盖寡	ke zhong zhe gai gua	1
+肯数邺下黄须儿	ken shu ye xia huang xu er	1
+肯与邻翁相对饮	ken yu lin weng xiang dui yin	1
+空悲昔人有	kong bei xi ren you	1
+空悲远游子	kong bei yuan you zi	1
+恐不任我意	kong bu ren wo yi	1
+空城澹月华	kong cheng dan yue hua	1
+空城雀	kong cheng que	1
+空持罗带	kong chi luo dai	1
+空床难独守	kong chuang nan du shou	1
+恐此事非奇	kong ci shi fei qi	1
+空翠落庭阴	kong cui luo ting yin	1
+空翠烟霏	kong cui yan fei	1
+孔德绍	kong de shao	1
+孔德之容	kong de zhi rong	1
+空洞无一物	kong dong wu yi wu	1
+恐非平生魂	kong fei ping sheng hun	1
+空歌易水寒	kong ge yi shui han	1
+空故纳万境	kong gu na wan jing	1
+箜篌曲	kong hou qu	1
+箜篌谣	kong hou yao	1
+恐皇舆之败绩	kong huang yu zhi bai ji	1
+空见葡萄入汉家	kong jian pu tao ru han jia	1
+恐结他生里	kong jie ta sheng li	1
+孔矩	kong ju	1
+空觉极圆	kong jue ji yuan	1
+空空如也	kong kong ru ye	1
+空劳流水声	kong lao liu shui sheng	1
+空令岁月易蹉跎	kong ling sui yue yi cuo tuo	1
+恐美人之迟暮	kong mei ren zhi chi mu	1
+孔明庙前有老柏	kong ming miao qian you lao bai	1
+恐年岁之不吾与	kong nian sui zhi bu wu yu	1
+孔平仲	kong ping zhong	1
+孔雀东飞何处栖	kong que dong fei he chu qi	1
+空山百鸟散还合	kong shan bai niao san hai he	1
+空山秋气清	kong shan qiu qi qing	1
+空山松子落	kong shan song zi luo	1
+空山啼夜猿	kong shan ti ye yuan	1
+孔绍安	kong shao an	1
+恐是汉代韩张良	kong shi han dai han zhang liang	1
+空水共氤氲	kong shui gong yin yun	1
+空王应念我	kong wang ying nian wo	1
+空闻虎旅传宵柝	kong wen hu lv chuan xiao tuo	1
+空闻子夜鬼悲歌	kong wen zi ye gui bei ge	1
+孔武有力	kong wu you li	1
+空向秋波哭逝川	kong xiang qiu bo ku shi chuan	1
+空烟迷雨色	kong yan mi yu se	1
+孔夷	kong yi	1
+空忆谢将军	kong yi xie jiang jun	1
+空有当年旧烟月	kong you dang nian jiu yan yue	1
+空有羡鱼情	kong you xian yu qing	1
+空余泪痕	kong yu lei hen	1
+空园白露滴	kong yuan bai lu di	1
+空知返旧林	kong zhi fan jiu lin	1
+孔稚圭	kong zhi gui	1
+空中闻天鸡	kong zhong wen tian ji	1
+孔子不见	kong zi bu jian	1
+孔子辞以疾	kong zi ci yi ji	1
+孔子对曰	kong zi dui yue	1
+孔子观于吕梁	kong zi guan yu lv liang	1
+孔子过之	kong zi guo zhi	1
+孔子沐浴而朝	kong zi mu yu er chao	1
+孔子师郯子	kong zi shi tan zi	1
+孔子谓季氏	kong zi wei ji shi	1
+孔子闻之	kong zi wen zhi	1
+孔子西行不到秦	kong zi xi xing bu dao qin	1
+孔子于乡党	kong zi yu xiang dang	1
+寇泚	kou ci	1
+口道恒河沙复沙	kou dao heng he sha fu sha	1
+叩关而攻秦	kou guan er gong qin	1
+扣关无僮仆	kou guan wu tong pu	1
+口角流沫右手胝	kou jue liu mo you shou zhi	1
+扣门无犬吠	kou men wu quan fei	1
+口如含朱丹	kou ru han zhu dan	1
+扣舷而歌之	kou xian er ge zhi	1
+寇埴	kou zhi	1
+寇准	kou zhun	1
+哭晁卿衡	ku chao qing heng	1
+苦道来不易	ku dao lai bu yi	1
+苦含情	ku han qing	1
+枯木怪石图	ku mu guai shi tu	1
+枯木朽株齐努力	ku mu xiu zhu qi nu li	1
+苦情重诉	ku qing zhong su	1
+枯桑老柏寒飕飗	ku sang lao bai han sou liu	1
+哭声直上干云霄	ku sheng zhi shang gan yun xiao	1
+枯松倒挂倚绝壁	ku song dao gua yi jue bi	1
+枯松倒涧壑	ku song dao jian he	1
+酷相思	ku xiang si	1
+苦心岂免容蝼蚁	ku xin qi mian rong lou yi	1
+哭宣城善酿纪叟	ku xuan cheng shan niang ji sou	1
+枯鱼过河泣	ku yu guo he qi	1
+苦雨终风也解晴	ku yu zhong feng ye jie qing	1
+跨海斩长鲸	kua hai zhan chang jing	1
+跨马出郊时极目	kua ma chu jiao shi ji mu	1
+脍不厌细	kuai bu yan xi	1
+快活年	kuai huo nian	1
+快活三	kuai huo san	1
+会稽愚妇轻买臣	kuai ji yu fu qing mai chen	1
+快剑砍断生蛟鼍	kuai jian kan duan sheng jiao tuo	1
+快马加鞭未下鞍	kuai ma jia bian wei xia an	1
+块石枕头	kuai shi zhen tou	1
+快哉亭作	kuai zai ting zuo	1
+宽厚而爱人	kuan hou er ai ren	1
+宽心应是酒	kuan xin ying shi jiu	1
+旷安宅而弗居	kuang an zhai er fu ju	1
+狂飙为我从天落	kuang biao wei wo cong tian luo	1
+况臣孤苦	kuang chen gu ku	1
+狂而不直	kuang er bu zhi	1
+狂风暴雨终摧折	kuang feng bao yu zhong cui zhe	1
+狂风吹我心	kuang feng chui wo xin	1
+狂风挽断最长条	kuang feng wan duan zui chang tiao	1
+狂夫富贵在青春	kuang fu fu gui zai qing chun	1
+况复秦兵耐苦战	kuang fu qin bing nai ku zhan	1
+狂歌五柳前	kuang ge wu liu qian	1
+匡衡抗疏功名薄	kuang heng kang shu gong ming bo	1
+况爵禄乎	kuang jue lu hu	1
+狂客归舟逸兴多	kuang ke gui zhou yi xing duo	1
+狂来轻世界	kuang lai qing shi jie	1
+匡庐一带不停留	kuang lu yi dai bu ting liu	1
+况乃未休兵	kuang nai wei xiu bing	1
+匡山读书处	kuang shan du shu chu	1
+况是蔡家亲	kuang shi cai jia qin	1
+况是青春日将暮	kuang shi qing chun ri jiang mu	1
+况属高风晚	kuang shu gao feng wan	1
+狂童之狂也且	kuang tong zhi kuang ye qie	1
+旷兮其若谷	kuang xi qi ruo gu	1
+况余白首	kuang yu bai shou	1
+旷哉至人心	kuang zai zhi ren xin	1
+狂者进取	kuang zhe jin qu	1
+匡之直之	kuang zhi zhi zhi	1
+狂醉	kuang zui	1
+夔府孤城落日斜	kui fu gu cheng luo ri xie	1
+窥见室家之好	kui jian shi jia zhi hao	1
+傀儡吟	kui lei yin	1
+窥室惟案几	kui shi wei an ji	1
+困而不学	kun er bu xue	1
+困而学之	kun er xue zhi	1
+昆鸡长笑老鹰非	kun ji chang xiao lao ying fei	1
+昆明池	kun ming chi	1
+鲲鹏水击三千里	kun peng shui ji san qian li	1
+鲲鹏展翅	kun peng zhan chi	1
+喇叭声咽	la ba sheng yan	1
+腊梅花	la mei hua	1
+腊梅香	la mei xiang	1
+蜡照半笼金翡翠	la zhao ban long jin fei cui	1
+来当婀娜时	lai dang e nuo shi	1
+来对白头吟	lai dui bai tou yin	1
+来而记之者已少	lai er ji zhi zhe yi shao	1
+来鹄	lai hu	1
+来即我谋	lai ji wo mou	1
+来来去去如风卷	lai lai qu qu ru feng juan	1
+来去九江侧	lai qu jiu jiang ce	1
+来日大难	lai ri da nan	1
+来日犹可追	lai ri you ke zhui	1
+来如雷霆收震怒	lai ru lei ting shou zhen nu	1
+来世不可待	lai shi bu ke dai	1
+来是空言去绝踪	lai shi kong yan qu jue zong	1
+来试人间第二泉	lai shi ren jian di er quan	1
+来时万里同为客	lai shi wan li tong wei ke	1
+来途若梦行	lai tu ruo meng xing	1
+来往不逢人	lai wang bu feng ren	1
+来往预期程	lai wang yu qi cheng	1
+赖问空门知气味	lai wen kong men zhi qi wei	1
+来吾导夫先路	lai wu dao fu xian lu	1
+赖以拄其间	lai yi zhu qi jian	1
+来者复为谁	lai zhe fu wei shui	1
+赖兹托令门	lai zi tuo ling men	1
+兰桂芳	lan gui fang	1
+懒画眉	lan hua mei	1
+烂嚼红茸	lan jiao hong rong	1
+兰陵美酒郁金香	lan ling mei jiu yu jin xiang	1
+揽裙脱丝履	lan qun tuo si lv	1
+兰若生春夏	lan re sheng chun xia	1
+蓝水远从千涧落	lan shui yuan cong qian jian luo	1
+懒堂女子	lan tang nv zi	1
+蓝田日暖玉生烟	lan tian ri nuan yu sheng yan	1
+兰叶春葳蕤	lan ye chun wei rui	1
+揽衣推枕起徘徊	lan yi tui zhen qi pai huai	1
+兰之猗猗	lan zhi yi yi	1
+狼跋	lang ba	1
+狼跋其胡	lang ba qi hu	1
+浪打天门石壁开	lang da tian men shi bi kai	1
+浪花有意千里雪	lang hua you yi qian li xue	1
+浪里来煞	lang li lai sha	1
+廊深阁迥此徘徊	lang shen ge jiong ci pai huai	1
+郎士元	lang shi yuan	1
+浪淘沙北戴河	lang tao sha bei dai he	1
+浪淘沙令	lang tao sha ling	1
+浪下三吴起白烟	lang xia san wu qi bai yan	1
+浪笑榴花不及春	lang xiao liu hua bu ji chun	1
+郎亦坏人心	lang yi huai ren xin	1
+浪自生百忧	lang zi sheng bai you	1
+老病有孤舟	lao bing you gu zhou	1
+老大意转拙	lao da yi zhuan zhuo	1
+老而不死	lao er bu si	1
+老而无夫曰寡	lao er wu fu yue gua	1
+劳而无功	lao er wu gong	1
+劳光彩	lao guang cai	1
+劳苦而功高如此	lao ku er gong gao ru ci	1
+劳劳送客亭	lao lao song ke ting	1
+劳劳亭	lao lao ting	1
+劳力者治於人	lao li zhe zhi yu ren	1
+老年花似雾中看	lao nian hua si wu zhong kan	1
+老妻画纸为棋局	lao qi hua zhi wei qi ju	1
+老去悲秋强自宽	lao qu bei qiu qiang zi kuan	1
+老去恋明时	lao qu lian ming shi	1
+老人七十仍沽酒	lao ren qi shi reng gu jiu	1
+老僧已死成新塔	lao seng yi si cheng xin ta	1
+劳生有限	lao sheng you xian	1
+老使我怨	lao shi wo yuan	1
+劳心悄兮	lao xin qiao xi	1
+老忧王室泣铜驼	lao you wang shi qi tong tuo	1
+老者安之	lao zhe an zhi	1
+老者衣帛食肉	lao zhe yi bo shi rou	1
+老至居人下	lao zhi ju ren xia	1
+劳之来之	lao zhi lai zhi	1
+乐彼之园	le bi zhi yuan	1
+乐道人之善	le dao ren zhi shan	1
+乐多贤友	le duo xian you	1
+乐而不淫	le er bu yin	1
+乐观态度	le guan tai du	1
+乐国乐国	le guo yue guo	1
+乐极哀来月东出	le ji ai lai yue dong chu	1
+乐郊乐郊	le jiao le jiao	1
+乐令	le ling	1
+乐民之乐者	le min zhi le zhe	1
+乐其可知也	le qi ke zhi ye	1
+乐且有仪	le qie you yi	1
+乐然后笑	le ran hou xiao	1
+乐世	le shi	1
+乐岁终身饱	le sui zhong shen bao	1
+乐岁终身苦	le sui zhong shen ku	1
+乐土乐土	le tu le tu	1
+乐婉	le wan	1
+乐以忘忧	le yi wang you	1
+乐亦在其中	le yi zai qi zhong	1
+乐亦在其中矣	le yi zai qi zhong yi	1
+乐游春苑断肠天	le you chun yuan duan chang tian	1
+乐幽心屡止	le you xin lv zhi	1
+乐游原上清秋节	le you yuan shang qing qiu jie	1
+乐游原上望昭陵	le you yuan shang wang zhao ling	1
+乐云乐云	le yun le yun	1
+乐只君子	le zhi jun zi	1
+泪飞顿作倾盆雨	lei fei dun zuo qing pen yu	1
+雷鼓动山川	lei gu dong shan chuan	1
+泪痕消夜烛	lei hen xiao ye zhu	1
+泪红云	lei hong yun	1
+磊磊落落桃花结	lei lei luo luo tao hua jie	1
+泪落连珠子	lei luo lian zhu zi	1
+雷霆走精锐	lei ting zou jing rui	1
+泪向客中多	lei xiang ke zhong duo	1
+泪亦不能为之堕	lei yi bu neng wei zhi duo	1
+类与不类	lei yu bu lei	1
+酹月	lei yue	1
+泪珠和笔墨齐下	lei zhu he bi mo qi xia	1
+冷处偏佳	leng chu pian jia	1
+冷翠烛	leng cui zhu	1
+冷灰残烛动离情	leng hui can zhu dong li qing	1
+冷冥冥	leng ming ming	1
+冷溶溶	leng rong rong	1
+冷笑置之而已	leng xiao zhi zhi er yi	1
+冷烟和月	leng yan he yue	1
+冷眼向洋看世界	leng yan xiang yang kan shi jie	1
+冷朝阳	leng zhao yang	1
+李百药	li bai yao	1
+李白一斗诗百篇	li bai yi dou shi bai pian	1
+离杯惜共传	li bei xi gong chuan	1
+李壁	li bi	1
+离别何足叹	li bie he zu tan	1
+离别正堪悲	li bie zheng kan bei	1
+李搏	li bo	1
+李播	li bo	1
+李渤	li bo	1
+李伯虎	li bo hu	1
+立不中门	li bu zhong men	1
+力不足也	li bu zu ye	1
+力不足者	li bu zu zhe	1
+李岑	li cen	1
+李曾伯	li ceng bo	1
+李昌符	li chang fu	1
+李昌邺	li chang ye	1
+李朝卿	li chao qing	1
+李澄之	li cheng zhi	1
+李赤	li chi	1
+李持正	li chi zheng	1
+李处全	li chu quan	1
+李从善	li cong shan	1
+李从远	li cong yuan	1
+李从周	li cong zhou	1
+李得	li de	1
+立德明道	li de ming dao	1
+李德润	li de run	1
+李憕	li deng	1
+立登要路津	li deng yao lu jin	1
+李洞	li dong	1
+李端	li duan	1
+立而饮之	li er yin zhi	1
+黎逢	li feng	1
+李逢吉	li feng ji	1
+李福业	li fu ye	1
+李甘	li gan	1
+骊歌一叠	li ge yi die	1
+李肱	li gong	1
+李广无功缘数奇	li guang wu gong yuan shu qi	1
+李瀚	li han	1
+李行言	li hang yan	1
+李好古	li hao gu	1
+李好义	li hao yi	1
+李何	li he	1
+李和风	li he feng	1
+离恨空随江水长	li hen kong sui jiang shui chang	1
+李侯有佳句	li hou you jia ju	1
+梨花白雪香	li hua bai xue xiang	1
+梨花淡白柳深青	li hua dan bai liu shen qing	1
+李花开	li hua kai	1
+梨花满地不开门	li hua man di bu kai men	1
+梨花千树雪	li hua qian shu xue	1
+李怀远	li huai yuan	1
+李回	li hui	1
+理会是非遣	li hui shi fei qian	1
+李姬传	li ji chuan	1
+李季萼	li ji e	1
+李季华	li ji hua	1
+李季兰	li ji lan	1
+李家明	li jia ming	1
+李嘉佑	li jia you	1
+李嘉祐	li jia you	1
+李建枢	li jian shu	1
+李建勋	li jian xun	1
+李绛	li jiang	1
+李结	li jie	1
+李节	li jie	1
+力尽关山未解围	li jin guan shan wei jie wei	1
+历尽天华成此景	li jin tian hua cheng ci jing	1
+李谨言	li jin yan	1
+李景伯	li jing bo	1
+李敬方	li jing fang	1
+李景俭	li jing jian	1
+李景良	li jing liang	1
+李景让	li jing rang	1
+李敬玄	li jing xuan	1
+李敬则	li jing ze	1
+李迥秀	li jiong xiu	1
+李玖	li jiu	1
+李九龄	li jiu ling	1
+李居仁	li ju ren	1
+李君行	li jun xing	1
+李伉	li kang	1
+李康成	li kang cheng	1
+李克恭	li ke gong	1
+吏课升斗积	li ke sheng dou ji	1
+离苦海	li ku hai	1
+李夔	li kui	1
+力困衰怠竭	li kun shuai dai jie	1
+李廓	li kuo	1
+历览前贤国与家	li lan qian xian guo yu jia	1
+历历开元事	li li kai yuan shi	1
+历历历历开元事	li li li li kai yuan shi	1
+李谅	li liang	1
+李令	li ling	1
+李隆基	li long ji	1
+离鸾	li luan	1
+离鸾别凤烟梧中	li luan bie feng yan wu zhong	1
+李吕	li lv	1
+李昴英	li mao ying	1
+李梦符	li meng fu	1
+李秘	li mi	1
+黎民不饥不寒	li min bu ji bu han	1
+李溟	li ming	1
+李明远	li ming yuan	1
+李鼐	li nai	1
+李南金	li nan jin	1
+力排南山三壮士	li pai nan shan san zhuang shi	1
+李彭	li peng	1
+李频	li pin	1
+李朴	li pu	1
+李颀	li qi	1
+李栖筠	li qi jun	1
+李潜	li qian	1
+李峤	li qiao	1
+李清臣	li qing chen	1
+离情终日思风波	li qing zhong ri si feng bo	1
+李璆	li qiu	1
+李衢	li qu	1
+鲤趋而过庭	li qu er guo ting	1
+李群玉	li qun yu	1
+里仁第四	li ren di si	1
+丽人行	li ren xing	1
+李日新	li ri xin	1
+李如璧	li ru bi	1
+骊山北构而西折	li shan bei gou er xi zhe	1
+李山甫	li shan fu	1
+李商英	li shang ying	1
+李韶	li shao	1
+利涉	li she	1
+吏舍局终年	li she ju zhong nian	1
+李深	li shen	1
+李绅	li shen	1
+栗深林兮惊层巅	li shen lin xi jing ceng dian	1
+李石才	li shi cai	1
+李世民	li shi min	1
+李士元	li shi yuan	1
+李适之	li shi zhi	1
+李氏子蟠	li shi zi pan	1
+李收	li shou	1
+李纾	li shu	1
+李叔霁	li shu ji	1
+李斯税驾苦不早	li si shui jia ku bu zao	1
+李竦	li song	1
+李太玄	li tai xuan	1
+李坦然	li tan ran	1
+离堂思琴瑟	li tang si qin se	1
+李体仁	li ti ren	1
+李天骥	li tian ji	1
+离天三尺三	li tian san chi san	1
+立天下之正位	li tian xia zhi zheng wei	1
+历天又入海	li tian you ru hai	1
+黎廷瑞	li ting rui	1
+离亭宴	li ting yan	1
+离亭燕	li ting yan	1
+鲤退而学礼	li tui er xue li	1
+鲤退而学诗	li tui er xue shi	1
+李汶儒	li wen ru	1
+李渥	li wo	1
+李习	li xi	1
+李希仲	li xi zhong	1
+李暇	li xia	1
+李咸	li xian	1
+李岘	li xian	1
+李咸用	li xian yong	1
+离形去知	li xing qu zhi	1
+李序	li xu	1
+李续	li xu	1
+李宣古	li xuan gu	1
+李宣远	li xuan yuan	1
+李旬	li xun	1
+李询	li xun	1
+李延陵	li yan ling	1
+溧阳公主年十四	li yang gong zhu nian shi si	1
+李曜	li yao	1
+李冶	li ye	1
+李邺	li ye	1
+李乂	li yi	1
+李亿	li yi	1
+李嶷	li yi	1
+李益	li yi	1
+李义府	li yi fu	1
+礼以行之	li yi xing zhi	1
+李婴	li ying	1
+李郢	li ying	1
+理莹	li ying	1
+李幼卿	li you qing	1
+李屿	li yu	1
+李羽	li yu	1
+李虞	li yu	1
+厉与西施	li yu xi shi	1
+李玉箫	li yu xiao	1
+李愿	li yuan	1
+李元纮	li yuan hong	1
+李元嘉	li yuan jia	1
+李元卓	li yuan zhuo	1
+梨园子弟白发新	li yuan zi di bai fa xin	1
+梨园子弟散如烟	li yuan zi di san ru yan	1
+礼云礼云	li yun li yun	1
+李赞华	li zan hua	1
+李漳	li zhang	1
+李章武	li zhang wu	1
+李拯	li zheng	1
+李正封	li zheng feng	1
+李骘	li zhi	1
+礼之端也	li zhi duan ye	1
+历职郎署	li zhi lang shu	1
+李之问	li zhi wen	1
+荔枝香近	li zhi xiang jin	1
+李仲光	li zhong guang	1
+李昼	li zhou	1
+李胄	li zhou	1
+利洲南渡	li zhou nan du	1
+李子卿	li zi qing	1
+李子申	li zi shen	1
+李子酉	li zi you	1
+李子正	li zi zheng	1
+李宗闵	li zong min	1
+怜薄命	lian bo ming	1
+联步趋丹陛	lian bu qu dan bi	1
+连昌宫词	lian chang gong ci	1
+炼丹砂	lian dan sha	1
+怜蛾不点灯	lian e bu dian deng	1
+廉而不刿	lian er bu gui	1
+连峰去天不盈尺	lian feng qu tian bu ying chi	1
+敛尽春山羞不语	lian jin chun shan xiu bu yu	1
+帘旌不动夕阳迟	lian jing bu dong xi yang chi	1
+怜君何事到天涯	lian jun he shi dao tian ya	1
+帘幕重重	lian mu chong chong	1
+脸腻香薰似有情	lian ni xiang xun si you qing	1
+恋情深	lian qing shen	1
+连山接海隅	lian shan jie hai yu	1
+连山起烟雾	lian shan qi yan wu	1
+连山若波涛	lian shan ruo bo tao	1
+连山晚照红	lian shan wan zhao hong	1
+莲生淤泥中	lian sheng yu ni zhong	1
+廉氏	lian shi	1
+帘外春寒赐锦袍	lian wai chun han ci jin pao	1
+恋香衾	lian xiang qin	1
+连云开甲宅	lian yun kai jia zhai	1
+连枝理	lian zhi li	1
+连诸侯者次之	lian zhu hou zhe ci zhi	1
+两岸桃花夹古津	liang an tao hua jia gu jin	1
+两岸猿声啼不尽	liang an yuan sheng ti bu jin	1
+良宝终见弃	liang bao zhong jian qi	1
+两别泣不休	liang bie qi bu xiu	1
+两不见	liang bu jian	1
+两草犹一心	liang cao you yi xin	1
+良辰未必有佳期	liang chen wei bi you jia qi	1
+两处滴池水	liang chu di chi shui	1
+梁大年	liang da nian	1
+梁德裕	liang de yu	1
+凉簟碧纱厨	liang dian bi sha chu	1
+凉风吹夜雨	liang feng chui ye yu	1
+凉风起天末	liang feng qi tian mo	1
+凉风日潇洒	liang feng ri xiao sa	1
+凉风只在殿西头	liang feng zhi zai dian xi tou	1
+梁父吟	liang fu yin	1
+梁甫吟	liang fu yin	1
+梁父吟成恨有馀	liang fu yin cheng hen you yu	1
+两汉乐府	liang han yue fu	1
+梁惠王曰	liang hui wang yue	1
+梁惠王章句上	liang hui wang zhang ju shang	1
+梁惠王章句下	liang hui wang zhang ju xia	1
+两家求合葬	liang jia qiu he zang	1
+良家子	liang jia zi	1
+梁间燕子闻长叹	liang jian yan zi wen chang tan	1
+两口不团圆	liang kou bu tuan yuan	1
+梁令	liang ling	1
+良庖岁更刀	liang pao sui geng dao	1
+梁洽	liang qia	1
+良人罢远征	liang ren ba yuan zheng	1
+两人对酌山花开	liang ren dui zhuo shan hua kai	1
+良人玉勒乘骢马	liang ren yu le cheng cong ma	1
+良人昨夜情	liang ren zuo ye qing	1
+两三星火是瓜州	liang san xing huo shi gua zhou	1
+两水夹明镜	liang shui jia ming jing	1
+凉思	liang si	1
+两同心	liang tong xin	1
+梁献	liang xian	1
+良相头上进贤冠	liang xiang tou shang jin xian guan	1
+良宵盛会喜空前	liang xiao sheng hui xi kong qian	1
+两小无嫌猜	liang xiao wu xian cai	1
+两心相照	liang xin xiang zhao	1
+梁铉	liang xuan	1
+梁园日暮乱飞鸦	liang yuan ri mu luan fei ya	1
+梁园吟	liang yuan yin	1
+两月共半边	liang yue gong ban bian	1
+凉月如眉挂柳湾	liang yue ru mei gua liu wan	1
+梁震	liang zhen	1
+凉州胡人为我吹	liang zhou hu ren wei wo chui	1
+梁州令	liang zhou ling	1
+梁州梦	liang zhou meng	1
+聊持宝剑动星文	liao chi bao jian dong xing wen	1
+料得年年断肠处	liao de nian nian duan chang chu	1
+辽东小妇年十五	liao dong xiao fu nian shi wu	1
+蓼莪	liao e	1
+聊厚不为薄	liao hou bu wei bo	1
+聊可与娱	liao ke yu yu	1
+寥廓江天万里霜	liao kuo jiang tian wan li shuang	1
+聊乐我员	liao le wo yuan	1
+寥落悲前事	liao luo bei qian shi	1
+寥落古行宫	liao luo gu xing gong	1
+寥落寒山对虚牖	liao luo han shan dui xu you	1
+廖凝	liao ning	1
+聊书所怀	liao shu suo huai	1
+蓼萧	liao xiao	1
+廖行之	liao xing zhi	1
+廖有方	liao you fang	1
+烈风无时休	lie feng wu shi xiu	1
+列国自有疆	lie guo zi you jiang	1
+列郡讴歌惜	lie jun ou ge xi	1
+烈女操	lie nv cao	1
+列缺霹雳	lie que pi li	1
+裂缺霹雳	lie que pi li	1
+列传七十	lie zhuan qi shi	1
+林表民	lin biao min	1
+林表明霁色	lin biao ming ji se	1
+林楚翘	lin chu qiao	1
+林淳	lin chun	1
+临春风	lin chun feng	1
+临洞庭	lin dong ting	1
+林断山明竹隐墙	lin duan shan ming zhu yin qiang	1
+林璠	lin fan	1
+林放问礼之本	lin fang wen li zhi ben	1
+临风怀谢公	lin feng huai xie gong	1
+临风听暮蝉	lin feng ting mu chan	1
+临感忽难收	lin gan hu nan shou	1
+临高台	lin gao tai	1
+林革	lin ge	1
+邻国相望	lin guo xiang wang	1
+邻国之民不加少	lin guo zhi min bu jia shao	1
+林花发岸口	lin hua fa an kou	1
+林花扫更落	lin hua sao geng luo	1
+林回弃千金之璧	lin hui qi qian jin zhi bi	1
+林昏瘴不开	lin hun zhang bu kai	1
+临江王节士歌	lin jiang wang jie shi ge	1
+林宽	lin kuan	1
+林琨	lin kun	1
+临流驻归驾	lin liu zhu gui jia	1
+临路歌	lin lu ge	1
+临洛水	lin luo shui	1
+林茂鸟知归	lin mao niao zhi gui	1
+林栖见羽毛	lin qi jian yu mao	1
+临其穴	lin qi xue	1
+邻人满墙头	lin ren man qiang tou	1
+临人以德	lin ren yi de	1
+临丧不哀	lin sang bu ai	1
+林深无人鸟相呼	lin shen wu ren niao xiang hu	1
+林嵩	lin song	1
+林外	lin wai	1
+林卧愁春尽	lin wo chou chun jin	1
+林下何须远借问	lin xia he xu yuan jie wen	1
+临行一杯酒	lin xing yi bei jiu	1
+林珝	lin xu	1
+林仰	lin yang	1
+临颍美人在白帝	lin ying mei ren zai bai di	1
+林月低向后	lin yue di xiang hou	1
+林藻	lin zao	1
+麟之角	lin zhi jiao	1
+临之以庄则敬	lin zhi yi zhuang ze jing	1
+麟之趾	lin zhi zhi	1
+林滋	lin zi	1
+林自然	lin zi ran	1
+凌波曲	ling bo qu	1
+凌波微步有人愁	ling bo wei bu you ren chou	1
+凌波仙子生尘袜	ling bo xian zi sheng chen wa	1
+零丁孤苦	ling ding gu ku	1
+菱歌清唱不胜春	ling ge qing chang bu sheng chun	1
+令狐楚	ling hu chu	1
+令狐德棻	ling hu de fen	1
+令狐峘	ling hu huan	1
+令狐绹	ling hu tao	1
+令将军与臣有郤	ling jiang jun yu chen you xi	1
+零泪缘缨流	ling lei yuan ying liu	1
+泠泠彻夜	ling ling che ye	1
+泠泠七弦遍	ling ling qi xian bian	1
+泠泠七弦上	ling ling qi xian shang	1
+玲珑四犯	ling long si fan	1
+玲珑王	ling long wang	1
+玲珑望秋月	ling long wang qiu yue	1
+零露瀼瀼	ling lu rang rang	1
+零露漙兮	ling lu zhuan xi	1
+伶伦吹裂孤生竹	ling lun chui lie gu sheng zhu	1
+零落成泥辗作尘	ling luo cheng ni zhan zuo chen	1
+零落依草木	ling luo yi cao mu	1
+伶俜萦苦辛	ling ping ying ku xin	1
+泠青沼	ling qing zhao	1
+泠然善也	ling ran shan ye	1
+令人长号不自禁	ling ren chang hao bu zi jin	1
+令人发深省	ling ren fa shen xing	1
+令人行妨	ling ren xing fang	1
+领如蝤蛴	ling ru qiu qi	1
+岭色千重万重雨	ling se qian zhong wan chong yu	1
+灵山多秀色	ling shan duo xiu se	1
+岭上晴云披絮帽	ling shang qing yun pi xu mao	1
+岭树重遮千里目	ling shu zhong zhe qian li mu	1
+菱透浮萍绿锦池	ling tou fu ping lv jin chi	1
+岭外音书绝	ling wai yin shu jue	1
+凌万顷之茫然	ling wan qing zhi mang ran	1
+令行天下	ling xing tian xia	1
+凌烟功臣少颜色	ling yan gong chen shao yan se	1
+零雨其濛	ling yu qi meng	1
+岭猿同旦暮	ling yuan tong dan mu	1
+凌云健笔意纵横	ling yun jian bi yi zong heng	1
+灵准	ling zhun	1
+刘褒	liu bao	1
+柳边人歇待船归	liu bian ren xie dai chuan gui	1
+留别王侍御维	liu bie wang shi yu wei	1
+刘采春	liu cai chun	1
+柳曾	liu ceng	1
+刘叉	liu cha	1
+刘敞	liu chang	1
+刘长川	liu chang chuan	1
+柳长春	liu chang chun	1
+刘常卿	liu chang qing	1
+六朝文物草连空	liu chao wen wu cao lian kong	1
+刘崇龟	liu chong gui	1
+柳初新	liu chu xin	1
+流传汉地曲转奇	liu chuan han di qu zhuan qi	1
+刘大辨	liu da bian	1
+刘道昌	liu dao chang	1
+刘得仁	liu de ren	1
+刘洞	liu dong	1
+刘蕃	liu fan	1
+柳逢	liu feng	1
+刘复	liu fu	1
+刘阜	liu fu	1
+柳富	liu fu	1
+柳拂旌旗露未干	liu fu jing qi lu wei gan	1
+刘皋	liu gao	1
+刘耕	liu geng	1
+刘珙	liu gong	1
+柳公绰	liu gong chuo	1
+刘公兴	liu gong xing	1
+刘谷	liu gu	1
+柳挂九衢丝	liu gua jiu qu si	1
+柳含烟	liu han yan	1
+刘沆	liu hang	1
+榴花开欲然	liu hua kai yu ran	1
+刘晃	liu huang	1
+柳浑	liu hun	1
+刘几	liu ji	1
+刘洎	liu ji	1
+刘济	liu ji	1
+刘季孙	liu ji sun	1
+刘脊虚	liu ji xu	1
+刘驾	liu jia	1
+留家	liu jia	1
+刘兼	liu jian	1
+刘戬	liu jian	1
+刘鉴	liu jian	1
+刘将孙	liu jiang sun	1
+刘泾	liu jing	1
+刘景翔	liu jing xiang	1
+刘迥	liu jiong	1
+刘浚	liu jun	1
+刘均国	liu jun guo	1
+柳堪结	liu kan jie	1
+刘轲	liu ke	1
+刘克逊	liu ke xun	1
+留客住	liu ke zhu	1
+刘暌	liu kui	1
+刘廓	liu kuo	1
+刘郎已恨蓬山远	liu lang yi hen peng shan yuan	1
+浏漓顿挫	liu li dun cuo	1
+琉璃砚水长枯槁	liu li yan shui chang ku gao	1
+流离之子	liu li zhi zi	1
+留连光景惜朱颜	liu lian guang jing xi zhu yan	1
+流落征南将	liu luo zheng nan jiang	1
+柳绿更带朝烟	liu lv geng dai chao yan	1
+柳绿更带春烟	liu lv geng dai chun yan	1
+六麻	liu ma	1
+骝马新跨白玉鞍	liu ma xin kua bai yu an	1
+刘袤	liu mao	1
+六么序	liu me xu	1
+柳泌	liu mi	1
+流年一掷梭	liu nian yi zhi suo	1
+六盘山上高峰	liu pan shan shang gao feng	1
+刘錡	liu qi	1
+刘潜	liu qian	1
+六曲屏山和梦遥	liu qu ping shan he meng yao	1
+流入宫墙	liu ru gong qiang	1
+柳如丝	liu ru si	1
+刘三复	liu san fu	1
+柳色黄	liu se huang	1
+柳色黄金嫩	liu se huang jin nen	1
+柳色新	liu se xin	1
+刘商	liu shang	1
+柳梢春	liu shao chun	1
+刘慎虚	liu shen xu	1
+刘氏妇	liu shi fu	1
+刘使君	liu shi jun	1
+刘氏云	liu shi yun	1
+六十字	liu shi zi	1
+刘述	liu shu	1
+流水如有意	liu shui ru you yi	1
+流水十年间	liu shui shi nian jian	1
+流水通波接武冈	liu shui tong bo jie wu gang	1
+流水无情草自春	liu shui wu qing cao zi chun	1
+流水无心西复东	liu shui wu xin xi fu dong	1
+流俗之所轻也	liu su zhi suo qing ye	1
+刘损	liu sun	1
+刘太冲	liu tai chong	1
+刘太真	liu tai zhen	1
+刘坦	liu tan	1
+柳棠	liu tang	1
+刘焘	liu tao	1
+刘畋	liu tian	1
+刘天迪	liu tian di	1
+柳条藤蔓系离情	liu tiao teng wan xi li qing	1
+刘望	liu wang	1
+刘望之	liu wang zhi	1
+刘细君	liu xi jun	1
+刘希夷	liu xi yi	1
+刘宪	liu xian	1
+刘仙伦	liu xian lun	1
+刘象	liu xiang	1
+流响出疏桐	liu xiang chu shu tong	1
+刘向传经心事违	liu xiang chuan jing xin shi wei	1
+刘孝孙	liu xiao sun	1
+流星白羽腰间插	liu xing bai yu yao jian cha	1
+刘性初	liu xing chu	1
+刘行敏	liu xing min	1
+柳絮飞时别洛阳	liu xu fei shi bie luo yang	1
+柳絮飞时花满城	liu xu fei shi hua man cheng	1
+刘学箕	liu xue ji	1
+流血涂野草	liu xue tu ye cao	1
+刘学颜	liu xue yan	1
+柳亚子先生	liu ya zi xian sheng	1
+刘炎	liu yan	1
+刘言史	liu yan shi	1
+柳腰轻	liu yao qing	1
+刘邺	liu ye	1
+柳叶儿	liu ye er	1
+柳叶开时任好风	liu ye kai shi ren hao feng	1
+刘乙	liu yi	1
+刘夷道	liu yi dao	1
+六亿神州尽舜尧	liu yi shen zhou jin shun yao	1
+刘一止	liu yi zhi	1
+刘祎之	liu yi zhi	1
+六英	liu ying	1
+流莺漂荡复参差	liu ying piao dang fu cen ci	1
+刘应雄	liu ying xiong	1
+流影照明妃	liu ying zhao ming fei	1
+刘幽求	liu you qiu	1
+刘友贤	liu you xian	1
+六语	liu yu	1
+六鱼	liu yu	1
+刘元淑	liu yuan shu	1
+六月	liu yue	1
+六月徂暑	liu yue cu shu	1
+六月时	liu yue shi	1
+六月天兵征腐恶	liu yue tian bing zheng fu e	1
+柳恽	liu yun	1
+刘云甫	liu yun fu	1
+刘允济	liu yun ji	1
+刘赞	liu zan	1
+刘皂	liu zao	1
+流照伏波营	liu zhao fu bo ying	1
+刘昭禹	liu zhao yu	1
+刘之才	liu zhi cai	1
+柳枝秋	liu zhi qiu	1
+柳枝五首	liu zhi wu shou	1
+柳中庸	liu zhong yong	1
+刘舟	liu zhou	1
+留著舞衣中	liu zhu wu yi zhong	1
+刘子实	liu zi shi	1
+刘子玄	liu zi xuan	1
+柳宗元	liu zong yuan	1
+留醉与山翁	liu zui yu shan weng	1
+龙池柳色雨中深	long chi liu se yu zhong shen	1
+隆冬到来时	long dong dao lai shi	1
+泷冈阡表	long gang qian biao	1
+龙虎相啖食	long hu xiang dan shi	1
+龙媒去尽鸟呼风	long mei qu jin niao hu feng	1
+龙丘居士亦可怜	long qiu ju shi yi ke lian	1
+龙山会	long shan hui	1
+陇上羊归塞草烟	long shang yang gui sai cao yan	1
+龙腾凤集	long teng feng ji	1
+陇头泉	long tou quan	1
+陇头水	long tou shui	1
+陇头月	long tou yue	1
+陇头云	long tou yun	1
+龙衔宝盖承朝日	long xian bao gai cheng zhao ri	1
+龙吟虎啸一时发	long yin hu xiao yi shi fa	1
+龙吟曲	long yin qu	1
+陇云愁	long yun chou	1
+龙种自与常人殊	long zhong zi yu chang ren shu	1
+露白宵钟彻	lou bai xiao zhong che	1
+楼采	lou cai	1
+楼观沧海日	lou guan cang hai ri	1
+楼观岳阳尽	lou guan yue yang jin	1
+楼寒院冷接平明	lou han yuan leng jie ping ming	1
+楼兰斩未还	lou lan zhan wei huan	1
+楼前宫畔暮江流	lou qian gong pan mu jiang liu	1
+楼上花枝笑独眠	lou shang hua zhi xiao du mian	1
+楼上黄昏欲望休	lou shang huang hun yu wang xiu	1
+楼上曲	lou shang qu	1
+楼台成海气	lou tai cheng hai qi	1
+楼台深翠微	lou tai shen cui wei	1
+楼台与天通	lou tai yu tian tong	1
+楼头张丽华	lou tou zhang li hua	1
+楼倚霜树外	lou yi shuang shu wai	1
+楼颖	lou ying	1
+路隘林深苔滑	lu ai lin shen tai hua	1
+陆翱	lu ao	1
+卢藏用	lu cang yong	1
+露草覆寒虫	lu cao fu han chong	1
+陆长源	lu chang yuan	1
+卢储	lu chu	1
+路出寒云外	lu chu han yun wai	1
+鹭点烟汀	lu dian yan ting	1
+路逢斗鸡者	lu feng dou ji zhe	1
+路贯	lu guan	1
+六合正相应	lu he zheng xiang ying	1
+卢鸿一	lu hong yi	1
+露华	lu hua	1
+露华春慢	lu hua chun man	1
+芦花深处泊孤舟	lu hua shen chu bo gu zhou	1
+炉火照天地	lu huo zhao tian di	1
+路极河流远	lu ji he liu yuan	1
+卢家少妇郁金堂	lu jia shao fu yu jin tang	1
+卢家少妇郁金香	lu jia shao fu yu jin xiang	1
+陆坚	lu jian	1
+虏箭如沙射金甲	lu jian ru sha she jin jia	1
+陆敬	lu jing	1
+卢景亮	lu jing liang	1
+鲁酒薄而邯郸围	lu jiu bo er han dan wei	1
+鲁酒不可醉	lu jiu bu ke zui	1
+虏酒千钟不醉人	lu jiu qian zhong bu zui ren	1
+卢橘杨梅次第新	lu ju yang mei ci di xin	1
+卢钧	lu jun	1
+陆凯	lu kai	1
+鲁连特高妙	lu lian te gao miao	1
+卢令	lu ling	1
+辘轳金井	lu lu jin jing	1
+辘轳金井梧桐晚	lu lu jin jing wu tong wan	1
+卢纶	lu lun	1
+鹿门月照开烟树	lu men yue zhao kai yan shu	1
+鹿鸣之什	lu ming zhi shen	1
+路难思共济	lu nan si gong ji	1
+路旁时卖故侯瓜	lu pang shi mai gu hou gua	1
+卢骈	lu pian	1
+卢频	lu pin	1
+陆凭	lu ping	1
+虏骑崩腾畏蒺藜	lu qi beng teng wei ji li	1
+露气寒光集	lu qi han guang ji	1
+虏骑千重只似无	lu qi qian zhong zhi si wu	1
+鹿虔扆	lu qian yi	1
+卢群	lu qun	1
+卢汝弼	lu ru bi	1
+陆叡	lu rui	1
+虏塞兵气连云屯	lu sai bing qi lian yun tun	1
+庐山东南五老峰	lu shan dong nan wu lao feng	1
+庐山秀出南斗傍	lu shan xiu chu nan dou bang	1
+庐山谣	lu shan yao	1
+卢尚书	lu shang shu	1
+禄仕当随牒	lu shi dang sui die	1
+露湿晴花春殿香	lu shi qing hua chun dian xiang	1
+鲁收	lu shou	1
+渌水荡漾清猿啼	lu shui dang yang qing yuan ti	1
+渌水净素月	lu shui jing su yue	1
+卢思道	lu si dao	1
+录调	lu tiao	1
+卢文纪	lu wen ji	1
+卢渥	lu wo	1
+鲁无君子者	lu wu jun zi zhe	1
+卢象	lu xiang	1
+炉香闲袅凤凰儿	lu xiang xian niao feng huang er	1
+卢携	lu xie	1
+卢延让	lu yan rang	1
+卢殷	lu yin	1
+路远不可测	lu yuan bu ke ce	1
+陆蕴	lu yun	1
+禄在其中矣	lu zai qi zhong yi	1
+卢肇	lu zhao	1
+卢照邻	lu zhao lin	1
+卢真	lu zhen	1
+卢贞	lu zhen	1
+虏阵横北荒	lu zhen heng bei huang	1
+卢征	lu zheng	1
+露重飞难进	lu zhong fei nan jin	1
+卢注	lu zhu	1
+陆子	lu zi	1
+卢僎	lu zun	1
+乱蝉衰草小池塘	luan chan shuai cao xiao chi tang	1
+鸾刀缕切空纷纶	luan dao lv qie kong fen lun	1
+乱定几年归	luan ding ji nian gui	1
+鸾镜鸳衾两断肠	luan jing yuan qin liang duan chang	1
+栾清	luan qing	1
+乱入池中看不见	luan ru chi zhong kan bu jian	1
+乱山残雪夜	luan shan can xue ye	1
+乱山来蜀道	luan shan lai shu dao	1
+鸾翔凤翥众仙下	luan xiang feng zhu zhong xian xia	1
+乱烟笼碧砌	luan yan long bi qi	1
+銮舆迥出千门柳	luan yu jiong chu qian men liu	1
+乱云低薄暮	luan yun di bo mu	1
+乱云飞渡仍从容	luan yun fei du reng cong rong	1
+略陈固陋	lue chen gu lou	1
+略考其行事	lue kao qi xing shi	1
+略输文采	lue shu wen cai	1
+论功还欲请长缨	lun gong hai yu qing chang ying	1
+论画以形似	lun hua yi xing si	1
+论诗匡鼎来	lun shi kuang ding lai	1
+轮台城北旄头落	lun tai cheng bei mao tou luo	1
+轮台城头夜吹角	lun tai cheng tou ye chui jiao	1
+轮台子	lun tai zi	1
+论心何必先同调	lun xin he bi xian tong diao	1
+伦与物忘	lun yu wu wang	1
+落笔超群英	luo bi chao qun ying	1
+骆宾王	luo bin wang	1
+洛城一别四千里	luo cheng yi bie si qian li	1
+罗椿	luo chun	1
+落帆逗淮镇	luo fan dou huai zhen	1
+罗敷媚	luo fu mei	1
+罗浮山下梅花村	luo fu shan xia mei hua cun	1
+罗浮山下四时春	luo fu shan xia si shi chun	1
+罗唝曲	luo hong qu	1
+落花飞	luo hua fei	1
+落花飞雪何茫茫	luo hua fei xue he mang mang	1
+落花寂寂委青苔	luo hua ji ji wei qing tai	1
+落花狼藉酒阑珊	luo hua lang ji jiu lan shan	1
+落花落	luo hua luo	1
+落花如风吹	luo hua ru feng chui	1
+落花如有意	luo hua ru you yi	1
+落花时节读华章	luo hua shi jie du hua zhang	1
+落花踏尽游何处	luo hua ta jin you he chu	1
+落花盈我衣	luo hua ying wo yi	1
+落花犹似堕楼人	luo hua you si duo lou ren	1
+落花逐流水	luo hua zhu liu shui	1
+罗荐春香暖不知	luo jian chun xiang nuan bu zhi	1
+罗炯	luo jiong	1
+骆浚	luo jun	1
+罗立言	luo li yan	1
+珞珞如石	luo luo ru shi	1
+落梅风	luo mei feng	1
+罗虬	luo qiu	1
+罗让	luo rang	1
+落日楼台一笛风	luo ri lou tai yi di feng	1
+落日满秋山	luo ri man qiu shan	1
+落日平台上	luo ri ping tai shang	1
+落日平原秋草中	luo ri ping yuan qiu cao zhong	1
+落日五湖春	luo ri wu hu chun	1
+落日芜湖色	luo ri wu hu se	1
+落日心犹壮	luo ri xin you zhuang	1
+落日绣帘卷	luo ri xiu lian juan	1
+落日忆山中	luo ri yi shan zhong	1
+落日照大旗	luo ri zhao da qi	1
+罗绍威	luo shao wei	1
+络丝娘	luo si niang	1
+逻娑沙尘哀怨生	luo suo sha chen ai yuan sheng	1
+罗泰	luo tai	1
+络纬秋啼金井阑	luo wei qiu ti jin jing lan	1
+罗帷舒卷	luo wei shu juan	1
+罗帷送上七香车	luo wei song shang qi xiang che	1
+罗惜惜	luo xi xi	1
+罗珦	luo xiang	1
+罗袖动香香不已	luo xiu dong xiang xiang bu yi	1
+洛阳城东桃李花	luo yang cheng dong tao li hua	1
+洛阳春	luo yang chun	1
+洛阳东风几时来	luo yang dong feng ji shi lai	1
+洛阳访才子	luo yang fang cai zi	1
+洛阳陌	luo yang mo	1
+洛阳女	luo yang nv	1
+洛阳女儿对门居	luo yang nv er dui men ju	1
+洛阳女儿惜颜色	luo yang nv er xi yan se	1
+洛阳女儿行	luo yang nv er xing	1
+罗邺	luo ye	1
+落叶聚还散	luo ye ju hai san	1
+落叶满阶红不扫	luo ye man jie hong bu sao	1
+落叶满空山	luo ye man kong shan	1
+落叶秋风早	luo ye qiu feng zao	1
+落叶人何在	luo ye ren he zai	1
+落叶他乡树	luo ye ta xiang shu	1
+落叶添薪仰古槐	luo ye tian xin yang gu huai	1
+罗衣一此鉴	luo yi yi ci jian	1
+罗衣欲换更添香	luo yi yu huan geng tian xiang	1
+罗隐	luo yin	1
+落月	luo yue	1
+落月满屋梁	luo yue man wu liang	1
+罗织红纱	luo zhi hong sha	1
+吕本中	lv ben zhong	1
+绿窗明月在	lv chuang ming yue zai	1
+旅馆寒灯独不眠	lv guan han deng du bu mian	1
+旅馆无良伴	lv guan wu liang ban	1
+绿槐高柳咽新蝉	lv huai gao liu yan xin chan	1
+吕价	lv jia	1
+吕炅	lv jiong	1
+屡貌寻常行路人	lv mao xun chang xing lu ren	1
+旅美学者	lv mei xue zhe	1
+吕牧	lv mu	1
+吕南公	lv nan gong	1
+率疲弊之卒	lv pi bi zhi zu	1
+绿蒲向堪把	lv pu xiang kan ba	1
+闾丘晓	lv qiu xiao	1
+吕群	lv qun	1
+吕让	lv rang	1
+绿树青苔半夕阳	lv shu qing tai ban xi yang	1
+绿水环绕	lv shui huan rao	1
+绿水青山枉自多	lv shui qing shan wang zi duo	1
+绿水绕飞阁	lv shui rao fei ge	1
+绿水人家绕	lv shui ren jia rao	1
+旅宿	lv su	1
+吕同老	lv tong lao	1
+吕渭	lv wei	1
+吕渭老	lv wei lao	1
+吕温	lv wen	1
+吕希纯	lv xi chun	1
+绿兮衣兮	lv xi yi xi	1
+绿烟灭尽清辉发	lv yan mie jin qing hui fa	1
+旅雁向南飞	lv yan xiang nan fei	1
+绿杨结烟垂袅风	lv yang jie yan chui niao feng	1
+绿杨树下养精神	lv yang shu xia yang jing shen	1
+绿杨枝外尽汀洲	lv yang zhi wai jin ting zhou	1
+绿腰	lv yao	1
+旅夜书怀	lv ye shu huai	1
+绿意	lv yi	1
+吕颐浩	lv yi hao	1
+虑以下人	lv yi xia ren	1
+侣鱼虾而友麋鹿	lv yu xia er you mi lu	1
+绿云扰扰	lv yun rao rao	1
+屡憎于人	lv zeng yu ren	1
+旅枕梦残	lv zhen meng can	1
+履至尊而制六合	lv zhi zun er zhi lu he	1
+绿竹青青	lv zhu qing qing	1
+绿竹入幽径	lv zhu ru you jing	1
+绿竹猗猗	lv zhu yi yi	1
+马不进也	ma bu jin ye	1
+马戴	ma dai	1
+马逢	ma feng	1
+马怀素	ma huai su	1
+麻郎儿	ma lang er	1
+马令	ma ling	1
+马鸣风萧萧	ma ming feng xiao xiao	1
+马上黄金鞍	ma shang huang jin an	1
+马首向何处	ma shou xiang he chu	1
+马踏春泥半是花	ma ta chun ni ban shi hua	1
+马蹄声碎	ma ti sheng sui	1
+马天骥	ma tian ji	1
+马廷鸾	ma ting luan	1
+马衔边地雪	ma xian bian di xue	1
+马湘	ma xiang	1
+马萧萧	ma xiao xiao	1
+麻鞋见天子	ma xie jian tian zi	1
+马乂	ma yi	1
+马异	ma yi	1
+马邑龙堆路几千	ma yi long dui lu ji qian	1
+麻衣如雪	ma yi ru xue	1
+麻衣如雪一枝梅	ma yi ru xue yi zhi mei	1
+蚂蚁缘槐夸大国	ma yi yuan huai kua da guo	1
+马彧	ma yu	1
+马致恭	ma zhi gong	1
+马周	ma zhou	1
+马子严	ma zi yan	1
+迈陂塘	mai bei tang	1
+埋骨何须桑梓地	mai gu he xu sang zi di	1
+卖花声	mai hua sheng	1
+麦秀两岐	mai xiu liang qi	1
+满朝欢	man chao huan	1
+满川风月替人愁	man chuan feng yue ti ren chou	1
+满地芦花和我老	man di lu hua he wo lao	1
+漫江碧透	man jiang bi tou	1
+满江天	man jiang tian	1
+满街狼犬	man jie lang quan	1
+缦立远视	man li yuan shi	1
+慢令致期谓之贼	man ling zhi qi wei zhi zei	1
+满龙堆	man long dui	1
+满路花	man lu hua	1
+漫漫轻云露月光	man man qing yun lu yue guang	1
+满目悲生事	man mu bei sheng shi	1
+漫天皆白	man tian jie bai	1
+满庭花	man ting hua	1
+满庭霜	man ting shuang	1
+满眼蓬蒿共一丘	man yan peng hao gong yi qiu	1
+满院春	man yuan chun	1
+满园花	man yuan hua	1
+满园深浅色	man yuan shen qian se	1
+满座顽云拨不开	man zuo wan yun bo bu kai	1
+莽昆仑	mang kun lun	1
+忙里偷闲得几回	mang li tou xian de ji hui	1
+茫茫大梦中	mang mang da meng zhong	1
+茫茫江汉上	mang mang jiang han shang	1
+茫茫九派流中国	mang mang jiu pai liu zhong guo	1
+茫茫漫漫方自悲	mang mang man man fang zi bei	1
+芒芒然归	mang mang ran gui	1
+茫茫天地间	mang mang tian di jian	1
+莽莽万重山	mang mang wan chong shan	1
+氓之蚩蚩	mang zhi chi chi	1
+毛斑斑	mao ban ban	1
+毛并	mao bing	1
+貌恭而不心服	mao gong er bu xin fu	1
+茂陵不见封侯印	mao ling bu jian feng hou yin	1
+旄丘	mao qiu	1
+茅亭宿花影	mao ting su hua ying	1
+毛文锡	mao wen xi	1
+茅屋访孤僧	mao wu fang gu seng	1
+毛熙震	mao xi zhen	1
+毛血洒平芜	mao xue sa ping wu	1
+毛泽东	mao ze dong	1
+美成在久	mei cheng zai jiu	1
+梅窗	mei chuang	1
+眉黛夺将萱草色	mei dai duo jiang xuan cao se	1
+梅动雪前香	mei dong xue qian xiang	1
+没蕃故人	mei fan gu ren	1
+眉峰碧	mei feng bi	1
+美服患人指	mei fu huan ren zhi	1
+梅花词	mei hua ci	1
+梅花欢喜漫天雪	mei hua huan xi man tian xue	1
+梅花句	mei hua ju	1
+梅花开尽百花开	mei hua kai jin bai hua kai	1
+梅花满枝空断肠	mei hua man zhi kong duan chang	1
+梅花年后多	mei hua nian hou duo	1
+梅花引	mei hua yin	1
+梅娇	mei jiao	1
+美酒成都堪送老	mei jiu cheng du kan song lao	1
+美酒聊共挥	mei jiu liao gong hui	1
+美酒一杯声一曲	mei jiu yi bei sheng yi qu	1
+没来由	mei lai you	1
+梅岭三章	mei ling san zhang	1
+没马蹄	mei ma ti	1
+昧昧我思之	mei mei wo si zhi	1
+眉目艳皎月	mei mu yan jiao yue	1
+每念斯耻	mei nian si chi	1
+眉娘	mei niang	1
+梅弄影	mei nong ying	1
+梅坡	mei po	1
+美人病来遮面	mei ren bing lai zhe mian	1
+美人春	mei ren chun	1
+美人胡为隔秋水	mei ren hu wei ge qiu shui	1
+美人结长恨	mei ren jie chang hen	1
+美人娟娟隔秋水	mei ren juan juan ge qiu shui	1
+美人卷珠帘	mei ren juan zhu lian	1
+美人清江畔	mei ren qing jiang pan	1
+美人如花隔云端	mei ren ru hua ge yun duan	1
+美人天上落	mei ren tian shang luo	1
+美人兮美人	mei ren xi mei ren	1
+美人相并立琼轩	mei ren xiang bing li qiong xuan	1
+美人在时花满堂	mei ren zai shi hua man tang	1
+美人折向庭前过	mei ren zhe xiang ting qian guo	1
+美人之贻	mei ren zhi yi	1
+每日报平安	mei ri bao ping an	1
+每日江头尽醉归	mei ri jiang tou jin zui gui	1
+美如玉	mei ru yu	1
+梅蕊腊前破	mei rui la qian po	1
+梅圣俞诗集序	mei sheng yu shi ji xu	1
+媒妁之言	mei shuo zhi yan	1
+每岁烟花一万重	mei sui yan hua yi wan chong	1
+莓苔见履痕	mei tai jian lv hen	1
+美无度	mei wu du	1
+每下愈况	mei xia yu kuang	1
+梅雪飘裙	mei xue piao qun	1
+媚眼惟看宿鹭窠	mei yan wei kan su lu ke	1
+每有良朋	mei you liang peng	1
+梅月圆	mei yue yuan	1
+每至夕照低阴	mei zhi xi zhao di yin	1
+每至于族	mei zhi yu zu	1
+每逐青溪水	mei zhu qing xi shui	1
+梅子欲尝新	mei zi yu chang xin	1
+门对浙江潮	men dui zhe jiang chao	1
+门径俯清溪	men jing fu qing xi	1
+门临古陂曲	men lin gu bei qu	1
+门前迟行迹	men qian chi xing ji	1
+门前冷落车马稀	men qian leng luo che ma xi	1
+门前万竿竹	men qian wan gan zhu	1
+门前学种先生柳	men qian xue zhong xian sheng liu	1
+门人问曰	men ren wen yue	1
+扪参历井仰胁息	men shen li jing yang xie xi	1
+门外韩擒虎	men wai han qin hu	1
+门系钓鱼船	men xi diao yu chuan	1
+孟翱	meng ao	1
+孟宾于	meng bin yu	1
+孟迟	meng chi	1
+梦到故园多少路	meng dao gu yuan duo shao lu	1
+梦芙蓉	meng fu rong	1
+梦魂不到关山难	meng hun bu dao guan shan nan	1
+梦魂香	meng hun xiang	1
+孟简	meng jian	1
+梦江口	meng jiang kou	1
+猛将清九垓	meng jiang qing jiu gai	1
+猛将腰间大羽箭	meng jiang yao jian da yu jian	1
+孟郊	meng jiao	1
+梦井	meng jing	1
+孟敬子问之	meng jing zi wen zhi	1
+梦李白二首之二	meng li bai er shou zhi er	1
+梦李白二首之一	meng li bai er shou zhi yi	1
+朦胧树色隐昭阳	meng long shu se yin zhao yang	1
+孟启	meng qi	1
+孟球	meng qiu	1
+孟守	meng shou	1
+猛兽不据	meng shou bu ju	1
+孟孙问孝于我	meng sun wen xiao yu wo	1
+梦为远别啼难唤	meng wei yuan bie ti nan huan	1
+孟武伯问孝	meng wu bo wen xiao	1
+梦仙游	meng xian you	1
+孟翔	meng xiang	1
+梦行云	meng xing yun	1
+梦扬州	meng yang zhou	1
+孟懿子问孝	meng yi zi wen xiao	1
+梦饮酒者	meng yin jiu zhe	1
+梦游天姥吟留别	meng you tian mu yin liu bie	1
+孟云卿	meng yun qing	1
+梦泽悲风动白茅	meng ze bei feng dong bai mao	1
+孟之反不伐	meng zhi fan bu fa	1
+孟子对曰	meng zi dui yue	1
+孟子见梁襄王	meng zi jian liang xiang wang	1
+孟子将朝王	meng zi jiang chao wang	1
+孟子去齐	meng zi qu qi	1
+孟子谓齐宣王曰	meng zi wei qi xuan wang yue	1
+宓妃留枕魏王才	mi fei liu zhen wei wang cai	1
+猕猴骑土牛	mi hou qi tu niu	1
+迷花不事君	mi hua bu shi jun	1
+迷花倚石忽已暝	mi hua yi shi hu yi ming	1
+弥勒真弥勒	mi le zhen mi le	1
+靡使归聘	mi shi gui pin	1
+靡室劳矣	mi shi lao yi	1
+米粟非不多也	mi su fei bu duo ye	1
+密锁重关掩绿苔	mi suo zhong guan yan lv tai	1
+密陀僧	mi tuo seng	1
+迷仙引	mi xian yin	1
+迷阳迷阳	mi yang mi yang	1
+密叶罗青烟	mi ye luo qing yan	1
+密叶隐歌鸟	mi ye yin ge niao	1
+靡有朝矣	mi you chao yi	1
+靡有孑遗	mi you jie yi	1
+米友仁	mi you ren	1
+密雨斜侵薜荔墙	mi yu xie qin bi li qiang	1
+密州上元	mi zhou shang yuan	1
+缅伯高	mian bo gao	1
+绵绵蛮蛮如有情	mian mian man man ru you qing	1
+绵绵若存	mian mian ruo cun	1
+面前明	mian qian ming	1
+面如玉	mian ru yu	1
+眠沙卧水自成群	mian sha wo shui zi cheng qun	1
+眠时忆问醒时事	mian shi yi wen xing shi shi	1
+沔水	mian shui	1
+免于刑戮	mian yu xing lu	1
+渺沧海之一粟	miao cang hai zhi yi su	1
+苗发	miao fa	1
+藐姑射之山	miao gu ye zhi shan	1
+苗晋卿	miao jin qing	1
+渺渺没孤鸿	miao miao mei gu hong	1
+渺渺兮予怀	miao miao xi yu huai	1
+邈然不可攀	miao ran bu ke pan	1
+庙堂无策可平戎	miao tang wu ce ke ping rong	1
+妙舞此曲神扬扬	miao wu ci qu shen yang yang	1
+苗则槁矣	miao ze gao yi	1
+妙湛总持不动尊	miao zhan zong chi bu dong zun	1
+灭六国者	mie liu guo zhe	1
+灭烛怜光满	mie zhu lian guang man	1
+民德归厚矣	min de gui hou yi	1
+民复孝慈	min fu xiao ci	1
+民国奇耻	min guo qi chi	1
+民具尔瞻	min ju er zhan	1
+民利百倍	min li bai bei	1
+黾勉空仰止	min mian kong yang zhi	1
+黾勉求之	min mian qiu zhi	1
+黾勉同心	min mian tong xin	1
+民如野鹿	min ru ye lu	1
+民散久矣	min san jiu yi	1
+民斯为下矣	min si wei xia yi	1
+民无能名焉	min wu neng ming yan	1
+民无所定	min wu suo ding	1
+民无信不立	min wu xin bu li	1
+民鲜久矣	min xian jiu yi	1
+民心不乱	min xin bu luan	1
+民亦乐其乐	min yi le qi le	1
+敏以求之者也	min yi qiu zhi zhe ye	1
+民亦忧其忧	min yi you qi you	1
+民有饥色	min you ji se	1
+悯馀	min yu	1
+敏于事而慎于言	min yu shi er shen yu yan	1
+敏则有功	min ze you gong	1
+民之从事	min zhi cong shi	1
+民之难治	min zhi nan zhi	1
+民之失德	min zhi shi de	1
+民主共和	min zhu gong he	1
+民族阵线	min zu zhen xian	1
+明白畅达	ming bai chang da	1
+明白四达	ming bai si da	1
+命不可变	ming bu ke bian	1
+名不虚传	ming bu xu chuan	1
+鸣蝉更乱行人耳	ming chan geng luan xing ren er	1
+明朝挂帆席	ming chao gua fan xi	1
+明朝望乡处	ming chao wang xiang chu	1
+明朝驿使发	ming chao yi shi fa	1
+明朝有封事	ming chao you feng shi	1
+明朝游上苑	ming chao you shang yuan	1
+明朝元会日	ming chao yuan hui ri	1
+名成八阵图	ming cheng ba zhen tu	1
+明耻篇	ming chi pian	1
+明道若昧	ming dao ruo mei	1
+明断自天启	ming duan zi tian qi	1
+明发不寐	ming fa bu mei	1
+名花倾国两相欢	ming hua qing guo liang xiang huan	1
+鸣机夜课图记	ming ji ye ke tu ji	1
+明君制民之产	ming jun zhi min zhi chan	1
+冥吏	ming li	1
+螟蛉有子	ming ling you zi	1
+命令昨颁	ming ling zuo ban	1
+冥冥孤高多烈风	ming ming gu gao duo lie feng	1
+冥冥花正开	ming ming hua zheng kai	1
+冥冥九疑葬	ming ming jiu yi zang	1
+冥冥鸟去迟	ming ming niao qu chi	1
+冥冥日沉夕	ming ming ri chen xi	1
+冥冥日沈夕	ming ming ri shen xi	1
+明眸皓齿今何在	ming mou hao chi jin he zai	1
+明年春色倍还人	ming nian chun se bei hai ren	1
+明年花开复谁在	ming nian hua kai fu shui zai	1
+明年花开时	ming nian hua kai shi	1
+明年秋	ming nian qiu	1
+明年谁此凭栏干	ming nian shui ci ping lan gan	1
+名岂文章著	ming qi wen zhang zhu	1
+明日巴陵道	ming ri ba ling dao	1
+明日隔山岳	ming ri ge shan yue	1
+明日黄花蝶也愁	ming ri huang hua die ye chou	1
+明日落花飞絮	ming ri luo hua fei xu	1
+明日岁华新	ming ri sui hua xin	1
+明日遂行	ming ri sui xing	1
+明日又逢春	ming ri you feng chun	1
+命如南山石	ming ru nan shan shi	1
+明时思解愠	ming shi si jie yun	1
+名殊体不殊	ming shu ti bu shu	1
+命随年欲尽	ming sui nian yu jin	1
+鸣梭	ming suo	1
+明我长相忆	ming wo chang xiang yi	1
+明星荧荧	ming xing ying ying	1
+名亦既有	ming yi ji you	1
+明以教我	ming yi jiao wo	1
+名与身孰亲	ming yu shen shu qin	1
+名余曰正则兮	ming yu yue zheng ze xi	1
+明月半墙	ming yue ban qiang	1
+明月不归沉碧海	ming yue bu gui chen bi hai	1
+明月出海底	ming yue chu hai di	1
+明月出天山	ming yue chu tian shan	1
+明月何曾是两乡	ming yue he ceng shi liang xiang	1
+明月皎皎入华池	ming yue jiao jiao ru hua chi	1
+明月流光	ming yue liu guang	1
+明月落谁家	ming yue luo shui jia	1
+明月明年何处看	ming yue ming nian he chu kan	1
+命曰琵琶行	ming yue pi pa xing	1
+明月前溪后溪	ming yue qian xi hou xi	1
+明月斜	ming yue xie	1
+明月引	ming yue yin	1
+明月隐高树	ming yue yin gao shu	1
+明月棹孤舟	ming yue zhao gu zhou	1
+明月直入	ming yue zhi ru	1
+明月逐来	ming yue zhu lai	1
+明月逐人来	ming yue zhu ren lai	1
+鸣噪自纷纷	ming zao zi fen fen	1
+明朝有意抱琴来	ming zhao you yi bao qin lai	1
+鸣筝金粟柱	ming zheng jin su zhu	1
+命之行也	ming zhi xing ye	1
+缪氏子	miu shi zi	1
+莫不静好	mo bu jing hao	1
+莫不中音	mo bu zhong yin	1
+墨池记	mo chi ji	1
+莫大乎尊亲	mo da hu zun qin	1
+莫大于海	mo da yu hai	1
+莫待春风总吹却	mo dai chun feng zong chui que	1
+莫待无花空折枝	mo dai wu hua kong zhe zhi	1
+莫待晓风吹	mo dai xiao feng chui	1
+莫道君行早	mo dao jun xing zao	1
+莫道昆明池水浅	mo dao kun ming chi shui qian	1
+磨刀向猪羊	mo dao xiang zhu yang	1
+莫得同车归	mo de tong che gui	1
+磨而不磷	mo er bu lin	1
+莫非自己	mo fei zi ji	1
+莫恨黄花未吐	mo hen huang hua wei tu	1
+莫己知也	mo ji zhi ye	1
+莫嫁如兄夫	mo jia ru xiong fu	1
+莫见长安行乐处	mo jian chang an xing le chu	1
+磨剑莫磨锥	mo jian mo mo zhui	1
+莫将边地比京都	mo jiang bian di bi jing du	1
+莫将孤月对猿愁	mo jiang gu yue dui yuan chou	1
+莫教踏碎琼瑶	mo jiao ta sui qiong yao	1
+莫教枝上啼	mo jiao zhi shang ti	1
+莫令事不举	mo ling shi bu ju	1
+莫买沃洲山	mo mai wo zhou shan	1
+莫谩愁沽酒	mo man chou gu jiu	1
+莫蒙	mo meng	1
+漠漠帆来重	mo mo fan lai zhong	1
+脉脉广川流	mo mo guang chuan liu	1
+漠漠水田飞白鹭	mo mo shui tian fei bai lu	1
+莫逆于心	mo ni yu xin	1
+莫遣佳期更后期	mo qian jia qi geng hou qi	1
+莫遣沙场匹马还	mo qian sha chang pi ma hai	1
+莫然无魂	mo ran wu hun	1
+莫如兄弟	mo ru xiong di	1
+莫若以明	mo ruo yi ming	1
+陌上花	mo shang hua	1
+陌上花开蝴蝶飞	mo shang hua kai hu die fei	1
+陌上看花人	mo shang kan hua ren	1
+陌上郎	mo shang lang	1
+陌上桑	mo shang sang	1
+陌上相逢讵相识	mo shang xiang feng ju xiang shi	1
+没身不殆	mo shen bu dai	1
+莫是藁砧归	mo shi gao zhen gui	1
+莫使金尊空对月	mo shi jin zun kong dui yue	1
+莫使金樽空对月	mo shi jin zun kong dui yue	1
+莫思归	mo si gui	1
+莫思身外无穷事	mo si shen wai wu qiong shi	1
+莫损愁眉与细腰	mo sun chou mei yu xi yao	1
+莫叹韶华容易逝	mo tan shao hua rong yi shi	1
+莫慰母心	mo wei mu xin	1
+莫为轻阴便拟归	mo wei qing yin bian ni gui	1
+莫我肯德	mo wo ken de	1
+莫我肯顾	mo wo ken gu	1
+莫我肯劳	mo wo ken lao	1
+莫我知也夫	mo wo zhi ye fu	1
+莫吾犹人也	mo wu you ren ye	1
+莫嫌旧日云中守	mo xian jiu ri yun zhong shou	1
+莫嫌荦确坡头路	mo xian luo que po tou lu	1
+莫向临邛去	mo xiang lin qiong qu	1
+莫宣卿	mo xuan qing	1
+莫学武陵人	mo xue wu ling ren	1
+莫学游侠儿	mo xue you xia er	1
+磨牙吮血	mo ya shun xue	1
+莫言朝花不复落	mo yan chao hua bu fu luo	1
+莫言贫贱长可欺	mo yan pin jian chang ke qi	1
+莫言贫贱即可欺	mo yan pin jian ji ke qi	1
+莫厌伤多酒入唇	mo yan shang duo jiu ru chun	1
+莫以今时宠	mo yi jin shi chong	1
+摸鱼子	mo yu zi	1
+莫之敢指	mo zhi gan zhi	1
+末之难矣	mo zhi nan yi	1
+莫之能守	mo zhi neng shou	1
+莫之能御也	mo zhi neng yu ye	1
+莫知其极	mo zhi qi ji	1
+莫知其始	mo zhi qi shi	1
+莫知其所终	mo zhi qi suo zhong	1
+莫知其他	mo zhi qi ta	1
+莫之为而为者	mo zhi wei er wei zhe	1
+莫知我哀	mo zhi wo ai	1
+莫之知避	mo zhi zhi bi	1
+莫之致而至者	mo zhi zhi er zhi zhe	1
+莫之知载	mo zhi zhi zai	1
+磨锥成小利	mo zhui cheng xiao li	1
+莫自使眼枯	mo zi shi yan ku	1
+某两地	mou liang di	1
+牟融	mou rong	1
+暮霭生深树	mu ai sheng shen shu	1
+目不能两视而明	mu bu neng liang shi er ming	1
+目不视恶色	mu bu shi e se	1
+木不怨落于秋天	mu bu yuan luo yu qiu tian	1
+暮从碧山下	mu cong bi shan xia	1
+暮隔千里情	mu ge qian li qing	1
+穆护砂	mu hu sha	1
+沐皇恩	mu huang en	1
+暮婚晨告别	mu hun chen gao bie	1
+目尽长空闲	mu jin chang kong xian	1
+穆陵关北愁爱子	mu ling guan bei chou ai zi	1
+木落雁南渡	mu luo yan nan du	1
+木落知寒近	mu luo zhi han jin	1
+牧马频来去	mu ma pin lai qu	1
+木末芙蓉花	mu mo fu rong hua	1
+暮年诗赋动江关	mu nian shi fu dong jiang guan	1
+慕娉婷	mu ping ting	1
+暮禽相与还	mu qin xiang yu hai	1
+暮秋独游曲江	mu qiu du you qu jiang	1
+暮去朝来淘不住	mu qu zhao lai tao bu zhu	1
+暮惹御香归	mu re yu xiang gui	1
+暮色苍茫看劲松	mu se cang mang kan jin song	1
+暮上河阳桥	mu shang he yang qiao	1
+木声	mu sheng	1
+母氏劳苦	mu shi lao ku	1
+母氏劬劳	mu shi qu lao	1
+母氏圣善	mu shi sheng shan	1
+暮随肥马尘	mu sui fei ma chen	1
+母孙二人	mu sun er ren	1
+牧童敲火牛砺角	mu tong qiao huo niu li jiao	1
+穆王何事不重来	mu wang he shi bu chong lai	1
+目无所见	mu wu suo jian	1
+母兮鞠我	mu xi ju wo	1
+暮烟秋雨过枫桥	mu yan qiu yu guo feng qiao	1
+木叶纷纷落	mu ye fen fen luo	1
+木叶萧萧	mu ye xiao xiao	1
+慕幽	mu you	1
+沐浴清化	mu yu qing hua	1
+暮雨相呼失	mu yu xiang hu shi	1
+目遇之而成色	mu yu zhi er cheng se	1
+沐浴子	mu yu zi	1
+母曰	mu yue	1
+暮云碧	mu yun bi	1
+暮云收尽溢清寒	mu yun shou jin yi qing han	1
+睦州四韵	mu zhou si yun	1
+暮作吴宫妃	mu zuo wu gong fei	1
+那得久	na de jiu	1
+哪个虫儿敢作	na ge chong er gan zuo	1
+那堪把剪刀	na kan ba jian dao	1
+那堪玄鬓影	na kan xuan bin ying	1
+那闻旧人哭	na wen jiu ren ku	1
+乃赋离骚	nai fu li sao	1
+奈何今之人	nai he jin zhi ren	1
+奈何取之尽锱铢	nai he qu zhi jin zi zhu	1
+乃合天德	nai he tian de	1
+奈何万乘之主	nai he wan sheng zhi zhu	1
+奈何阻重深	nai he zu zhong shen	1
+乃见狡童	nai jian jiao tong	1
+乃见狂且	nai jian kuang qie	1
+耐可乘流直上天	nai ke cheng liu zhi shang tian	1
+乃可以长生	nai ke yi chang sheng	1
+乃令张良留谢	nai ling zhang liang liu xie	1
+乃凝于神	nai ning yu shen	1
+乃如左丘无目	nai ru zuo qiu wu mu	1
+乃生男子	nai sheng nan zi	1
+乃是离之	nai shi li zhi	1
+乃武乃文	nai wu nai wen	1
+乃知兵者是凶器	nai zhi bing zhe shi xiong qi	1
+乃知尔丑	nai zhi er chou	1
+乃中经首之会	nai zhong jing shou zhi hui	1
+南北东西路	nan bei dong xi lu	1
+南朝民歌	nan chao min ge	1
+难得之货	nan de zhi huo	1
+南都行	nan dou xing	1
+男儿本自重横行	nan er ben zi zhong heng xing	1
+男儿到死心如铁	nan er dao si xin ru tie	1
+男儿生身自有役	nan er sheng shen zi you yi	1
+男儿生世间	nan er sheng shi jian	1
+男儿事长征	nan er shi chang zheng	1
+男儿须读五车书	nan er xu du wu che shu	1
+南方有鸟	nan fang you niao	1
+南风入弦	nan feng ru xian	1
+南歌子	nan ge zi	1
+南宫适出	nan gong shi chu	1
+南冠客思侵	nan guan ke si qin	1
+南国烽烟正十年	nan guo feng yan zheng shi nian	1
+南湖秋水夜无烟	nan hu qiu shui ye wu yan	1
+南极老人星	nan ji lao ren xing	1
+南极老人应寿昌	nan ji lao ren ying shou chang	1
+南菊再逢人卧病	nan ju zai feng ren wo bing	1
+南柯子	nan ke zi	1
+赧郎明月夜	nan lang ming yue ye	1
+南陵别儿童入京	nan ling bie er tong ru jing	1
+南陵寓使迟	nan ling yu shi chi	1
+南楼令	nan lou ling	1
+南溟夫人	nan ming fu ren	1
+男女并驾	nan nv bing jia	1
+男女居室	nan nv ju shi	1
+南浦清江万里桥	nan pu qing jiang wan li qiao	1
+南浦月	nan pu yue	1
+南取百越之地	nan qu bai yue zhi di	1
+南取汉中	nan qu han zhong	1
+南人有言曰	nan ren you yan yue	1
+南容三复白圭	nan rong san fu bai gui	1
+南山崔崔	nan shan cui cui	1
+南山归敝庐	nan shan gui bi lu	1
+南山截竹为筚篥	nan shan jie zhu wei bi li	1
+南山居士	nan shan ju shi	1
+南山烈烈	nan shan lie lie	1
+南山新长凤凰雏	nan shan xin chang feng huang chu	1
+南山有桑	nan shan you sang	1
+南山有台	nan shan you tai	1
+南山与秋色	nan shan yu qiu se	1
+南山之下	nan shan zhi xia	1
+难忘旧日恩	nan wang jiu ri en	1
+难为俗人言	nan wei su ren yan	1
+难为俗人言也	nan wei su ren yan ye	1
+南轩松	nan xuan song	1
+南雁归时更寂寥	nan yan gui shi geng ji liao	1
+南有嘉鱼之什	nan you jia yu zhi shen	1
+南有樛木	nan you jiu mu	1
+南枝向暖北枝寒	nan zhi xiang nuan bei zhi han	1
+南卓	nan zhuo	1
+男子千年志	nan zi qian nian zhi	1
+囊括经世道	nang kuo jing shi dao	1
+囊括四海之意	nang kuo si hai zhi yi	1
+曩者辱赐书	nang zhe ru ci shu	1
+囊中自有钱	nang zhong zi you qian	1
+哪吒令	ne zha ling	1
+内家娇	nei jia jiao	1
+内立法度	nei li fa du	1
+内无怨女	nei wu yuan nv	1
+内省不疚	nei xing bu jiu	1
+馁在其中矣	nei zai qi zhong yi	1
+能得几时好	neng de ji shi hao	1
+能复饮乎	neng fu yin hu	1
+能胡歌	neng hu ge	1
+能竭其力	neng jie qi li	1
+能近取譬	neng jin qu pi	1
+能如婴儿乎	neng ru ying er hu	1
+能使枉者直	neng shi wang zhe zhi	1
+能体纯素	neng ti chun su	1
+能为雌乎	neng wei ci hu	1
+能无离乎	neng wu li hu	1
+能无为乎	neng wu wei hu	1
+能无知乎	neng wu zhi hu	1
+能行五者于天下	neng xing wu zhe yu tian xia	1
+能以礼让为国乎	neng yi li rang wei guo hu	1
+能者在职	neng zhe zai zhi	1
+能知古始	neng zhi gu shi	1
+能致其身	neng zhi qi shen	1
+霓裳一曲千峰上	ni chang yi qu qian feng shang	1
+倪偁	ni chen	1
+逆道违天	ni dao wei tian	1
+尼丘山	ni qiu shan	1
+泥上偶然留指爪	ni shang ou ran liu zhi zhao	1
+霓裳羽衣	ni shang yu yi	1
+泥他沽酒拔金钗	ni ta gu jiu ba jin chai	1
+拟托良媒益自伤	ni tuo liang mei yi zi shang	1
+霓为衣兮风为马	ni wei yi xi feng wei ma	1
+逆以煎我怀	ni yi jian wo huai	1
+倪翼周	ni yi zhou	1
+泥拥奔蛇径	ni yong ben she jing	1
+匿怨而友其人	ni yuan er you qi ren	1
+睨柱吞嬴	ni zhu tun ying	1
+年版	nian ban	1
+年大自疏隔	nian da zi shu ge	1
+碾雕白玉	nian diao bai yu	1
+捻断数茎须	nian duan shu jing xu	1
+年共晓光新	nian gong xiao guang xin	1
+辇来于秦	nian lai yu qin	1
+念母劳家里	nian mu lao jia li	1
+年年今夜尽	nian nian jin ye jin	1
+年年柳色	nian nian liu se	1
+年年岁岁一床书	nian nian sui sui yi chuang shu	1
+年年欲惜春	nian nian yu xi chun	1
+年年越溪女	nian nian yue xi nv	1
+年年战骨埋荒外	nian nian zhan gu mai huang wai	1
+念奴娇昆仑	nian nu jiao kun lun	1
+念奴娇鸟儿问答	nian nu jiao niao er wen da	1
+辇前才人带弓箭	nian qian cai ren dai gong jian	1
+念去去千里烟波	nian qu qu qian li yan bo	1
+年深岂免有缺画	nian shen qi mian you que hua	1
+年始十八九	nian shi shi ba jiu	1
+念无与为乐者	nian wu yu wei le zhe	1
+念香衾	nian xiang qin	1
+念与世间辞	nian yu shi jian ci	1
+年长色衰	nian zhang se shuai	1
+鸟度屏风里	niao du ping feng li	1
+鸟儿问答	niao er wen da	1
+鸟飞不到吴天长	niao fei bu dao wu tian chang	1
+鸟归沙有迹	niao gui sha you ji	1
+鸟尽良弓藏	niao jin liang gong cang	1
+鸟鸣涧	niao ming jian	1
+鸟鸣嘤嘤	niao ming ying ying	1
+袅袅秋风生	niao niao qiu feng sheng	1
+鸟兽不可与同群	niao shou bu ke yu tong qun	1
+鸟鼠攸去	niao shu you qu	1
+鸟向平芜远近	niao xiang ping wu yuan jin	1
+鸟亦罢其鸣	niao yi ba qi ming	1
+涅而不缁	nie er bu zi	1
+蹑履相逢迎	nie lv xiang feng ying	1
+聂胜琼	nie sheng qiong	1
+蹑足行伍之间	nie zu hang wu zhi jian	1
+凝碧池头奏管弦	ning bi chi tou zou guan xian	1
+宁化	ning hua	1
+凝绝不通声渐歇	ning jue bu tong sheng jian xie	1
+宁莫之知	ning mo zhi zhi	1
+凝情自悄然	ning qing zi qiao ran	1
+宁生而曳尾涂中	ning sheng er ye wei tu zhong	1
+宁同万死碎绮翼	ning tong wan si sui qi yi	1
+宁为鸡口	ning wei ji kou	1
+宁武子	ning wu zi	1
+宁知草间人	ning zhi cao jian ren	1
+宁知晓向云间没	ning zhi xiao xiang yun jian mei	1
+牛丛	niu cong	1
+牛郎欲问瘟神事	niu lang yu wen wen shen shi	1
+牛马四足	niu ma si zu	1
+牛女年年渡	niu nv nian nian du	1
+牛峤	niu qiao	1
+牛僧孺	niu seng ru	1
+牛山何必独沾衣	niu shan he bi du zhan yi	1
+牛希济	niu xi ji	1
+牛渚矶	niu zhu ji	1
+牛渚西江夜	niu zhu xi jiang ye	1
+侬道横江恶	nong dao heng jiang e	1
+弄篙莫溅水	nong gao mo jian shui	1
+弄花香满衣	nong hua xiang man yi	1
+弄花雨	nong hua yu	1
+秾丽今何在	nong li jin he zai	1
+弄巧成拙	nong qiao cheng zhuo	1
+努力加餐饭	nu li jia can fan	1
+努力尽今夕	nu li jin jin xi	1
+驽马恋栈豆	nu ma lian zhan dou	1
+驽马十驾	nu ma shi jia	1
+怒其臂以当车辙	nu qi bi yi dang che zhe	1
+暖带入春风	nuan dai ru chun feng	1
+诺诺复尔尔	nuo nuo fu er er	1
+女床无树不栖鸾	nv chuang wu shu bu qi luan	1
+女萝山鬼语相邀	nv luo shan gui yu xiang yao	1
+女心伤悲	nv xin shang bei	1
+女行无偏斜	nv xing wu pian xie	1
+女也不爽	nv ye bu shuang	1
+女曰鸡鸣	nv yue ji ming	1
+女之耽兮	nv zhi dan xi	1
+女子今有行	nv zi jin you xing	1
+女子善怀	nv zi shan huai	1
+女子有行	nv zi you xing	1
+女子之祥	nv zi zhi xiang	1
+偶然间	ou ran jian	1
+偶然值林叟	ou ran zhi lin sou	1
+偶似山林客	ou si shan lin ke	1
+偶相逢	ou xiang feng	1
+欧阳宾	ou yang bin	1
+欧阳彬	ou yang bin	1
+欧阳澈	ou yang che	1
+欧阳瑾	ou yang jin	1
+欧阳炯	ou yang jiong	1
+欧阳珣	ou yang xun	1
+欧阳詹	ou yang zhan	1
+偶缘犹未忘多情	ou yuan you wei wang duo qing	1
+偶值当途石	ou zhi dang tu shi	1
+怕愁贪睡独开迟	pa chou tan shui du kai chi	1
+排歌	pai ge	1
+徘徊庭树下	pai huai ting shu xia	1
+徘徊于斗牛之间	pai huai yu dou niu zhi jian	1
+潘牥	pan fang	1
+盘根错节之既破	pan gen cuo jie zhi ji po	1
+攀桂仰天高	pan gui yang tian gao	1
+攀荷弄其珠	pan he nong qi zhu	1
+盘马弯弓惜不发	pan ma wan gong xi bu fa	1
+潘孟阳	pan meng yang	1
+磐石方且厚	pan shi fang qie hou	1
+磐石无转移	pan shi wu zhuan yi	1
+判司卑官不堪说	pan si bei guan bu kan shuo	1
+盘飧市远无兼味	pan sun shi yuan wu jian wei	1
+潘唐	pan tang	1
+潘图	pan tu	1
+潘熊飞	pan xiong fei	1
+潘炎	pan yan	1
+潘雍	pan yong	1
+潘佑	pan you	1
+潘岳悼亡犹费词	pan yue dao wang you fei ci	1
+庞德公	pang de gong	1
+庞籍	pang ji	1
+庞蕴	pang yun	1
+庖丁释刀对曰	pao ding shi dao dui yue	1
+炮火连天	pao huo lian tian	1
+袍裤宫人扫御床	pao ku gong ren sao yu chuang	1
+抛球乐	pao qiu le	1
+庖人虽不治庖	pao ren sui bu zhi pao	1
+抛绣球	pao xiu qiu	1
+庖有肥肉	pao you fei rou	1
+匏有苦叶	pao you ku ye	1
+裴澈	pei che	1
+陪臣执国命	pei chen zhi guo ming	1
+裴诚	pei cheng	1
+裴达	pei da	1
+裴迪	pei di	1
+裴翻	pei fan	1
+沛公安在	pei gong an zai	1
+沛公大惊	pei gong da jing	1
+沛公奉卮酒为寿	pei gong feng zhi jiu wei shou	1
+沛公今事有急	pei gong jin shi you ji	1
+沛公居山东时	pei gong ju shan dong shi	1
+沛公军霸上	pei gong jun ba shang	1
+沛公军在霸上	pei gong jun zai ba shang	1
+沛公默然	pei gong mo ran	1
+沛公起如厕	pei gong qi ru ce	1
+沛公已去	pei gong yi qu	1
+沛公欲王关中	pei gong yu wang guan zhong	1
+沛公则置车骑	pei gong ze zhi che qi	1
+裴光庭	pei guang ting	1
+裴航	pei hang	1
+裴皞	pei hao	1
+裴潾	pei lin	1
+裴略	pei lue	1
+沛然下雨	pei ran xia yu	1
+裴淑	pei shu	1
+裴说	pei shuo	1
+裴湘	pei xiang	1
+裴铏	pei xing	1
+裴休	pei xiu	1
+裴谞	pei xu	1
+裴延	pei yan	1
+裴瑶	pei yao	1
+裴耀卿	pei yao qing	1
+配义与道	pei yi yu dao	1
+裴夷直	pei yi zhi	1
+佩玉将将	pei yu jiang jiang	1
+佩玉鸣鸾罢歌舞	pei yu ming luan ba ge wu	1
+佩玉琼琚	pei yu qiong ju	1
+佩玉之傩	pei yu zhi nuo	1
+喷壑数十里	pen he shu shi li	1
+彭蟾	peng chan	1
+朋党论	peng dang lun	1
+彭芳远	peng fang yuan	1
+捧剑仆	peng jian pu	1
+蓬莱此去无多路	peng lai ci qu wu duo lu	1
+蓬莱阁	peng lai ge	1
+蓬莱宫阙对南山	peng lai gong que dui nan shan	1
+蓬门未识绮罗香	peng men wei shi qi luo xiang	1
+芃芃其麦	peng peng qi mai	1
+彭叔夏	peng shu xia	1
+鹏抟九天	peng tuan jiu tian	1
+烹羊宰牛且为乐	peng yang zai niu qie wei le	1
+朋友有信	peng you you xin	1
+朋友之馈	peng you zhi kui	1
+彭正大	peng zheng da	1
+鹏之徙于南冥也	peng zhi xi yu nan ming ye	1
+彭子翔	peng zi xiang	1
+譬道之在天下	pi dao zhi zai tian xia	1
+蚍蜉撼树谈何易	pi fu han shu tan he yi	1
+霹雳一声暴动	pi li yi sheng bao dong	1
+匹马西从天外归	pi ma xi cong tian wai gui	1
+琵琶行并序	pi pa xing bing xu	1
+琵琶一曲肠堪断	pi pa yi qu chang kan duan	1
+皮日休	pi ri xiu	1
+譬如北辰	pi ru bei chen	1
+譬如平地	pi ru ping di	1
+譬如为山	pi ru wei shan	1
+否泰如天地	pi tai ru tian di	1
+披帷西向立	pi wei xi xiang li	1
+披香殿前花始红	pi xiang dian qian hua shi hong	1
+披衣更向门前望	pi yi geng xiang men qian wang	1
+披衣觉露滋	pi yi jue lu zi	1
+譬之宫墙	pi zhi gong qiang	1
+譬诸草木	pi zhu cao mu	1
+譬诸小人	pi zhu xiao ren	1
+偏到鸳鸯两字冰	pian dao yuan yang liang zi bing	1
+偏惊物候新	pian jing wu hou xin	1
+骗了无涯过客	pian le wu ya guo ke	1
+翩翩起舞	pian pian qi wu	1
+偏其反而	pian qi fan er	1
+偏师借重黄公略	pian shi jie zhong huang gong lue	1
+片言可以折狱者	pian yan ke yi zhe yu zhe	1
+片云天共远	pian yun tian gong yuan	1
+偏在洛阳东	pian zai luo yang dong	1
+扁舟共济与君同	pian zhou gong ji yu jun tong	1
+偏坐金鞍调白羽	pian zuo jin an tiao bai yu	1
+飘泊天涯	piao bo tian ya	1
+漂泊西南天地间	piao bo xi nan tian di jian	1
+飘拂升天行	piao fu sheng tian xing	1
+飘零君不知	piao ling jun bu zhi	1
+飘零事已空	piao ling shi yi kong	1
+飘零随风	piao ling sui feng	1
+缥缈孤鸿影	piao miao gu hong ying	1
+飘飘何所似	piao piao he suo si	1
+飘萧松桂秋	piao xiao song gui qiu	1
+牝常以静胜牡	pin chang yi jing sheng mu	1
+贫村才数家	pin cun cai shu jia	1
+贫而无怨难	pin er wu yuan nan	1
+贫俭诚所尚	pin jian cheng suo shang	1
+贫贱夫妻百事哀	pin jian fu qi bai shi ai	1
+贫贱江头自浣纱	pin jian jiang tou zi huan sha	1
+贫贱有此女	pin jian you ci nv	1
+拼今生	pin jin sheng	1
+贫居依谷口	pin ju yi gu kou	1
+拼了尽烛	pin le jin zhu	1
+品令	pin ling	1
+频年不解兵	pin nian bu jie bing	1
+贫女	pin nv	1
+贫且贱焉	pin qie jian yan	1
+贫人见之	pin ren jian zhi	1
+贫也乐	pin ye le	1
+拼一醉	pin yi zui	1
+平曾	ping ceng	1
+平陈与宋	ping chen yu song	1
+平淡无奇	ping dan wu qi	1
+屏风九叠云锦张	ping feng jiu die yun jin zhang	1
+屏风绝句	ping feng jue ju	1
+屏风周昉画纤腰	ping feng zhou fang hua xian yao	1
+凭割断愁思恨缕	ping ge duan chou si hen lv	1
+凭君莫射南来雁	ping jun mo she nan lai yan	1
+平明别我上山去	ping ming bie wo shang shan qu	1
+平明吹笛大军行	ping ming chui di da jun xing	1
+平明闾巷扫花开	ping ming lv xiang sao hua kai	1
+平明每幸长生殿	ping ming mei xing chang sheng dian	1
+平明骑马入宫门	ping ming qi ma ru gong men	1
+娉娉袅袅十三余	ping ping niao niao shi san yu	1
+平平平	ping ping ping	1
+平平平平	ping ping ping ping	1
+平平平平平	ping ping ping ping ping	1
+平平平平平平	ping ping ping ping ping ping	1
+平平平平平平平	ping ping ping ping ping ping ping	1
+平平平仄	ping ping ping ze	1
+平平平仄仄	ping ping ping ze ze	1
+平平平仄仄平平	ping ping ping ze ze ping ping	1
+平平仄	ping ping ze	1
+平平仄仄平	ping ping ze ze ping	1
+平平仄仄平平	ping ping ze ze ping ping	1
+平平仄仄平平仄	ping ping ze ze ping ping ze	1
+平平仄仄仄平	ping ping ze ze ze ping	1
+平平仄仄仄平平	ping ping ze ze ze ping ping	1
+平铺湘水流	ping pu xiang shui liu	1
+平如镜面	ping ru jing mian	1
+平沙浩浩四无边	ping sha hao hao si wu bian	1
+平沙列万幕	ping sha lie wan mu	1
+平沙莽莽黄入天	ping sha mang mang huang ru tian	1
+平沙日未没	ping sha ri wei mei	1
+平沙万里绝人烟	ping sha wan li jue ren yan	1
+平生不下泪	ping sheng bu xia lei	1
+平生负奇节	ping sheng fu qi jie	1
+平生实爱才	ping sheng shi ai cai	1
+平生五千卷	ping sheng wu qian juan	1
+平生五色线	ping sheng wu se xian	1
+平生一片心	ping sheng yi pian xin	1
+平生自有分	ping sheng zi you fen	1
+凭轩涕泗流	ping xuan ti si liu	1
+砯崖转石万壑雷	ping ya zhuan shi wan he lei	1
+平阳歌舞新承宠	ping yang ge wu xin cheng chong	1
+平野入青徐	ping ye ru qing xu	1
+平易恬淡	ping yi tian dan	1
+平韵	ping yun	1
+平仄平	ping ze ping	1
+平仄平平	ping ze ping ping	1
+平仄平平平仄	ping ze ping ping ping ze	1
+平仄平平平仄仄	ping ze ping ping ping ze ze	1
+平仄平平仄	ping ze ping ping ze	1
+平仄平平仄仄	ping ze ping ping ze ze	1
+平仄平平仄仄平	ping ze ping ping ze ze ping	1
+平仄仄	ping ze ze	1
+平仄仄平	ping ze ze ping	1
+平仄仄平平	ping ze ze ping ping	1
+平仄仄平平仄	ping ze ze ping ping ze	1
+平仄仄平平仄仄	ping ze ze ping ping ze ze	1
+平仄仄平仄	ping ze ze ping ze	1
+颇得清净理	po de qing jing li	1
+破笛	po di	1
+婆罗门	po luo men	1
+婆罗门引	po luo men yin	1
+破帽多情却恋头	po mao duo qing que lian tou	1
+破山寺后禅院	po shan si hou chan yuan	1
+破邵	po shao	1
+颇学阴何苦用心	po xue yin he ku yong xin	1
+破灶烧湿苇	po zao shao shi wei	1
+破阵乐	po zhen le	1
+迫之如火煎	po zhi ru huo jian	1
+破字令	po zi ling	1
+掊斗折衡	pou dou zhe heng	1
+浦边风	pu bian feng	1
+铺床拂席置羹饭	pu chuang fu xi zhi geng fan	1
+扑粉蝶	pu fen die	1
+匍匐救之	pu fu jiu zhi	1
+扑蝴蝶	pu hu die	1
+仆窃不逊	pu qie bu xun	1
+菩萨蛮大柏地	pu sa man da bai di	1
+菩萨蛮黄鹤楼	pu sa man huang he lou	1
+菩萨面	pu sa mian	1
+菩萨清凉月	pu sa qing liang yue	1
+朴散则为器	pu san ze wei qi	1
+浦树远含滋	pu shu yuan han zi	1
+葡萄浆	pu tao jiang	1
+葡萄深碧	pu tao shen bi	1
+普天乐	pu tian le	1
+普天之下	pu tian zhi xia	1
+蒲苇一时纫	pu wei yi shi ren	1
+蒲宗孟	pu zong meng	1
+齐安郡后池绝句	qi an jun hou chi jue ju	1
+其安易持	qi an yi chi	1
+淇奥	qi ao	1
+栖白	qi bai	1
+七百里驱十五日	qi bai li qu shi wu ri	1
+骑白象	qi bai xiang	1
+齐必变食	qi bi bian shi	1
+岂必局束为人鞿	qi bi ju shu wei ren ji	1
+其蔽也荡	qi bi ye dang	1
+其蔽也绞	qi bi ye jiao	1
+其蔽也狂	qi bi ye kuang	1
+其蔽也乱	qi bi ye luan	1
+其蔽也愚	qi bi ye yu	1
+其蔽也贼	qi bi ye zei	1
+气变而有形	qi bian er you xing	1
+岂不尔思	qi bu er si	1
+戚不敢言	qi bu gan yan	1
+其不可者拒之	qi bu ke zhe ju zhi	1
+岂不日戒	qi bu ri jie	1
+岂不如贼焉	qi bu ru zei yan	1
+其不善者恶之	qi bu shan zhe e zhi	1
+岂不夙夜	qi bu su ye	1
+杞不足征也	qi bu zu zheng ye	1
+七层摩苍穹	qi ceng mo cang qiong	1
+栖蟾	qi chan	1
+其出弥远	qi chu mi yuan	1
+其出人也远矣	qi chu ren ye yuan yi	1
+齐楚之精英	qi chu zhi jing ying	1
+凄怆摧心肝	qi chuang cui xin gan	1
+其次不辱身	qi ci bu ru shen	1
+其次辟地	qi ci pi di	1
+其次辟色	qi ci pi se	1
+其次辟言	qi ci pi yan	1
+其次弱者	qi ci ruo zhe	1
+其从之也	qi cong zhi ye	1
+其脆易泮	qi cui yi pan	1
+其德乃普	qi de nai pu	1
+其德天杀	qi de tian sha	1
+汽笛一声肠已断	qi di yi sheng chang yi duan	1
+绮殿千寻起	qi dian qian xun qi	1
+凄断百年身	qi duan bai nian shen	1
+期而后可	qi er hou ke	1
+弃而违之	qi er wei zhi	1
+奇峰出奇云	qi feng chu qi yun	1
+祈父	qi fu	1
+其父攘羊	qi fu rang yang	1
+岂敢定居	qi gan ding ju	1
+岂敢反乎	qi gan fan hu	1
+岂敢盘桓	qi gan pan huan	1
+齐歌空复情	qi ge kong fu qing	1
+其故何也	qi gu he ye	1
+泣孤舟之嫠妇	qi gu zhou zhi li fu	1
+其广数千里	qi guang shu qian li	1
+其鬼不神	qi gui bu shen	1
+齐国虽褊小	qi guo sui bian xiao	1
+杞国无事忧天倾	qi guo wu shi you tian qing	1
+岂好辩哉	qi hao bian zai	1
+旗号镰刀斧头	qi hao lian dao fu tou	1
+岂合令郎君	qi he ling lang jun	1
+其何如	qi he ru	1
+其何伤于日月乎	qi he shang yu ri yue hu	1
+其何以行之哉	qi he yi xing zhi zai	1
+起宏图	qi hong tu	1
+其后二年	qi hou er nian	1
+其后六年	qi hou liu nian	1
+其后也处	qi hou ye chu	1
+其后也悔	qi hou ye hui	1
+齐侯之子	qi hou zhi zi	1
+绮户	qi hu	1
+齐浣	qi huan	1
+其黄而陨	qi huang er yun	1
+其或继周者	qi huo ji zhou zhe	1
+齐己	qi ji	1
+骐骥一跃	qi ji yi yue	1
+弃甲曳兵而走	qi jia ye bing er zou	1
+其皆出于此乎	qi jie chu yu ci hu	1
+泣尽继以血	qi jin ji yi xue	1
+其进愈难	qi jin yu nan	1
+其精甚真	qi jing shen zhen	1
+其觉无忧	qi jue wu you	1
+其觉也形开	qi jue ye xing kai	1
+起看天地色凄凉	qi kan tian di se qi liang	1
+其可怪也欤	qi ke guai ye yu	1
+汔可小康	qi ke xiao kang	1
+期可已矣	qi ke yi yi	1
+其可左右	qi ke zuo you	1
+其揆一也	qi kui yi ye	1
+契阔谈宴	qi kuo tan yan	1
+其乐只且	qi le zhi qie	1
+其丽不亿	qi li bu yi	1
+绮丽不足珍	qi li bu zu zhen	1
+岂力能制敌欤	qi li neng zhi di yu	1
+戚里生昌胤	qi li sheng chang yin	1
+其里之富人见之	qi li zhi fu ren jian zhi	1
+七里之郭	qi li zhi guo	1
+凄凉宝剑篇	qi liang bao jian pian	1
+凄凉犯	qi liang fan	1
+其良人出	qi liang ren chu	1
+凄凉调	qi liang tiao	1
+七律	qi lv	1
+七律到韶山	qi lv dao shao shan	1
+七律冬云	qi lv dong yun	1
+骑驴渺渺入荒陂	qi lv miao miao ru huang bei	1
+其寐也魂交	qi mei ye hun jiao	1
+其美者自美	qi mei zhe zi mei	1
+其民淳淳	qi min chun chun	1
+其民缺缺	qi min que que	1
+其名不去	qi ming bu qu	1
+其鸣喈喈	qi ming jie jie	1
+其名为鲲	qi ming wei kun	1
+其名为鹏	qi ming wei peng	1
+七年之内	qi nian zhi nei	1
+七娘子	qi niang zi	1
+骑牛远远过前村	qi niu yuan yuan guo qian cun	1
+妻孥怪我在	qi nu guai wo zai	1
+其泣喤喤	qi qi huang huang	1
+凄凄去亲爱	qi qi qu qin ai	1
+其寝不梦	qi qin bu meng	1
+凄清如许	qi qing ru xu	1
+其去不能止	qi qu bu neng zhi	1
+崎岖不易行	qi qu bu yi xing	1
+其曲中规	qi qu zhong gui	1
+岂人	qi ren	1
+齐人伐燕	qi ren fa yan	1
+其人甚远	qi ren shen yuan	1
+岂人为	qi ren wei	1
+其日固久	qi ri gu jiu	1
+其日牛马嘶	qi ri niu ma si	1
+其入不距	qi ru bu ju	1
+岂上望夫台	qi shang wang fu tai	1
+其神不伤人	qi shen bu shang ren	1
+齐声唤	qi sheng huan	1
+棋声惊昼眠	qi sheng jing zhou mian	1
+其生若浮	qi sheng ruo fu	1
+其声呜呜然	qi sheng wu wu ran	1
+其生也荣	qi sheng ye rong	1
+其生也天行	qi sheng ye tian xing	1
+其生之时	qi sheng zhi shi	1
+其食不甘	qi shi bu gan	1
+岂是池中物	qi shi chi zhong wu	1
+七十老翁何所求	qi shi lao weng he suo qiu	1
+气势两相高	qi shi liang xiang gao	1
+其使民也义	qi shi min ye yi	1
+其实七兮	qi shi qi xi	1
+其事上也敬	qi shi shang ye jing	1
+其视下也	qi shi xia ye	1
+起视夜何其	qi shi ye he qi	1
+其室则迩	qi shi ze er	1
+七十者衣帛食肉	qi shi zhe yi bo shi rou	1
+其实之肴	qi shi zhi yao	1
+七十字	qi shi zi	1
+其孰能讥之乎	qi shu neng ji zhi hu	1
+淇水汤汤	qi shui shang shang	1
+淇水滺滺	qi shui you you	1
+其谁知之	qi shui zhi zhi	1
+其舜也与	qi shun ye yu	1
+其斯而已矣	qi si er yi yi	1
+其死若休	qi si ruo xiu	1
+其死也哀	qi si ye ai	1
+其死也物化	qi si ye wu hua	1
+其斯之谓与	qi si zhi wei yu	1
+其所师	qi suo shi	1
+其他可能也	qi ta ke neng ye	1
+泣涕涟涟	qi ti lian lian	1
+泣涕如雨	qi ti ru yu	1
+岂忘二三子	qi wang er san zi	1
+其往欲何云	qi wang yu he yun	1
+七围八围	qi wei ba wei	1
+其未得之也	qi wei de zhi ye	1
+其为惑也	qi wei huo ye	1
+其为气也	qi wei qi ye	1
+岂为妻子谋	qi wei qi zi mou	1
+其为人也	qi wei ren ye	1
+其为仁之本与	qi wei ren zhi ben yu	1
+其惟圣人乎	qi wei sheng ren hu	1
+其微易散	qi wei yi san	1
+其未兆易谋	qi wei zhao yi mou	1
+奇文共欣赏	qi wen gong xin shang	1
+其文漫灭	qi wen man mie	1
+岂无膏沐	qi wu gao mu	1
+起舞莲花剑	qi wu lian hua jian	1
+綦毋潜	qi wu qian	1
+其无私德	qi wu si de	1
+岂无他士	qi wu ta shi	1
+其无正也	qi wu zheng ye	1
+其息深深	qi xi shen shen	1
+七夕始言归	qi xi shi yan gui	1
+七夕谁见同	qi xi shui jian tong	1
+气息奄奄	qi xi yan yan	1
+其下不昧	qi xia bu mei	1
+其下平旷	qi xia ping kuang	1
+其下维萚	qi xia wei tuo	1
+其贤不及孔子	qi xian bu ji kong zi	1
+岂羡王侯	qi xian wang hou	1
+其险也如此	qi xian ye ru ci	1
+岂向人间住	qi xiang ren jian zhu	1
+齐相杀之费二桃	qi xiang sha zhi fei er tao	1
+岂销铄	qi xiao shuo	1
+其啸也歌	qi xiao ye ge	1
+其心塞渊	qi xin sai yuan	1
+其心以为不然者	qi xin yi wei bu ran zhe	1
+其心与之然	qi xin yu zhi ran	1
+其行己也恭	qi xing ji ye gong	1
+其胸襟	qi xiong jin	1
+岂虚言哉	qi xu yan zai	1
+齐宣王问	qi xuan wang wen	1
+齐宣王问曰	qi xuan wang wen yue	1
+栖鸦归后	qi ya gui hou	1
+其言不让	qi yan bu rang	1
+七言古诗	qi yan gu shi	1
+七言绝句	qi yan jue ju	1
+其言似不足者	qi yan si bu zu zhe	1
+其言也善	qi yan ye shan	1
+其言之不怍	qi yan zhi bu zuo	1
+七阳	qi yang	1
+其养民也惠	qi yang min ye hui	1
+其叶沃若	qi ye wo ruo	1
+期夜月	qi ye yue	1
+其叶蓁蓁	qi ye zhen zhen	1
+栖一	qi yi	1
+其意常在沛公也	qi yi chang zai pei gong ye	1
+岂伊地气暖	qi yi di qi nuan	1
+期已久矣	qi yi jiu yi	1
+其一人恶	qi yi ren e	1
+其一人美	qi yi ren mei	1
+其翼若垂天之云	qi yi ruo chui tian zhi yun	1
+其仪一兮	qi yi yi xi	1
+其义一也	qi yi yi ye	1
+岂宜重问后庭花	qi yi zhong wen hou ting hua	1
+其用不弊	qi yong bu bi	1
+其用不穷	qi yong bu qiong	1
+岂有悔哉	qi you hui zai	1
+其由来	qi you lai	1
+齐有孟尝	qi you meng chang	1
+其有所试矣	qi you suo shi yi	1
+齐有倜傥生	qi you ti tang sheng	1
+其犹橐龠乎	qi you tuo yue hu	1
+岂有文章惊海内	qi you wen zhang jing hai nei	1
+其有夜旦之常	qi you ye dan zhi chang	1
+其由也与	qi you ye yu	1
+七虞	qi yu	1
+七遇	qi yu	1
+其愚不可及也	qi yu bu ke ji ye	1
+其雨其雨	qi yu qi yu	1
+其于人也	qi yu ren ye	1
+岂余身之惮殃兮	qi yu shen zhi dan yang xi	1
+跂予望之	qi yu wang zhi	1
+起予者商也	qi yu zhe shang ye	1
+七月时	qi yue shi	1
+七月食瓜	qi yue shi gua	1
+七月在野	qi yue zai ye	1
+其在道也	qi zai dao ye	1
+岂在多杀伤	qi zai duo sha shang	1
+其在宗庙朝廷	qi zai zong miao chao ting	1
+其则不远	qi ze bu yuan	1
+淇则有岸	qi ze you an	1
+欹枕江南烟雨	qi zhen jiang nan yan yu	1
+其政察察	qi zheng cha cha	1
+其政闷闷	qi zheng men men	1
+其正色邪	qi zheng se xie	1
+其争也君子	qi zheng ye jun zi	1
+气之大者也	qi zhi da zhe ye	1
+其知道乎	qi zhi dao hu	1
+气之聚也	qi zhi ju ye	1
+其知可及也	qi zhi ke ji ye	1
+弃掷逦迤	qi zhi li yi	1
+其知弥少	qi zhi mi shao	1
+其直如矢	qi zhi ru shi	1
+其制稍异于前	qi zhi shao yi yu qian	1
+气之帅也	qi zhi shuai ye	1
+弃脂水也	qi zhi shui ye	1
+其至矣乎	qi zhi yi hu	1
+其终也已	qi zhong ye yi	1
+其中有精	qi zhong you jing	1
+其中有物	qi zhong you wu	1
+其中有象	qi zhong you xiang	1
+其中有信	qi zhong you xin	1
+岂逐春风一一回	qi zhu chun feng yi yi hui	1
+乞诸其邻而与之	qi zhu qi lin er yu zhi	1
+妻子好合	qi zi hao he	1
+其子七兮	qi zi qi xi	1
+其自视也	qi zi shi ye	1
+其作始也简	qi zuo shi ye jian	1
+起坐鱼鸟间	qi zuo yu niao jian	1
+恰似十五女儿腰	qia si shi wu nv er yao	1
+钱安安	qian an an	1
+千百里	qian bai li	1
+千变万化皆天机	qian bian wan hua jie tian ji	1
+前赤壁赋	qian chi bi fu	1
+浅处无妨有卧龙	qian chu wu fang you wo long	1
+千春隔流水	qian chun ge liu shui	1
+千村薜荔人遗矢	qian cun bi li ren yi shi	1
+千村万落生荆杞	qian cun wan luo sheng jing qi	1
+千二百轻鸾	qian er bai qing luan	1
+千古风流事	qian gu feng liu shi	1
+谦光	qian guang	1
+铅华不可弃	qian hua bu ke qi	1
+千唤不一回	qian huan bu yi hui	1
+千家山郭静朝晖	qian jia shan guo jing zhao hui	1
+千金裘	qian jin qiu	1
+千金一笑买倾城	qian jin yi xiao mai qing cheng	1
+前军夜战洮河北	qian jun ye zhan tao he bei	1
+乾康	qian kang	1
+迁客相看泪满衣	qian ke xiang kan lei man yi	1
+乾坤水上萍	qian kun shui shang ping	1
+乾坤一腐儒	qian kun yi fu ru	1
+乾坤展清眺	qian kun zhan qing tiao	1
+千里冰封	qian li bing feng	1
+千里不留行	qian li bu liu xing	1
+千里共明月	qian li gong ming yue	1
+千里佳期一夕休	qian li jia qi yi xi xiu	1
+千里江陵一日还	qian li jiang ling yi ri huan	1
+千里来寻故地	qian li lai xun gu di	1
+千里其如何	qian li qi ru he	1
+千里思	qian li si	1
+千里迢迢	qian li tiao tiao	1
+千里万里月明	qian li wan li yue ming	1
+千里莺啼绿映江	qian li ying ti lv ying jiang	1
+千里照相思	qian li zhao xiang si	1
+前路日将斜	qian lu ri jiang xie	1
+牵萝补茅屋	qian luo bu mao wu	1
+前年伐月支	qian nian fa yue zhi	1
+千年调	qian nian tiao	1
+牵牛出河西	qian niu chu he xi	1
+前辟四窗	qian pi si chuang	1
+钱起	qian qi	1
+浅浅石溜泻	qian qian shi liu xie	1
+千秋二壮士	qian qiu er zhuang shi	1
+千秋功罪	qian qiu gong zui	1
+千秋节	qian qiu jie	1
+千秋万岁	qian qiu wan sui	1
+千秋万岁后	qian qiu wan sui hou	1
+千秋万岁名	qian qiu wan sui ming	1
+千取百焉	qian qu bai yan	1
+前人田地后人收	qian ren tian di hou ren shou	1
+千仞之高	qian ren zhi gao	1
+千山响杜鹃	qian shan xiang du juan	1
+褰裳	qian shang	1
+褰裳涉溱	qian shang she qin	1
+千乘之君	qian sheng zhi jun	1
+千室之邑	qian shi zhi yi	1
+千首诗轻万户侯	qian shou shi qing wan hu hou	1
+遣谁听	qian shui ting	1
+前太守臣逵	qian tai shou chen kui	1
+前头捉了张辉瓒	qian tou zhuo le zhang hui zan	1
+千万不复全	qian wan bu fu quan	1
+千万人之心也	qian wan ren zhi xin ye	1
+芊蔚何青青	qian wei he qing qing	1
+钱信	qian xin	1
+前行若无山	qian xing ruo wu shan	1
+钱珝	qian xu	1
+千寻铁锁沈江底	qian xun tie suo shen jiang di	1
+千岩万壑不辞劳	qian yan wan he bu ci lao	1
+千岩万壑路不定	qian yan wan he lu bu ding	1
+千岩万转路不定	qian yan wan zhuan lu bu ding	1
+前言戏之耳	qian yan xi zhi er	1
+牵衣顿足拦道哭	qian yi dun zu lan dao ku	1
+千营共一呼	qian ying gong yi hu	1
+前缘竟何似	qian yuan jing he si	1
+千载落风尘	qian zai luo feng chen	1
+千载琵琶作胡语	qian zai pi pa zuo hu yu	1
+千载谢东风	qian zai xie dong feng	1
+浅则揭	qian ze jie	1
+千杖敲铿羯鼓催	qian zhang qiao keng jie gu cui	1
+强国请服	qiang guo qing fu	1
+枪急万人呼	qiang ji wan ren hu	1
+将进酒	qiang jin jiu	1
+将进酒杯莫停	qiang jin jiu bei mo ting	1
+将进酒君莫停	qiang jin jiu jun mo ting	1
+墙里佳人笑	qiang li jia ren xiao	1
+墙里秋千墙外道	qiang li qiu qian qiang wai dao	1
+强梁者不得其死	qiang liang zhe bu de qi si	1
+枪林逼	qiang lin bi	1
+强虏灰飞烟灭	qiang lu hui fei yan mie	1
+羌戎贺劳旋	qiang rong he lao xuan	1
+墙外行人	qiang wai xing ren	1
+蔷薇几度花	qiang wei ji du hua	1
+强为之名曰大	qiang wei zhi ming yue da	1
+强行者有志	qiang xing zhe you zhi	1
+强移栖息一枝安	qiang yi qi xi yi zhi an	1
+墙有茨	qiang you ci	1
+强欲从君无那老	qiang yu cong jun wu na lao	1
+强欲登高去	qiang yu deng gao qu	1
+枪榆枋而止	qiang yu fang er zhi	1
+憔悴也相关	qiao cui ye xiang guan	1
+憔悴支离为忆君	qiao cui zhi li wei yi jun	1
+桥低乌鹊夜	qiao di wu que ye	1
+桥回行欲断	qiao hui xing yu duan	1
+乔吉	qiao ji	1
+乔侃	qiao kan	1
+樵客初传汉姓名	qiao ke chu chuan han xing ming	1
+乔牌儿	qiao pai er	1
+桥欹绝涧中	qiao qi jue jian zhong	1
+翘翘错薪	qiao qiao cuo xin	1
+樵人归欲尽	qiao ren gui yu jin	1
+乔舜	qiao shun	1
+巧笑人疑在	qiao xiao ren yi zai	1
+巧笑之瑳	qiao xiao zhi cuo	1
+巧言令色	qiao yan ling se	1
+巧言偏辞	qiao yan pian ci	1
+巧言如簧	qiao yan ru huang	1
+乔知之	qiao zhi zhi	1
+巧啭岂能无本意	qiao zhuan qi neng wu ben yi	1
+妾薄命	qie bo ming	1
+妾不堪驱使	qie bu kan qu shi	1
+且持梦笔书奇景	qie chi meng bi shu qi jing	1
+妾当作蒲苇	qie dang zuo pu wei	1
+锲而舍之	qie er she zhi	1
+且尔言过矣	qie er yan guo yi	1
+妾发初覆额	qie fa chu fu e	1
+且放白鹿青崖间	qie fang bai lu qing ya jian	1
+怯夫慕义	qie fu mu yi	1
+且夫天地之间	qie fu tian di zhi jian	1
+且负下未易居	qie fu xia wei yi ju	1
+窃国者为诸侯	qie guo zhe wei zhu hou	1
+且何谓阁子也	qie he wei ge zi ye	1
+且教红粉相扶	qie jiao hong fen xiang fu	1
+且尽生前有限杯	qie jin sheng qian you xian bei	1
+且尽手中杯	qie jin shou zhong bei	1
+且就洞庭赊月色	qie jiu dong ting she yue se	1
+且看欲尽花经眼	qie kan yu jin hua jing yan	1
+且乐生前一杯酒	qie le sheng qian yi bei jiu	1
+挈妻子而去之走	qie qi zi er qu zhi zou	1
+切切故乡情	qie qie gu xiang qing	1
+且如今年冬	qie ru jin nian dong	1
+妾身未分明	qie shen wei fen ming	1
+且适南冥也	qie shi nan ming ye	1
+妾似井底桃	qie si jing di tao	1
+且随缘	qie sui yuan	1
+且往观乎	qie wang guan hu	1
+窃为大王不取也	qie wei da wang bu qu ye	1
+且为王孙立斯须	qie wei wang sun li si xu	1
+且为之奈何	qie wei zhi nai he	1
+窃闻天子已传位	qie wen tian zi yi chuan wei	1
+妾心井中水	qie xin jing zhong shui	1
+且须酣畅万古情	qie xu han chang wan gu qing	1
+且以汝之有身也	qie yi ru zhi you shen ye	1
+且以喜乐	qie yi xi le	1
+且饮美酒登高楼	qie yin mei jiu deng gao lou	1
+妾有情	qie you qing	1
+且由他	qie you ta	1
+妾有绣腰襦	qie you xiu yao ru	1
+且欲竟寻彭泽宰	qie yu jing xun peng ze zai	1
+且暂还家去	qie zan hai jia qu	1
+且知方也	qie zhi fang ye	1
+妾住在横塘	qie zhu zai heng tang	1
+秦爱纷奢	qin ai fen she	1
+秦川得及此间无	qin chuan de ji ci jian wu	1
+秦地可尽王也	qin di ke jin wang ye	1
+秦地罗敷女	qin di luo fu nv	1
+琴调	qin diao	1
+琴调相思引	qin diao xiang si yin	1
+秦娥梦断秦楼月	qin e meng duan qin lou yue	1
+亲而行之	qin er xing zhi	1
+勤而行之	qin er xing zhi	1
+亲而誉之	qin er yu zhi	1
+琴歌	qin ge	1
+秦皇岛外打鱼船	qin huang dao wai da yu chuan	1
+禽荒非所乐	qin huang fei suo le	1
+秦皇扫六合	qin huang sao lu he	1
+秦嘉	qin jia	1
+秦楼月	qin lou yue	1
+亲朋无一字	qin peng wu yi zi	1
+秦人不暇自哀	qin ren bu xia zi ai	1
+秦人开关延敌	qin ren kai guan yan di	1
+秦人视之	qin ren shi zhi	1
+秦桑低绿枝	qin sang di lv zhi	1
+琴瑟相思引	qin se xiang si yin	1
+琴瑟在御	qin se zai yu	1
+秦士录	qin shi lu	1
+秦时与臣游	qin shi yu chen you	1
+禽兽逼人	qin shou bi ren	1
+禽兽成群	qin shou cheng qun	1
+螓首蛾眉	qin shou e mei	1
+禽兽繁殖	qin shou fan zhi	1
+琴台日暮云	qin tai ri mu yun	1
+秦韬玉	qin tao yu	1
+溱洧	qin wei	1
+琴心三叠道初成	qin xin san die dao chu cheng	1
+勤心养公姥	qin xin yang gong lao	1
+溱与洧	qin yu wei	1
+沁园春长沙	qin yuan chun chang sha	1
+秦湛	qin zhan	1
+秦中自古帝王州	qin zhong zi gu di wang zhou	1
+青霭入看无	qing ai ru kan wu	1
+倾白酒	qing bai jiu	1
+倾杯	qing bei	1
+轻薄儿	qing bo er	1
+轻薄桃花逐水流	qing bo tao hua zhu shui liu	1
+轻薄为文哂未休	qing bo wei wen shen wei xiu	1
+清波引	qing bo yin	1
+庆长春	qing chang chun	1
+请尝试之	qing chang shi zhi	1
+清晨再拜铺丹墀	qing chen zai bai pu dan chi	1
+倾城最在著戎衣	qing cheng zui zai zhu rong yi	1
+轻翅萦枝舞蝶来	qing chi ying zhi wu die lai	1
+清川带长薄	qing chuan dai chang bo	1
+清川澹如此	qing chuan dan ru ci	1
+青春不再来	qing chun bu zai lai	1
+庆春宫	qing chun gong	1
+青春留不住	qing chun liu bu zhu	1
+青春岂不惜	qing chun qi bu xi	1
+青春虚度无所成	qing chun xu du wu suo cheng	1
+庆春泽	qing chun ze	1
+青春作伴好还乡	qing chun zuo ban hao huan xiang	1
+情词	qing ci	1
+清词丽句必为邻	qing ci li ju bi wei lin	1
+卿但暂还家	qing dan zan huan jia	1
+卿当日胜贵	qing dang ri sheng gui	1
+庆东原	qing dong yuan	1
+青墩溪畔龙钟客	qing dun xi pan long zhong ke	1
+情多去未得	qing duo qu wei de	1
+清风吹空月舒波	qing feng chui kong yue shu bo	1
+青枫江上秋帆远	qing feng jiang shang qiu fan yuan	1
+清风明月苦相思	qing feng ming yue ku xiang si	1
+清风明月无人管	qing feng ming yue wu ren guan	1
+青枫叶赤天雨霜	qing feng ye chi tian yu shuang	1
+青哥儿	qing ge er	1
+清歌妙舞落花前	qing ge miao wu luo hua qian	1
+清光应更多	qing guang ying geng duo	1
+清光犹为君	qing guang you wei jun	1
+晴光转绿苹	qing guang zhuan lv ping	1
+青归柳叶新	qing gui liu ye xin	1
+倾国倾城胜莫愁	qing guo qing cheng sheng mo chou	1
+青海头	qing hai tou	1
+清和风	qing he feng	1
+情何限	qing he xian	1
+清淮奉使千馀里	qing huai feng shi qian yu li	1
+青槐夹驰道	qing huai jia chi dao	1
+清辉淡水木	qing hui dan shui mu	1
+清辉照衣裳	qing hui zhao yi shang	1
+清江行	qing jiang xing	1
+清江一曲抱村流	qing jiang yi qu bao cun liu	1
+清静为天下正	qing jing wei tian xia zheng	1
+情久长	qing jiu chang	1
+请君为我侧耳听	qing jun wei wo ce er ting	1
+请看石上藤萝月	qing kan shi shang teng luo yue	1
+卿可去成婚	qing ke qu cheng hun	1
+顷刻兴亡过手	qing ke xing wang guo shou	1
+顷筐塈之	qing kuang xi zhi	1
+青莲居士谪仙人	qing lian ju shi zhe xian ren	1
+青绫被	qing ling bei	1
+青陵台	qing ling tai	1
+清流	qing liu	1
+请留盘石上	qing liu pan shi shang	1
+青楼薄幸名	qing lou bo xing ming	1
+青楼扑酒旗	qing lou pu jiu qi	1
+青楼自管弦	qing lou zi guan xian	1
+请略陈固陋	qing lue chen gu lou	1
+青萝拂行衣	qing luo fu xing yi	1
+轻罗已薄未更衣	qing luo yi bo wei geng yi	1
+青门种瓜人	qing men zhong gua ren	1
+青冥浩荡不见底	qing ming hao dang bu jian di	1
+清明几处有新烟	qing ming ji chu you xin yan	1
+清明即事	qing ming ji shi	1
+清明日	qing ming ri	1
+青泥何盘盘	qing ni he pan pan	1
+青鸟不传云外信	qing niao bu chuan yun wai xin	1
+青鸟飞去衔红巾	qing niao fei qu xian hong jin	1
+青鸟明丹心	qing niao ming dan xin	1
+青牛白马七香车	qing niu bai ma qi xiang che	1
+青女不饶霜	qing nv bu rao shuang	1
+晴偏好	qing pian hao	1
+轻颦双黛螺	qing pin shuang dai luo	1
+清平调	qing ping diao	1
+清平调词三首	qing ping diao ci san shou	1
+清平乐会昌	qing ping le hui chang	1
+清平乐六盘山	qing ping le liu pan shan	1
+清浅白石滩	qing qian bai shi tan	1
+庆千秋	qing qian qiu	1
+情亲见君意	qing qin jian jun yi	1
+庆清朝	qing qing chao	1
+庆清朝慢	qing qing chao man	1
+庆青春	qing qing chun	1
+青青夹御河	qing qing jia yu he	1
+青青竹笋迎船出	qing qing zhu sun ying chuan chu	1
+清秋幕府井梧寒	qing qiu mu fu jing wu han	1
+清秋燕子故飞飞	qing qiu yan zi gu fei fei	1
+情人怨遥夜	qing ren yuan yao ye	1
+青箬笠绿蓑衣	qing ruo li lv suo yi	1
+清瑟怨遥夜	qing se yuan yao ye	1
+青山朝别暮还见	qing shan chao bie mu hai jian	1
+青山澹吾虑	qing shan dan wu lv	1
+青山卷白云	qing shan juan bai yun	1
+青山空复情	qing shan kong fu qing	1
+青山空向人	qing shan kong xiang ren	1
+青山缭绕疑无路	qing shan liao rao yi wu lu	1
+青山绿水共为邻	qing shan lv shui gong wei lin	1
+青山明月不曾空	qing shan ming yue bu ceng kong	1
+青山明月梦中看	qing shan ming yue meng zhong kan	1
+青山湿遍	qing shan shi bian	1
+青衫湿遍	qing shan shi bian	1
+青山万里一孤舟	qing shan wan li yi gu zhou	1
+青山望断河	qing shan wang duan he	1
+青山行不尽	qing shan xing bu jin	1
+青山一道同云雨	qing shan yi dao tong yun yu	1
+青山犹哭声	qing shan you ku sheng	1
+青山着意化为桥	qing shan zhuo yi hua wei qiao	1
+清商怨	qing shang yuan	1
+轻生一剑知	qing sheng yi jian zhi	1
+青史古人空	qing shi gu ren kong	1
+青史几行名姓	qing shi ji hang ming xing	1
+清诗句句尽堪传	qing shi ju ju jin kan chuan	1
+请事斯语矣	qing shi si yu yi	1
+清时有味是无能	qing shi you wei shi wu neng	1
+清水白石何离离	qing shui bai shi he li li	1
+清水出芙蓉	qing shui chu fu rong	1
+清泗与淮通	qing si yu huai tong	1
+青松蔽日	qing song bi ri	1
+青松如膏沐	qing song ru gao mu	1
+青苔满阶砌	qing tai man jie qi	1
+青天骑白龙	qing tian qi bai long	1
+青天无片云	qing tian wu pian yun	1
+青天削出金芙蓉	qing tian xue chu jin fu rong	1
+青天有月来几时	qing tian you yue lai ji shi	1
+清湍鸣回溪	qing tuan ming hui xi	1
+轻纨细绮相追飞	qing wan xi qi xiang zhui fei	1
+请往谓项伯	qing wang wei xiang bo	1
+清渭东流剑阁深	qing wei dong liu jian ge shen	1
+请问其目	qing wen qi mu	1
+青溪	qing xi	1
+清溪清我心	qing xi qing wo xin	1
+清溪深不测	qing xi shen bu ce	1
+青霞断绛河	qing xia duan jiang he	1
+清香更何用	qing xiang geng he yong	1
+清心拂尘服	qing xin fu chen fu	1
+清新庾开府	qing xin yu kai fu	1
+青杏儿	qing xing er	1
+庆宣和	qing xuan he	1
+请循其本	qing xun qi ben	1
+青眼高歌惧未老	qing yan gao ge ju wei lao	1
+清言见古今	qing yan jian gu jin	1
+青阳逼岁除	qing yang bi sui chu	1
+清扬婉兮	qing yang wan xi	1
+清夜坠玄天	qing ye zhui xuan tian	1
+请以剑舞	qing yi jian wu	1
+请以战喻	qing yi zhan yu	1
+轻阴阁小雨	qing yin ge xiao yu	1
+清远道士	qing yuan dao shi	1
+清月出岭光入扉	qing yue chu ling guang ru fei	1
+卿云	qing yun	1
+青云当自致	qing yun dang zi zhi	1
+青云少年子	qing yun shao nian zi	1
+轻云微月	qing yun wei yue	1
+青云羡鸟飞	qing yun xian niao fei	1
+青云怨	qing yun yuan	1
+顷在黄州	qing zai huang zhou	1
+轻则失根	qing ze shi gen	1
+青冢黄昏路	qing zhong huang hun lu	1
+轻舟去何疾	qing zhou qu he ji	1
+请奏鸣琴广陵客	qing zou ming qin guang ling ke	1
+穷兵黩武今如此	qiong bing du wu jin ru ci	1
+穷愁千万端	qiong chou qian wan duan	1
+穷发之北	qiong fa zhi bei	1
+琼楼玉宇	qiong lou yu yu	1
+穷年忧黎元	qiong nian you li yuan	1
+琼台	qiong tai	1
+穷巷牛羊归	qiong xiang niu yang gui	1
+穷亦不足悲	qiong yi bu zu bei	1
+琼珠碎却圆	qiong zhu sui que yuan	1
+秋边一雁声	qiu bian yi yan sheng	1
+丘不与易也	qiu bu yu yi ye	1
+秋草独寻人去后	qiu cao du xun ren qu hou	1
+秋蝉疏引	qiu chan shu yin	1
+秋池不自冷	qiu chi bu zi leng	1
+秋丛绕舍似陶家	qiu cong rao she si tao jia	1
+丘丹	qiu dan	1
+秋登兰山寄张五	qiu deng lan shan ji zhang wu	1
+秋风不相待	qiu feng bu xiang dai	1
+秋风忽忆江东行	qiu feng hu yi jiang dong xing	1
+秋风惊绿	qiu feng jing lv	1
+秋风卷入小单于	qiu feng juan ru xiao chan yu	1
+秋风清	qiu feng qing	1
+秋风走马出咸阳	qiu feng zou ma chu xian yang	1
+秋歌	qiu ge	1
+秋光满目	qiu guang man mu	1
+秋毫不敢有所近	qiu hao bu gan you suo jin	1
+秋河隔在数峰西	qiu he ge zai shu feng xi	1
+秋荷一滴露	qiu he yi di lu	1
+秋花落更迟	qiu hua luo geng chi	1
+秋花冒绿水	qiu hua mao lv shui	1
+秋槐叶落空宫里	qiu huai ye luo kong gong li	1
+秋江碧入吴	qiu jiang bi ru wu	1
+秋尽江南草木凋	qiu jin jiang nan cao mu diao	1
+秋景丽	qiu jing li	1
+秋菊能傲霜	qiu ju neng ao shuang	1
+秋空明月悬	qiu kong ming yue xuan	1
+秋来处处割愁肠	qiu lai chu chu ge chou chang	1
+秋来南向飞	qiu lai nan xiang fei	1
+秋来未著花	qiu lai wei zhu hua	1
+秋来相顾尚飘蓬	qiu lai xiang gu shang piao peng	1
+丘峦崩摧	qiu luan beng cui	1
+秋梦不归家	qiu meng bu gui jia	1
+秋浦歌十七首	qiu pu ge shi qi shou	1
+秋浦途中	qiu pu tu zhong	1
+求其友声	qiu qi you sheng	1
+秋千期约	qiu qian qi yue	1
+秋千索	qiu qian suo	1
+求仁而得仁	qiu ren er de ren	1
+秋日望乡心	qiu ri wang xiang xin	1
+秋蕊香	qiu rui xiang	1
+求若所欲	qiu ruo suo yu	1
+秋色从西来	qiu se cong xi lai	1
+秋色横空	qiu se heng kong	1
+秋色老梧桐	qiu se lao wu tong	1
+秋色无远近	qiu se wu yuan jin	1
+秋色有佳兴	qiu se you jia xing	1
+秋山又几重	qiu shan you ji chong	1
+秋声不可闻	qiu sheng bu ke wen	1
+秋声万户竹	qiu sheng wan hu zhu	1
+秋收时节暮云愁	qiu shou shi jie mu yun chou	1
+秋水	qiu shui	1
+秋水秋天生夕风	qiu shui qiu tian sheng xi feng	1
+秋水日潺湲	qiu shui ri chan yuan	1
+秋水为神玉为骨	qiu shui wei shen yu wei gu	1
+丘说	qiu shuo	1
+秋思冬愁春恨望	qiu si dong chou chun hen wang	1
+秋思耗	qiu si hao	1
+秋思夜	qiu si ye	1
+丘为	qiu wei	1
+邱为	qiu wei	1
+求为可知也	qiu wei ke zhi ye	1
+求我庶士	qiu wo shu shi	1
+秋下荆门	qiu xia jing men	1
+秋宵吟	qiu xiao yin	1
+秋宵月色胜春宵	qiu xiao yue se sheng chun xiao	1
+秋宵月下有怀	qiu xiao yue xia you huai	1
+虬须虎眉仍大颡	qiu xu hu mei reng da sang	1
+秋雁又南回	qiu yan you nan hui	1
+秋夜长	qiu ye chang	1
+秋夜寄邱员外	qiu ye ji qiu yuan wai	1
+求也为之	qiu ye wei zhi	1
+秋夜雨	qiu ye yu	1
+丘亦耻之	qiu yi chi zhi	1
+秋以为期	qiu yi wei qi	1
+秋雨晴时泪不晴	qiu yu qing shi lei bu qing	1
+丘悦	qiu yue	1
+秋月明	qiu yue ming	1
+秋月夜	qiu yue ye	1
+秋云暗几重	qiu yun an ji chong	1
+求者遍山隅	qiu zhe bian shan yu	1
+丘之不得济也	qiu zhi bu de ji ye	1
+求之不得心常爱	qiu zhi bu de xin chang ai	1
+求之不可得	qiu zhi bu ke de	1
+丘中有麻	qiu zhong you ma	1
+曲罢曾教善才服	qu ba ceng jiao shan cai fu	1
+曲罢悯然	qu ba min ran	1
+曲岛苍茫接翠微	qu dao cang mang jie cui wei	1
+驱儿罗酒浆	qu er luo jiu jiang	1
+曲肱而枕之	qu gong er zhen zhi	1
+去郭轩楹敞	qu guo xuan ying chang	1
+渠会永无缘	qu hui yong wu yuan	1
+曲尽河星稀	qu jin he xing xi	1
+曲尽已忘情	qu jin yi wang qing	1
+去来固无迹	qu lai gu wu ji	1
+曲阑干	qu lan gan	1
+驱马出关门	qu ma chu guan men	1
+驱马复归来	qu ma fu gui lai	1
+驱马悠悠	qu ma you you	1
+去年花里逢君别	qu nian hua li feng jun bie	1
+去年人到今年老	qu nian ren dao jin nian lao	1
+去年相送	qu nian xiang song	1
+屈平词赋悬日月	qu ping ci fu xuan ri yue	1
+曲千秋	qu qian qiu	1
+去去不足观	qu qu bu zu guan	1
+去去复去去	qu qu fu qu qu	1
+曲曲如屏	qu qu ru ping	1
+去去思君深	qu qu si jun shen	1
+去日儿童皆长大	qu ri er tong jie zhang da	1
+曲入冥	qu ru ming	1
+取瑟而歌	qu se er ge	1
+去世法舟轻	qu shi fa zhou qing	1
+去时冠剑是丁年	qu shi guan jian shi ding nian	1
+去时里正与裹头	qu shi li zheng yu guo tou	1
+瞿塘峡口冷烟低	qu tang xia kou leng yan di	1
+瞿塘滟预堆	qu tang yan yu dui	1
+取天下常以无事	qu tian xia chang yi wu shi	1
+趣途无百里	qu tu wu bai li	1
+臞翁	qu weng	1
+去吴中	qu wu zhong	1
+驱烟寻涧户	qu yan xun jian hu	1
+区以别矣	qu yi bie yi	1
+去以六月息者也	qu yi liu yue xi zhe ye	1
+屈原	qu yuan	1
+屈原放逐	qu yuan fang zhu	1
+屈原离骚	qu yuan li sao	1
+曲则全者	qu ze quan zhe	1
+屈折礼乐	qu zhe li yue	1
+取之无禁	qu zhi wu jin	1
+屈指西风几时来	qu zhi xi feng ji shi lai	1
+屈指行程二万	qu zhi xing cheng er wan	1
+屈指行程两万	qu zhi xing cheng liang wan	1
+去住彼此无消息	qu zhu bi ci wu xiao xi	1
+权德舆	quan de yu	1
+犬吠水声中	quan fei shui sheng zhong	1
+泉壑带茅茨	quan he dai mao ci	1
+劝金船	quan jin chuan	1
+劝君酒	quan jun jiu	1
+劝君莫拒杯	quan jun mo ju bei	1
+劝君莫惜金缕衣	quan jun mo xi jin lv yi	1
+劝君惜取少年时	quan jun xi qu shao nian shi	1
+劝君终日酩酊醉	quan jun zhong ri ming ding zui	1
+全民有责	quan min you ze	1
+权审	quan shen	1
+泉声咽危石	quan sheng yan wei shi	1
+劝我识作石鼓歌	quan wo shi zuo shi gu ge	1
+全无敌	quan wu di	1
+权无染	quan wu ran	1
+泉源在庭户	quan yuan zai ting hu	1
+泉源在左	quan yuan zai zuo	1
+荃者所以在鱼	quan zhe suo yi zai yu	1
+劝醉	quan zui	1
+却道	que dao	1
+雀儿答道	que er da dao	1
+却顾所来径	que gu suo lai jing	1
+却怕有人知	que pa you ren zhi	1
+鹊桥仙令	que qiao xian ling	1
+却去闻秋风	que qu wen qiu feng	1
+阙然久不报	que ran jiu bu bao	1
+鹊踏枝	que ta zhi	1
+阙题	que ti	1
+却望青青巘	que wang qing qing yan	1
+却下水晶帘	que xia shui jing lian	1
+却嫌脂粉污颜色	que xian zhi fen wu yan se	1
+却匈奴七百余里	que xiong nu qi bai yu li	1
+却疑春色在邻家	que yi chun se zai lin jia	1
+却忆红楼半夜灯	que yi hong lou ban ye deng	1
+却与小姑别	que yu xiao gu bie	1
+缺月昏昏漏未央	que yue hun hun lou wei yang	1
+却走马以粪	que zou ma yi fen	1
+群捕鱼儿溪影中	qun bu yu er xi ying zhong	1
+群雌粥粥	qun ci yu yu	1
+群而不党	qun er bu dang	1
+群壑倏已暝	qun he shu yi ming	1
+群居终日	qun ju zhong ri	1
+群轻折轴	qun qing zhe zhou	1
+群山万壑赴荆门	qun shan wan he fu jing men	1
+逡巡而不敢进	qun xun er bu gan jin	1
+群彦今汪洋	qun yan jin wang yang	1
+然此可为智者道	ran ci ke wei zhi zhe dao	1
+然而不胜者	ran er bu sheng zhe	1
+然而不王者	ran er bu wang zhe	1
+然而成败异变	ran er cheng bai yi bian	1
+然而未仁	ran er wei ren	1
+然后察之	ran hou cha zhi	1
+然后从而刑之	ran hou cong er xing zhi	1
+然后践华为城	ran hou jian hua wei cheng	1
+然后君子	ran hou jun zi	1
+然后请问	ran hou qing wen	1
+然后驱而之善	ran hou qu er zhi shan	1
+然后人侮之	ran hou ren wu zhi	1
+然后杀之	ran hou sha zhi	1
+然后图南	ran hou tu nan	1
+然后相携卧白云	ran hou xiang xie wo bai yun	1
+然后行事	ran hou xing shi	1
+然后知长短	ran hou zhi chang duan	1
+然后知轻重	ran hou zhi qing zhong	1
+然诺重	ran nuo zhong	1
+然秦以区区之地	ran qin yi qu qu zhi di	1
+苒苒几盈虚	ran ran ji ying xu	1
+冉冉云	ran ran yun	1
+然视其左右	ran shi qi zuo you	1
+然则何如	ran ze he ru	1
+然则师愈与	ran ze shi yu yu	1
+然则一羽之不举	ran ze yi yu zhi bu ju	1
+绕地游	rao di you	1
+绕弦风雨哀	rao xian feng yu ai	1
+热风吹雨洒江天	re feng chui yu sa jiang tian	1
+热泪欲零还住	re lei yu ling hai zhu	1
+热烈浪漫	re lie lang man	1
+人百其身	ren bai qi shen	1
+人必知之	ren bi zhi zhi	1
+人不见	ren bu jian	1
+人不堪其忧	ren bu kan qi you	1
+仁不能守之	ren bu neng shou zhi	1
+人不识	ren bu shi	1
+人不厌其取	ren bu yan qi qu	1
+人不厌其笑	ren bu yan qi xiao	1
+人不厌其言	ren bu yan qi yan	1
+人不以善言为贤	ren bu yi shan yan wei xian	1
+人初生	ren chu sheng	1
+人处一焉	ren chu yi yan	1
+人传郎在凤凰山	ren chuan lang zai feng huang shan	1
+人淡淡	ren dan dan	1
+人道横江好	ren dao heng jiang hao	1
+人得而诛之	ren de er zhu zhi	1
+认得醉翁语	ren de zui weng yu	1
+忍而不能舍也	ren er bu neng she ye	1
+人而不仁	ren er bu ren	1
+人而无恒	ren er wu heng	1
+人而无礼	ren er wu li	1
+人而无情	ren er wu qing	1
+人而无止	ren er wu zhi	1
+任翻	ren fan	1
+忍放花如雪	ren fang hua ru xue	1
+人非生而知之者	ren fei sheng er zhi zhi zhe	1
+人分千里外	ren fen qian li wai	1
+人告之以有过	ren gao zhi yi you guo	1
+忍更思量	ren geng si liang	1
+人归暮雪时	ren gui mu xue shi	1
+人归山郭暗	ren gui shan guo an	1
+任华	ren hua	1
+人或为鱼鳖	ren huo wei yu bie	1
+人间没个安排处	ren jian mei ge an pai chu	1
+人间如梦	ren jian ru meng	1
+人间万事出艰辛	ren jian wan shi chu jian xin	1
+人间亦自有丹丘	ren jian yi zi you dan qiu	1
+人间又见真乘黄	ren jian you jian zhen cheng huang	1
+人将拒我	ren jiang ju wo	1
+人将相食	ren jiang xiang shi	1
+人皆见之	ren jie jian zhi	1
+人皆苦炎热	ren jie ku yan re	1
+人皆谓我毁明堂	ren jie wei wo hui ming tang	1
+人皆为之	ren jie wei zhi	1
+人皆仰之	ren jie yang zhi	1
+人皆养子望聪明	ren jie yang zi wang cong ming	1
+人皆有兄弟	ren jie you xiong di	1
+人皆知有用之用	ren jie zhi you yong zhi yong	1
+人君当神器之重	ren jun dang shen qi zhi zhong	1
+人看隘若耶	ren kan ai ruo ye	1
+人来去	ren lai qu	1
+忍泪吟	ren lei yin	1
+人怜直节生来瘦	ren lian zhi jie sheng lai shou	1
+人六亿	ren liu yi	1
+人民五亿不团圆	ren min wu yi bu tuan yuan	1
+人命危浅	ren ming wei qian	1
+人能弘道	ren neng hong dao	1
+仁能守之	ren neng shou zhi	1
+人攀明月不可得	ren pan ming yue bu ke de	1
+人贫伤可怜	ren pin shang ke lian	1
+人乞祭余骄妾妇	ren qi ji yu jiao qie fu	1
+人其舍诸	ren qi she zhu	1
+人情翻覆似波澜	ren qing fan fu si bo lan	1
+人情已厌南中苦	ren qing yi yan nan zhong ku	1
+纫秋兰以为佩	ren qiu lan yi wei pei	1
+人去紫台秋入塞	ren qu zi tai qiu ru sai	1
+荏苒荏苒瞻四海	ren ran ren ran zhan si hai	1
+人人亲其亲	ren ren qin qi qin	1
+人日题诗寄草堂	ren ri ti shi ji cao tang	1
+人生本无事	ren sheng ben wu shi	1
+人生不得已	ren sheng bu de yi	1
+人生不满百	ren sheng bu man bai	1
+人生不如意	ren sheng bu ru yi	1
+人生不相见	ren sheng bu xiang jian	1
+人生处万类	ren sheng chu wan lei	1
+人生达命岂暇愁	ren sheng da ming qi xia chou	1
+人生得意须尽欢	ren sheng de yi xu jin huan	1
+人生非金石	ren sheng fei jin shi	1
+人生感意气	ren sheng gan yi qi	1
+人生贵相知	ren sheng gui xiang zhi	1
+人生几何春已夏	ren sheng ji he chun yi xia	1
+人生几何时	ren sheng ji he shi	1
+人生交契无老少	ren sheng jiao qi wu lao shao	1
+人生结交在终始	ren sheng jie jiao zai zhong shi	1
+人生看得几清明	ren sheng kan de ji qing ming	1
+人生难得相知心	ren sheng nan de xiang zhi xin	1
+人生能几何	ren sheng neng ji he	1
+人生飘忽百年内	ren sheng piao hu bai nian nei	1
+人生如草木	ren sheng ru cao mu	1
+人生如此自可乐	ren sheng ru ci zi ke le	1
+人生如朝露	ren sheng ru zhao lu	1
+人生实难	ren sheng shi nan	1
+人生天地间	ren sheng tian di jian	1
+人生天地之间	ren sheng tian di zhi jian	1
+人生无处不青山	ren sheng wu chu bu qing shan	1
+人生无家别	ren sheng wu jia bie	1
+人生无离别	ren sheng wu li bie	1
+人生易老天难老	ren sheng yi lao tian nan lao	1
+人生一世间	ren sheng yi shi jian	1
+人生有离合	ren sheng you li he	1
+人生由命非由他	ren sheng you ming fei you ta	1
+人生有情泪沾臆	ren sheng you qing lei zhan yi	1
+人生在世共如此	ren sheng zai shi gong ru ci	1
+人生在世间	ren sheng zai shi jian	1
+人生在世能几时	ren sheng zai shi neng ji shi	1
+任氏	ren shi	1
+人事不可量	ren shi bu ke liang	1
+人事多错迕	ren shi duo cuo wu	1
+人世难逢开口笑	ren shi nan feng kai kou xiao	1
+人世死前唯有别	ren shi si qian wei you bie	1
+人世死前惟有别	ren shi si qian wei you bie	1
+人事音书漫寂寥	ren shi yin shu man ji liao	1
+任士之所劳	ren shi zhi suo lao	1
+人谁感至精	ren shui gan zhi jing	1
+人似秋鸿来有信	ren si qiu hong lai you xin	1
+人随流水东西	ren sui liu shui dong xi	1
+人随沙路向江村	ren sui sha lu xiang jiang cun	1
+人随雁落西风	ren sui yan luo xi feng	1
+任他流水向人间	ren ta liu shui xiang ren jian	1
+人谓之不死	ren wei zhi bu si	1
+人无衣	ren wu yi	1
+任希古	ren xi gu	1
+衽席之上	ren xi zhi shang	1
+人行明镜中	ren xing ming jing zhong	1
+人行犹可复	ren xing you ke fu	1
+仁恤庶无尤	ren xu shu wu you	1
+壬戌之秋	ren xu zhi qiu	1
+人烟寒橘柚	ren yan han ju you	1
+人言真可畏	ren yan zhen ke wei	1
+任要	ren yao	1
+人杳杳	ren yao yao	1
+仁义充塞	ren yi chong se	1
+人亦念其家	ren yi nian qi jia	1
+人以食为天	ren yi shi wei tian	1
+人以为谄也	ren yi wei chan ye	1
+人亦有言	ren yi you yan	1
+仁义之端	ren yi zhi duan	1
+人有病	ren you bing	1
+人有恒言	ren you heng yan	1
+人游月边去	ren you yue bian qu	1
+仁远乎哉	ren yuan hu zai	1
+人猿相揖别	ren yuan xiang yi bie	1
+人月圆	ren yue yuan	1
+人在楼上	ren zai lou shang	1
+人在木兰舟	ren zai mu lan zhou	1
+仁在其中矣	ren zai qi zhong yi	1
+仁者安仁	ren zhe an ren	1
+仁者必有勇	ren zhe bi you yong	1
+仁者播其惠	ren zhe bo qi hui	1
+仁者如射	ren zhe ru she	1
+人至不去	ren zhi bu qu	1
+人之不善	ren zhi bu shan	1
+仁之端也	ren zhi duan ye	1
+人之过也	ren zhi guo ye	1
+人之好我	ren zhi hao wo	1
+人之将死	ren zhi jiang si	1
+人之君子	ren zhi jun zi	1
+人之生也	ren zhi sheng ye	1
+人之生也直	ren zhi sheng ye zhi	1
+人之所恶	ren zhi suo e	1
+人之所教	ren zhi suo jiao	1
+人之所美也	ren zhi suo mei ye	1
+人之所畏	ren zhi suo wei	1
+人之所欲	ren zhi suo yu	1
+人之所欲也	ren zhi suo yu ye	1
+人之无良	ren zhi wu liang	1
+人之言曰	ren zhi yan yue	1
+人之正路也	ren zhi zheng lu ye	1
+人自伤心水自流	ren zi shang xin shui zi liu	1
+人卒九州	ren zu jiu zhou	1
+任醉	ren zui	1
+日本晁卿辞帝都	ri ben chao qing ci di du	1
+日迟迟	ri chi chi	1
+日初出	ri chu chu	1
+日出雾露馀	ri chu wu lu yu	1
+日出行	ri chu xing	1
+日出有曜	ri chu you yao	1
+日出云中鸡犬喧	ri chu yun zhong ji quan xuan	1
+日出在东方	ri chu zai dong fang	1
+日出正东峰	ri chu zheng dong feng	1
+日啖荔支三百颗	ri dan li zhi san bai ke	1
+日复日	ri fu ri	1
+日光随意落	ri guang sui yi luo	1
+日光斜照集灵台	ri guang xie zhao ji ling tai	1
+日过午已昏	ri guo wu yi hun	1
+日居月诸	ri ji yue zhu	1
+日见孤峰水上浮	ri jian gu feng shui shang fu	1
+日脚下平地	ri jiao xia ping di	1
+日轮当午凝不去	ri lun dang wu ning bu qu	1
+日落长沙秋色远	ri luo chang sha qiu se yuan	1
+日落江湖白	ri luo jiang hu bai	1
+日落山水静	ri luo shan shui jing	1
+日落西山暮	ri luo xi shan mu	1
+日落香车入	ri luo xiang che ru	1
+日暮长江里	ri mu chang jiang li	1
+日暮待情人	ri mu dai qing ren	1
+日暮东风怨啼鸟	ri mu dong feng yuan ti niao	1
+日暮复何之	ri mu fu he zhi	1
+日暮聊为梁父吟	ri mu liao wei liang fu yin	1
+日暮秋风起	ri mu qiu feng qi	1
+日暮掩柴扉	ri mu yan chai fei	1
+日暮倚修竹	ri mu yi xiu zhu	1
+日暮征帆何处泊	ri mu zheng fan he chu bo	1
+日破云涛万里红	ri po yun tao wan li hong	1
+日日采莲去	ri ri cai lian qu	1
+日日春光斗日光	ri ri chun guang dou ri guang	1
+日日骑马来山中	ri ri qi ma lai shan zhong	1
+日日醉如泥	ri ri zui ru ni	1
+日色才临仙掌动	ri se cai lin xian zhang dong	1
+日色冷青松	ri se leng qing song	1
+日色已尽花含烟	ri se yi jin hua han yan	1
+日射纱窗风撼扉	ri she sha chuang feng han fei	1
+日晚江南望江北	ri wan jiang nan wang jiang bei	1
+日夕怀空意	ri xi huai kong yi	1
+日夕连秋声	ri xi lian qiu sheng	1
+日夕望君抱琴至	ri xi wang jun bao qin zhi	1
+日夕依仁全羽翼	ri xi yi ren quan yu yi	1
+日斜江上孤帆影	ri xie jiang shang gu fan ying	1
+日晏犹得眠	ri yan you de mian	1
+日夜东流人不知	ri ye dong liu ren bu zhi	1
+日夜经过赵李家	ri ye jing guo zhao li jia	1
+日夜随势行	ri ye sui shi xing	1
+日夜望将军至	ri ye wang jiang jun zhi	1
+日益骄固	ri yi jiao gu	1
+日已暮	ri yi mu	1
+日影反照	ri ying fan zhao	1
+日用饮食	ri yong yin shi	1
+日有食之	ri you shi zhi	1
+日喻	ri yu	1
+日羽肃天行	ri yu su tian xing	1
+日月出矣	ri yue chu yi	1
+日月忽其不淹兮	ri yue hu qi bu yan xi	1
+日月笼中鸟	ri yue long zhong niao	1
+日月逝矣	ri yue shi yi	1
+日月照耀金银台	ri yue zhao yao jin yin tai	1
+日凿一窍	ri zao yi qiao	1
+日正当午	ri zheng dang wu	1
+日知其所亡	ri zhi qi suo wang	1
+日之夕矣	ri zhi xi yi	1
+日中见斗	ri zhong jian dou	1
+戎马关山北	rong ma guan shan bei	1
+戎马生于郊	rong ma sheng yu jiao	1
+融融冶冶黄	rong rong ye ye huang	1
+容颜若飞电	rong yan ruo fei dian	1
+荣諲	rong yin	1
+戎昱	rong yu	1
+容止顺其猷	rong zhi shun qi you	1
+柔弱胜刚强	rou ruo sheng gang qiang	1
+輮使之然也	rou shi zhi ran ye	1
+輮以为轮	rou yi wei lun	1
+如不得已	ru bu de yi	1
+如不可求	ru bu ke qiu	1
+汝不知夫螳螂乎	ru bu zhi fu tang lang hu	1
+汝诚人耶	ru cheng ren ye	1
+如春登台	ru chun deng tai	1
+如此江山	ru ci jiang shan	1
+如此良人何	ru ci liang ren he	1
+如此至宝存岂多	ru ci zhi bao cun qi duo	1
+如得良友	ru de liang you	1
+如得其情	ru de qi qing	1
+如匪浣衣	ru fei huan yi	1
+汝坟	ru fen	1
+如逢故人	ru feng gu ren	1
+如果细心的话	ru guo xi xin de hua	1
+汝果欲学诗	ru guo yu xue shi	1
+如何肯到清秋日	ru he ken dao qing qiu ri	1
+如何四纪为天子	ru he si ji wei tian zi	1
+如翚斯飞	ru hui si fei	1
+入火不热	ru huo bu re	1
+如火益热	ru huo yi re	1
+如或知尔	ru huo zhi er	1
+乳间股脚	ru jian gu jiao	1
+如今人方为刀俎	ru jin ren fang wei dao zu	1
+汝看此书时	ru kan ci shu shi	1
+如可赎兮	ru ke shu xi	1
+如临深渊	ru lin shen yuan	1
+如临于谷	ru lin yu gu	1
+如履薄冰	ru lv bo bing	1
+如梦如梦	ru meng ru meng	1
+如南山之寿	ru nan shan zhi shou	1
+如鸟斯革	ru niao si ge	1
+汝岂得自由	ru qi de zi you	1
+汝泣告我	ru qi gao wo	1
+如其礼乐	ru qi li yue	1
+如泣如诉	ru qi ru su	1
+汝其勿悲	ru qi wu bei	1
+如千里	ru qian li	1
+如日月之食	ru ri yue zhi shi	1
+如日月之食焉	ru ri yue zhi shi yan	1
+入塞	ru sai	1
+如三岁兮	ru san sui xi	1
+如三月兮	ru san yue xi	1
+如杀无道	ru sha wu dao	1
+如山如河	ru shan ru he	1
+汝是大家子	ru shi da jia zi	1
+入蜀记	ru shu ji	1
+入水不濡	ru shui bu ru	1
+如水益深	ru shui yi shen	1
+如斯而已乎	ru si er yi hu	1
+如斯者	ru si zhe	1
+入宋	ru song	1
+如松茂矣	ru song mao yi	1
+如啼眼	ru ti yan	1
+如听万壑松	ru ting wan he song	1
+入潼关	ru tong guan	1
+汝为君子儒	ru wei jun zi ru	1
+入我床下	ru wo chuang xia	1
+如五六十	ru wu liu shi	1
+入无穷之门	ru wu qiong zhi men	1
+如享太牢	ru xiang tai lao	1
+如兄如弟	ru xiong ru di	1
+乳燕飞	ru yan fei	1
+汝阳三斗始朝天	ru yang san dou shi chao tian	1
+如意令	ru yi ling	1
+如婴儿之未孩	ru ying er zhi wei hai	1
+如有博施于民	ru you bo shi yu min	1
+如有复我者	ru you fu wo zhe	1
+如有王者	ru you wang zhe	1
+如有意	ru you yi	1
+如有用我者	ru you yong wo zhe	1
+如欲平治天下	ru yu ping zhi tian xia	1
+如鱼水	ru yu shui	1
+如月在天	ru yue zai tian	1
+如月之恒	ru yue zhi heng	1
+如在昨日	ru zai zuo ri	1
+入则事父兄	ru ze shi fu xiong	1
+如正人何	ru zheng ren he	1
+如之何其彻也	ru zhi he qi che ye	1
+如之何其废之	ru zhi he qi fei zhi	1
+如之何其可及也	ru zhi he qi ke ji ye	1
+如之何勿思	ru zhi he wu si	1
+如之何则可	ru zhi he ze ke	1
+如知其非义	ru zhi qi fei yi	1
+入之甚寒	ru zhi shen han	1
+如知为君之难也	ru zhi wei jun zhi nan ye	1
+入之愈深	ru zhi yu shen	1
+汝知之乎	ru zhi zhi hu	1
+如竹苞矣	ru zhu bao yi	1
+孺子孺子	ru zi ru zi	1
+软草平莎过雨新	ruan cao ping sha guo yu xin	1
+阮瑀	ruan yu	1
+阮阅	ruan yue	1
+瑞光千丈生白毫	rui guang qian zhang sheng bai hao	1
+瑞鹤仙影	rui he xian ying	1
+芮辉	rui hui	1
+芮挺章	rui ting zhang	1
+芮烨	rui ye	1
+瑞云浓	rui yun nong	1
+瑞鹧鸪	rui zhe gu	1
+蕊珠间	rui zhu jian	1
+睿作尧君宝	rui zuo yao jun bao	1
+润益	run yi	1
+润州城	run zhou cheng	1
+若白驹之过隙	ruo bai ju zhi guo xi	1
+若彼知之	ruo bi zhi zhi	1
+若存若亡	ruo cun ruo wang	1
+若到越溪逢越女	ruo dao yue xi feng yue nv	1
+若非巾柴车	ruo fei jin chai che	1
+若非群玉山头见	ruo fei qun yu shan tou jian	1
+若夫乘天地之正	ruo fu cheng tian di zhi zheng	1
+若负平生志	ruo fu ping sheng zhi	1
+若个是真梅	ruo ge shi zhen mei	1
+弱国入朝	ruo guo ru chao	1
+若可寄天下	ruo ke ji tian xia	1
+若可托天下	ruo ke tuo tian xia	1
+若烹小鲜	ruo peng xiao xian	1
+若入前为寿	ruo ru qian wei shou	1
+若圣与仁	ruo sheng yu ren	1
+若是其甚与	ruo shi qi shen yu	1
+若是晓珠明又定	ruo shi xiao zhu ming you ding	1
+若属皆且为所虏	ruo shu jie qie wei suo lu	1
+若望仆不相师	ruo wang pu bu xiang shi	1
+若为留得堂堂去	ruo wei liu de tang tang qu	1
+若问使君才与术	ruo wen shi jun cai yu shu	1
+若无清风吹	ruo wu qing feng chui	1
+若无所归	ruo wu suo gui	1
+若无罪而就死地	ruo wu zui er jiu si di	1
+若信贝多真实语	ruo xin bei duo zhen shi yu	1
+若耶溪	ruo ye xi	1
+若耶溪傍采莲女	ruo ye xi bang cai lian nv	1
+若耶溪边采莲女	ruo ye xi bian cai lian nv	1
+若有人兮天一方	ruo you ren xi tian yi fang	1
+若臧武仲之知	ruo zang wu zhong zhi zhi	1
+弱者道之用	ruo zhe dao zhi yong	1
+洒落出重云	sa luo chu zhong yun	1
+飒飒东风细雨来	sa sa dong feng xi yu lai	1
+飒飒秋雨中	sa sa qiu yu zhong	1
+飒飒松上雨	sa sa song shang yu	1
+飒爽英姿五尺枪	sa shuang ying zi wu chi qiang	1
+飒沓如流星	sa ta ru liu xing	1
+洒向人间都是怨	sa xiang ren jian dou shi yuan	1
+塞姑	sai gu	1
+塞马	sai ma	1
+塞马一声嘶	sai ma yi sheng si	1
+塞上曲	sai shang qu	1
+赛神	sai shen	1
+赛天香	sai tian xiang	1
+塞翁吟	sai weng yin	1
+塞下曲六首	sai xia qu liu shou	1
+塞垣春	sai yuan chun	1
+三百六十日	san bai liu shi ri	1
+三杯拂剑舞秋月	san bei fu jian wu qiu yue	1
+三杯通大道	san bei tong da dao	1
+三杯吐然诺	san bei tu ran nuo	1
+三边曙色动危旌	san bian shu se dong wei jing	1
+三部乐	san bu le	1
+散步咏凉天	san bu yong liang tian	1
+三餐而反	san can er fan	1
+三春白雪归青冢	san chun bai xue gui qing zhong	1
+三春三月忆三巴	san chun san yue yi san ba	1
+三春行乐在谁边	san chun xing le zai shei bian	1
+三春雁北飞	san chun yan bei fei	1
+三登乐	san deng le	1
+三冬足文史	san dong zu wen shi	1
+散而成章	san er cheng zhang	1
+散发乘夕凉	san fa cheng xi liang	1
+散发乘夜凉	san fa cheng ye liang	1
+三分割据纡筹策	san fen ge ju yu chou ce	1
+三分天下有其二	san fen tian xia you qi er	1
+散关三尺雪	san guan san chi xue	1
+三过其门而不入	san guo qi men er bu ru	1
+三号而出	san hao er chu	1
+三家者以雍彻	san jia zhe yi yong che	1
+三绛	san jiang	1
+三晋云山皆北向	san jin yun shan jie bei xiang	1
+三径苦无资	san jing ku wu zi	1
+三军大呼阴山动	san jun da hu yin shan dong	1
+三军过后尽开颜	san jun guo hou jin kai yan	1
+三里之城	san li zhi cheng	1
+三年奔走空皮骨	san nian ben zou kong pi gu	1
+三年不出	san nian bu chu	1
+三年不为乐	san nian bu wei le	1
+三年不言	san nian bu yan	1
+三年笛里关山月	san nian di li guan shan yue	1
+三年多难更凭危	san nian duo nan geng ping wei	1
+三年饥走荒山道	san nian ji zou huang shan dao	1
+三年谪宦此栖迟	san nian zhe huan ci qi chi	1
+三年之后	san nian zhi hou	1
+三年之丧	san nian zhi sang	1
+三年之外	san nian zhi wai	1
+三平调	san ping diao	1
+三千世界本无穷	san qian shi jie ben wu qiong	1
+三人成虎事多有	san ren cheng hu shi duo you	1
+三人相视而笑	san ren xiang shi er xiao	1
+三日不朝	san ri bu chao	1
+三日不食	san ri bu shi	1
+三日断五匹	san ri duan wu pi	1
+三日而死	san ri er si	1
+三日入厨下	san ri ru chu xia	1
+三三五五映垂杨	san san wu wu ying chui yang	1
+三山半落青天外	san shan ban luo qing tian wai	1
+三山十洞光玄箓	san shan shi dong guang xuan lu	1
+三上北高峰	san shang bei gao feng	1
+三生石上结因缘	san sheng shi shang jie yin yuan	1
+三生同听一楼钟	san sheng tong ting yi lou zhong	1
+三十八年过去	san shi ba nian guo qu	1
+三事大夫	san shi dai fu	1
+三十而立	san shi er li	1
+三十六离宫	san shi liu li gong	1
+三十六年	san shi liu nian	1
+三十六万人	san shi liu wan ren	1
+三十年来梦一场	san shi nian lai meng yi chang	1
+三世希不失矣	san shi xi bu shi yi	1
+三十一年还旧国	san shi yi nian hai jiu guo	1
+三岁贯女	san sui guan nv	1
+三岁食贫	san sui shi pin	1
+三岁为妇	san sui wei fu	1
+三台春曲	san tai chun qu	1
+三台令	san tai ling	1
+三叹	san tan	1
+散天花	san tian hua	1
+三万六千日	san wan liu qian ri	1
+三围四围	san wei si wei	1
+三五七言	san wu qi yan	1
+三五在东	san wu zai dong	1
+三五之夜	san wu zhi ye	1
+三峡楼台淹日月	san xia lou tai yan ri yue	1
+三峡星河影动摇	san xia xing he ying dong yao	1
+三湘愁鬓逢秋色	san xiang chou bin feng qiu se	1
+三湘衰鬓逢秋色	san xiang shuai bin feng qiu se	1
+三谢不能餐	san xie bu neng can	1
+三星在户	san xing zai hu	1
+三星在天	san xing zai tian	1
+三星在隅	san xing zai yu	1
+三嗅而作	san xiu er zuo	1
+三学士	san xue shi	1
+三肴	san yao	1
+三夜频梦君	san ye pin meng jun	1
+三以天下让	san yi tian xia rang	1
+三月不知肉味	san yue bu zhi rou wei	1
+三月初五日	san yue chu wu ri	1
+三月聚粮	san yue ju liang	1
+三月三日天气新	san yue san ri tian qi xin	1
+三月时	san yue shi	1
+三月雪连夜	san yue xue lian ye	1
+散则为死	san ze wei si	1
+三朝出入荣	san zhao chu ru rong	1
+三朝日	san zhao ri	1
+三株媚	san zhu mei	1
+三字令	san zi ling	1
+三子者出	san zi zhe chu	1
+丧己于物	sang ji yu wu	1
+丧事不敢不勉	sang shi bu gan bu mian	1
+桑田碧海须臾改	sang tian bi hai xu yu gai	1
+桑田变沧海	sang tian bian cang hai	1
+桑条无叶土生烟	sang tiao wu ye tu sheng yan	1
+丧致乎哀而止	sang zhi hu ai er zhi	1
+桑之落矣	sang zhi luo yi	1
+桑之未落	sang zhi wei luo	1
+桑中	sang zhong	1
+扫地花	sao di hua	1
+扫地舞	sao di wu	1
+扫花游	sao hua you	1
+嫂溺不援	sao ni bu yuan	1
+搔首踟蹰	sao shou chi chu	1
+搔首赋归欤	sao shou fu gui yu	1
+色勃如也	se bo ru ye	1
+色静深松里	se jing shen song li	1
+色厉而内荏	se li er nei ren	1
+色取仁而行违	se qu ren er xing wei	1
+瑟瑟罗裙金缕腰	se se luo qun jin lv yao	1
+色斯举矣	se si ju yi	1
+色庄者乎	se zhuang zhe hu	1
+僧伽歌	seng ga ge	1
+僧贯休	seng guan xiu	1
+僧皎然	seng jiao ran	1
+僧是愚氓犹可训	seng shi yu meng you ke xun	1
+僧言古壁佛画好	seng yan gu bi fo hua hao	1
+沙场烽火侵胡月	sha chang feng huo qin hu yue	1
+纱窗日落渐黄昏	sha chuang ri luo jian huang hun	1
+杀盗非杀人	sha dao fei sha ren	1
+纱灯古殿深	sha deng gu dian shen	1
+杀鸡为黍而食之	sha ji wei shu er shi zhi	1
+沙口石冻马蹄脱	sha kou shi dong ma ti tuo	1
+杀戮到鸡狗	sha lu dao ji gou	1
+沙平水息声影绝	sha ping shui xi sheng ying jue	1
+杀气三时作阵云	sha qi san shi zuo zhen yun	1
+沙丘城下寄杜甫	sha qiu cheng xia ji du fu	1
+杀人都市中	sha ren du shi zhong	1
+杀人莫敢前	sha ren mo gan qian	1
+杀人如不能举	sha ren ru bu neng ju	1
+杀人如剪草	sha ren ru jian cao	1
+杀人如麻	sha ren ru ma	1
+杀人以梃与刃	sha ren yi ting yu ren	1
+杀人亦有限	sha ren yi you xian	1
+杀人盈城	sha ren ying cheng	1
+杀人之众	sha ren zhi zhong	1
+沙塞子	sha sai zi	1
+沙上草阁柳新暗	sha shang cao ge liu xin an	1
+沙上凫雏傍母眠	sha shang fu chu bang mu mian	1
+杀生者不死	sha sheng zhe bu si	1
+沙头宿鹭联拳静	sha tou su lu lian quan jing	1
+沙行渡头歇	sha xing du tou xie	1
+山爱夕阳时	shan ai xi yang shi	1
+善抱者不脱	shan bao zhe bu tuo	1
+扇裁月魄羞难掩	shan cai yue po xiu nan yan	1
+擅长行书	shan chang xing shu	1
+山城斜路杏花香	shan cheng xie lu xing hua xiang	1
+山川满目泪沾衣	shan chuan man mu lei zhan yi	1
+山川其舍诸	shan chuan qi she zhu	1
+山川萧条极边土	shan chuan xiao tiao ji bian tu	1
+山从人面起	shan cong ren mian qi	1
+善贷且成	shan dai qie cheng	1
+善刀而藏之	shan dao er cang zhi	1
+山巅朱凤声嗷嗷	shan dian zhu feng sheng ao ao	1
+山东今岁点行频	shan dong jin sui dian hang pin	1
+善复为妖	shan fu wei yao	1
+山高水深	shan gao shui shen	1
+山光忽西落	shan guang hu xi luo	1
+山光物态弄春辉	shan guang wu tai nong chun hui	1
+山鬼谣	shan gui yao	1
+山河风景元无异	shan he feng jing yuan wu yi	1
+山红涧碧纷烂漫	shan hong jian bi fen lan man	1
+珊瑚碧树交枝柯	shan hu bi shu jiao zhi ke	1
+山花如绣颊	shan hua ru xiu jia	1
+山际逢羽人	shan ji feng yu ren	1
+山渐青	shan jian qing	1
+善建者不拔	shan jian zhe bu ba	1
+山将落日去	shan jiang luo ri qu	1
+善卷让天子	shan juan rang tian zi	1
+山开旷望旋平陆	shan kai kuang wang xuan ping lu	1
+山空鸟鼠秋	shan kong niao shu qiu	1
+山空松子落	shan kong song zi luo	1
+山口潜行始隈隩	shan kou qian xing shi wei ao	1
+山林二十年	shan lin er shi nian	1
+山林作伴	shan lin zuo ban	1
+山路倒枯松	shan lu dao ku song	1
+山暝听猿愁	shan ming ting yuan chou	1
+山南山北雪晴	shan nan shan bei xue qing	1
+山青花欲燃	shan qing hua yu ran	1
+山鸲鹆	shan qu yu	1
+山泉散漫绕阶流	shan quan san man rao jie liu	1
+善人是富	shan ren shi fu	1
+善人为邦百年	shan ren wei bang bai nian	1
+善人之宝	shan ren zhi bao	1
+善人之资	shan ren zhi zi	1
+山色空濛雨亦奇	shan se kong meng yu yi qi	1
+山色遥连秦树晚	shan se yao lian qin shu wan	1
+山山黄叶飞	shan shan huang ye fei	1
+珊珊可爱	shan shan ke ai	1
+山上离宫宫上楼	shan shang li gong gong shang lou	1
+山舍初成病乍轻	shan she chu cheng bing zha qing	1
+善生	shan sheng	1
+山石荦确行径微	shan shi luo que xing jing wei	1
+善始善终	shan shi shan zhong	1
+善始者实繁	shan shi zhe shi fan	1
+善数不用筹策	shan shu bu yong chou ce	1
+山水多所得	shan shui duo suo de	1
+山水空流山自闲	shan shui kong liu shan zi xian	1
+山水思微清	shan shui si wei qing	1
+山水有清音	shan shui you qing yin	1
+山寺钟鸣昼已昏	shan si zhong ming zhou yi hun	1
+山桃红	shan tao hong	1
+山头孤鹤向南飞	shan tou gu he xiang nan fei	1
+山头鼓角相闻	shan tou gu jiao xiang wen	1
+山外云	shan wai yun	1
+善为我辞焉	shan wei wo ci yan	1
+山为樽	shan wei zun	1
+山下旌旗在望	shan xia jing qi zai wang	1
+山下山下	shan xia shan xia	1
+山衔好月来	shan xian hao yue lai	1
+山县早休市	shan xian zao xiu shi	1
+缮性何由熟	shan xing he you shu	1
+善行无辙迹	shan xing wu zhe ji	1
+山形依旧枕寒流	shan xing yi jiu zhen han liu	1
+山虚风落石	shan xu feng luo shi	1
+善言无瑕谪	shan yan wu xia zhe	1
+善养生者	shan yang sheng zhe	1
+山意冲寒欲放梅	shan yi chong han yu fang mei	1
+山夷又纷然	shan yi you fen ran	1
+山阴道上桂花初	shan yin dao shang gui hua chu	1
+山阴道士如相见	shan yin dao shi ru xiang jian	1
+善有果而已	shan you guo er yi	1
+山有木兮谷有泉	shan you mu xi gu you quan	1
+山有枢	shan you shu	1
+山幽幽	shan you you	1
+山雨初含霁	shan yu chu han ji	1
+山月随人归	shan yue sui ren gui	1
+山月照弹琴	shan yue zhao tan qin	1
+山杂夏云多	shan za xia yun duo	1
+善珍	shan zhen	1
+山镇西犯	shan zhen xi fan	1
+山中发红萼	shan zhong fa hong e	1
+山中尚含绿	shan zhong shang han lv	1
+山中无所有	shan zhong wu suo you	1
+山中习静观朝槿	shan zhong xi jing guan chao jin	1
+山中相送罢	shan zhong xiang song ba	1
+山中一夜雨	shan zhong yi ye yu	1
+山中有流水	shan zhong you liu shui	1
+山中与幽人对酌	shan zhong yu you ren dui zhuo	1
+伤不实也	shang bu shi ye	1
+上蔡苍鹰何足道	shang cai cang ying he zu dao	1
+伤春怨	shang chun yuan	1
+上德抚神运	shang de fu shen yun	1
+尚德哉若人	shang de zai ruo ren	1
+上帝之风	shang di zhi feng	1
+上帝之声	shang di zhi sheng	1
+上而不下	shang er bu xia	1
+上古有大椿者	shang gu you da chun zhe	1
+上官仪	shang guan yi	1
+上官昭容	shang guan zhao rong	1
+上国随缘住	shang guo sui yuan zhu	1
+赏花时	shang hua shi	1
+上计轩辕	shang ji xuan yuan	1
+上江虹	shang jiang hong	1
+上将军居右	shang jiang jun ju you	1
+上尽重城更上楼	shang jin zhong cheng geng shang lou	1
+商君佐之	shang jun zuo zhi	1
+上窥青天	shang kui qing tian	1
+上林春	shang lin chun	1
+上林春慢	shang lin chun man	1
+上林繁花照眼新	shang lin fan hua zhao yan xin	1
+伤麟怨道穷	shang lin yuan dao qiong	1
+伤灵修之数化	shang ling xiu zhi shu hua	1
+上留田行	shang liu tian xing	1
+上略当分阃	shang lue dang fen kun	1
+上马娇	shang ma jiao	1
+尚寐无觉	shang mei wu jue	1
+赏明月	shang ming yue	1
+上南平	shang nan ping	1
+上平南	shang ping nan	1
+上平声	shang ping sheng	1
+上清沦谪得归迟	shang qing lun zhe de gui chi	1
+伤情怨	shang qing yuan	1
+上如标枝	shang ru biao zhi	1
+伤如之何	shang ru zhi he	1
+上三峡	shang san xia	1
+上善若水任方圆	shang shan ruo shui ren fang yuan	1
+商山四皓	shang shan si hao	1
+汤汤流水	shang shang liu shui	1
+上失其道	shang shi qi dao	1
+上士闻道	shang shi wen dao	1
+尚书固负若属耶	shang shu gu fu ruo shu ye	1
+上束马	shang shu ma	1
+上枢密韩太尉书	shang shu mi han tai wei shu	1
+上耸忽如飞	shang song hu ru fei	1
+上堂拜阿母	shang tang bai a mu	1
+赏玩夜忘归	shang wan ye wang gui	1
+上忘而下畔	shang wang er xia pan	1
+商闻之矣	shang wen zhi yi	1
+尚无位我生之后	shang wu wei wo sheng zhi hou	1
+尚无庸	shang wu yong	1
+上西楼	shang xi lou	1
+上西平	shang xi ping	1
+上下交征利	shang xia jiao zheng li	1
+尚想旧情怜婢仆	shang xiang jiu qing lian bi pu	1
+上小楼	shang xiao lou	1
+伤心不独为悲秋	shang xin bu du wei bei qiu	1
+上行杯	shang xing bei	1
+尚颜	shang yan	1
+上阳白发人	shang yang bai fa ren	1
+上阳春	shang yang chun	1
+商也不及	shang ye bu ji	1
+尚衣方进翠云裘	shang yi fang jin cui yun qiu	1
+上应美人意	shang ying mei ren yi	1
+上有分流水	shang you fen liu shui	1
+上有好者	shang you hao zhe	1
+上有可耕之田	shang you ke geng zhi tian	1
+上有青冥之长天	shang you qing ming zhi chang tian	1
+上有蔚蓝天	shang you wei lan tian	1
+上有无花之古树	shang you wu hua zhi gu shu	1
+上与浮云齐	shang yu fu yun qi	1
+尚余孤瘦雪霜姿	shang yu gu shou xue shuang zi	1
+上元夫人	shang yuan fu ren	1
+上圆下方	shang yuan xia fang	1
+上云乐	shang yun le	1
+商则	shang ze	1
+上之回	shang zhi hui	1
+尚自露寒花未开	shang zi lu han hua wei kai	1
+哨遍	shao bian	1
+邵博	shao bo	1
+少妇城南欲断肠	shao fu cheng nan yu duan chang	1
+少妇今春意	shao fu jin chun yi	1
+稍共夜凉分	shao gong ye liang fen	1
+少孤为客早	shao gu wei ke zao	1
+邵怀英	shao huai ying	1
+稍见市井喧	shao jian shi jing xuan	1
+邵景	shao jing	1
+烧兰才作烛	shao lan cai zuo zhu	1
+少陵野老吞生哭	shao ling ye lao tun sheng ku	1
+少年不得志	shao nian bu de zhi	1
+少年负壮气	shao nian fu zhuang qi	1
+少年离别意非轻	shao nian li bie yi fei qing	1
+少年上人号怀素	shao nian shang ren hao huai su	1
+少年十五二十时	shao nian shi wu er shi shi	1
+少年心	shao nian xin	1
+少年子	shao nian zi	1
+少卿足下	shao qing zu xia	1
+邵升	shao sheng	1
+少时诵诗书	shao shi song shi shu	1
+邵士彦	shao shi yan	1
+少思寡欲	shao si gua yu	1
+少喜神仙术	shao xi shen xian shu	1
+烧香曲	shao xiang qu	1
+少小离乡老大回	shao xiao li xiang lao da hui	1
+少小虽非投笔吏	shao xiao sui fei tou bi li	1
+少小幽燕客	shao xiao you yan ke	1
+稍逊风骚	shao xun feng sao	1
+邵谒	shao ye	1
+梢云良独难	shao yun liang du nan	1
+邵真	shao zhen	1
+少壮能几时	shao zhuang neng ji shi	1
+射不主皮	she bu zhu pi	1
+奢侈荒淫	she chi huang yin	1
+舍后且先	she hou qie xian	1
+摄乎大国之间	she hu da guo zhi jian	1
+舍己从人	she ji cong ren	1
+社稷依明主	she ji yi ming zhu	1
+社稷一戎衣	she ji yi rong yi	1
+舍酒去相语	she jiu qu xiang yu	1
+舍利弗	she li fu	1
+舍南舍北皆春水	she nan she bei jie chun shui	1
+舍南舍北皆种桃	she nan she bei jie zhong tao	1
+摄齐升堂	she qi sheng tang	1
+射日弓	she ri gong	1
+舍瑟而作	she se er zuo	1
+射杀山中白额虎	she sha shan zhong bai e hu	1
+舍生亦如此	she sheng yi ru ci	1
+赦书一日行万里	she shu yi ri xing wan li	1
+摄提贞于孟陬兮	she ti zhen yu meng zou xi	1
+舍我其谁也	she wo qi shui ye	1
+麝熏微度绣芙蓉	she xun wei du xiu fu rong	1
+奢则不孙	she ze bu sun	1
+舍正路而不由	she zheng lu er bu you	1
+舍之则藏	she zhi ze cang	1
+谁会成生此意	shei hui cheng sheng ci yi	1
+谁人曾与评说	shei ren ceng yu ping shuo	1
+谁人更扫黄金台	shei ren geng sao huang jin tai	1
+谁与	shei yu	1
+甚爱必大费	shen ai bi da fei	1
+申包惟恸哭	shen bao wei tong ku	1
+沈伯文	shen bo wen	1
+深不可识	shen bu ke shi	1
+深藏身与名	shen cang shen yu ming	1
+身长健	shen chang jian	1
+沈长卿	shen chang qing	1
+沈传师	shen chuan shi	1
+身当恩遇常轻敌	shen dang en yu chang qing di	1
+神得一以灵	shen de yi yi ling	1
+身登青云梯	shen deng qing yun ti	1
+神鼎飞丹砂	shen ding fei dan sha	1
+深冬放火如红霞	shen dong fang huo ru hong xia	1
+沈东美	shen dong mei	1
+沈端节	shen duan jie	1
+身多疾病思田里	shen duo ji bing si tian li	1
+深耕易耨	shen geng yi nou	1
+深宫二十年	shen gong er shi nian	1
+神鬼神帝	shen gui shen di	1
+参横斗转欲三更	shen heng dou zhuan yu san geng	1
+身后风流陌上花	shen hou feng liu mo shang hua	1
+申欢	shen huan	1
+神欢体自轻	shen huan ti zi qing	1
+沈回	shen hui	1
+沈徽	shen hui	1
+沈晦	shen hui	1
+神将来舍	shen jiang lai she	1
+身经百战曾百胜	shen jing bai zhan ceng bai sheng	1
+糁径杨花铺白毡	shen jing yang hua pu bai zhan	1
+深居俯夹城	shen ju fu jia cheng	1
+沈郎多病不胜衣	shen lang duo bing bu sheng yi	1
+深柳读书堂	shen liu du shu tang	1
+神妙独数江都王	shen miao du shu jiang du wang	1
+神莫大于化道	shen mo da yu hua dao	1
+慎莫近前丞相嗔	shen mo jin qian cheng xiang chen	1
+深谋远虑	shen mou yuan lv	1
+神农之言	shen nong zhi yan	1
+神女去已久	shen nv qu yi jiu	1
+神女生涯原是梦	shen nv sheng ya yuan shi meng	1
+神女应无恙	shen nv ying wu yang	1
+身披六铢衣	shen pi liu zhu yi	1
+身骑白马万人中	shen qi bai ma wan ren zhong	1
+神气不变	shen qi bu bian	1
+沈千运	shen qian yun	1
+深秋帘幕千家雨	shen qiu lian mu qian jia yu	1
+沈佺期	shen quan qi	1
+沈全期	shen quan qi	1
+神人无功	shen ren wu gong	1
+沈如筠	shen ru jun	1
+深山何处钟	shen shan he chu zhong	1
+深山夕照深秋雨	shen shan xi zhao shen qiu yu	1
+申申如也	shen shen ru ye	1
+诜诜兮	shen shen xi	1
+慎氏	shen shi	1
+身世悠悠何足问	shen shi you you he zu wen	1
+沈叔安	shen shu an	1
+身死人手	shen si ren shou	1
+沈颂	shen song	1
+深邃博大	shen sui bo da	1
+身外即浮云	shen wai ji fu yun	1
+沈蔚	shen wei	1
+身为贾人妇	shen wei gu ren fu	1
+身为天子	shen wei tian zi	1
+神无方	shen wu fang	1
+慎勿为妇死	shen wu wei fu si	1
+慎勿违吾语	shen wu wei wu yu	1
+神行令	shen xing ling	1
+慎行其余	shen xing qi yu	1
+身行万里半天下	shen xing wan li ban tian xia	1
+沈颜	shen yan	1
+慎言其余	shen yan qi yu	1
+沈腰潘鬓销磨	shen yao pan bin xiao mo	1
+深夜月当花	shen ye yue dang hua	1
+矧伊人矣	shen yi ren yi	1
+沈吟放拨插弦中	shen yin fang bo cha xian zhong	1
+神颖	shen ying	1
+沈宇	shen yu	1
+身欲奋飞病在床	shen yu fen fei bing zai chuang	1
+身与浮云无是非	shen yu fu yun wu shi fei	1
+身与货孰多	shen yu huo shu duo	1
+甚于水火	shen yu shui huo	1
+深院静	shen yuan jing	1
+深院月	shen yuan yue	1
+深院昼慵开	shen yuan zhou yong kai	1
+神赞	shen zan	1
+深则厉	shen ze li	1
+神之去	shen zhi qu	1
+神之听之	shen zhi ting zhi	1
+申之以孝悌之义	shen zhi yi xiao ti zhi yi	1
+慎终追远	shen zhong zhui yuan	1
+深竹暗浮烟	shen zhu an fu yan	1
+沈紫曼	shen zi man	1
+神纵欲福难为功	shen zong yu fu nan wei gong	1
+深坐蹙蛾眉	shen zuo cu e mei	1
+深坐颦蛾眉	shen zuo pin e mei	1
+胜败兵家事不期	sheng bai bing jia shi bu qi	1
+生别常恻恻	sheng bie chang ce ce	1
+绳不直	sheng bu zhi	1
+胜常	sheng chang	1
+圣朝无阙事	sheng chao wu que shi	1
+升沉不改故人情	sheng chen bu gai gu ren qing	1
+升沉应已定	sheng chen ying yi ding	1
+生刍一束	sheng chu yi shu	1
+圣代复元古	sheng dai fu yuan gu	1
+圣代即今多雨露	sheng dai ji jin duo yu lu	1
+圣代无隐者	sheng dai wu yin zhe	1
+圣德北服南单于	sheng de bei fu nan chan yu	1
+盛德无我位	sheng de wu wo wei	1
+声断续	sheng duan xu	1
+胜而不美	sheng er bu mei	1
+生而弗有	sheng er fu you	1
+生而同声	sheng er tong sheng	1
+生而知之者上也	sheng er zhi zhi zhe shang ye	1
+声非加疾也	sheng fei jia ji ye	1
+笙歌醉梦间	sheng ge zui meng jian	1
+生孩六月	sheng hai liu yue	1
+生乎吾后	sheng hu wu hou	1
+生乎吾前	sheng hu wu qian	1
+生还偶然遂	sheng huan ou ran sui	1
+生活的磨难	sheng huo de mo nan	1
+升阶伛偻荐脯酒	sheng jie yu lv jian pu jiu	1
+省吏	sheng li	1
+生离与死别	sheng li yu si bie	1
+生男埋没随百草	sheng nan mai mo sui bai cao	1
+圣女祠	sheng nv ci	1
+生女犹得嫁比邻	sheng nv you de jia bi lin	1
+生女有所归	sheng nv you suo gui	1
+升平乐	sheng ping le	1
+圣人不出	sheng ren bu chu	1
+圣人不利己	sheng ren bu li ji	1
+圣人不仁	sheng ren bu ren	1
+圣人不死	sheng ren bu si	1
+圣人常无心	sheng ren chang wu xin	1
+圣人成焉	sheng ren cheng yan	1
+圣人存而不论	sheng ren cun er bu lun	1
+生人但眠食	sheng ren dan mian shi	1
+圣人生焉	sheng ren sheng yan	1
+圣人无常师	sheng ren wu chang shi	1
+圣人无名	sheng ren wu ming	1
+圣人已死	sheng ren yi si	1
+圣人用之	sheng ren yong zhi	1
+圣人在天下	sheng ren zai tian xia	1
+胜人者有力	sheng ren zhe you li	1
+圣人之道	sheng ren zhi dao	1
+圣人之道也	sheng ren zhi dao ye	1
+圣人之德也	sheng ren zhi de ye	1
+圣人之所以为圣	sheng ren zhi suo yi wei sheng	1
+生人作死别	sheng ren zuo si bie	1
+生入玉门关	sheng ru yu men guan	1
+胜胜慢	sheng sheng man	1
+绳绳兮	sheng sheng xi	1
+绳绳兮不可名	sheng sheng xi bu ke ming	1
+生生者不生	sheng sheng zhe bu sheng	1
+胜事空自知	sheng shi kong zi zhi	1
+生事且弥漫	sheng shi qie mi man	1
+生事如转蓬	sheng shi ru zhuan peng	1
+生死不相离	sheng si bu xiang li	1
+胜似春光	sheng si chun guang	1
+生死无虑	sheng si wu lv	1
+胜似闲庭信步	sheng si xian ting xin bu	1
+升堂坐阶新雨足	sheng tang zuo jie xin yu zu	1
+生天生地	sheng tian sheng de	1
+圣王不作	sheng wang bu zuo	1
+声闻邻国	sheng wen lin guo	1
+圣文神武皇帝初	sheng wen shen wu huang di chu	1
+声闻于天	sheng wen yu tian	1
+声闻于野	sheng wen yu ye	1
+生我不得力	sheng wo bu de li	1
+生我劬劳	sheng wo qu lao	1
+圣无忧	sheng wu you	1
+生小不相识	sheng xiao bu xiang shi	1
+生小出野里	sheng xiao chu ye li	1
+圣心备焉	sheng xin bei yan	1
+圣心思贤才	sheng xin si xian cai	1
+声喧乱石中	sheng xuan luan shi zhong	1
+生涯共苦辛	sheng ya gong ku xin	1
+生涯岂料承优诏	sheng ya qi liao cheng you zhao	1
+生涯一片青山	sheng ya yi pian qing shan	1
+生涯在镜中	sheng ya zai jing zhong	1
+生也死之徒	sheng ye si zhi tu	1
+声以动容	sheng yi dong rong	1
+胜因夙所宗	sheng yin su suo zong	1
+剩有离人影	sheng you li ren ying	1
+剩有游人处	sheng you you ren chu	1
+圣则吾不能	sheng ze wu bu neng	1
+生长明妃尚有村	sheng zhang ming fei shang you cun	1
+生者为过客	sheng zhe wei guo ke	1
+圣之和者也	sheng zhi he zhe ye	1
+声之寂寞	sheng zhi ji mo	1
+生之来不能却	sheng zhi lai bu neng que	1
+圣之清者也	sheng zhi qing zhe ye	1
+圣之时者也	sheng zhi shi zhe ye	1
+生之质也	sheng zhi zhi ye	1
+生子还如孙仲谋	sheng zi hai ru sun zhong mou	1
+十爱词	shi ai ci	1
+石安民	shi an min	1
+十八年来堕世间	shi ba nian lai duo shi jian	1
+势拔五岳掩赤城	shi ba wu yue yan chi cheng	1
+十八香	shi ba xiang	1
+适百里者	shi bai li zhe	1
+适彼乐国	shi bi le guo	1
+适彼乐郊	shi bi le jiao	1
+侍婢卖珠回	shi bi mai zhu hui	1
+师不必贤于弟子	shi bu bi xian yu di zi	1
+士不可以不弘毅	shi bu ke yi bu hong yi	1
+时不可止	shi bu ke zhi	1
+十步杀一人	shi bu sha yi ren	1
+使不上漏	shi bu shang lou	1
+是不为也	shi bu wei ye	1
+誓不相隔卿	shi bu xiang ge qing	1
+逝不相好	shi bu xiang hao	1
+食不厌精	shi bu yan jing	1
+时不与我谋	shi bu yu wo mou	1
+时不再来	shi bu zai lai	1
+食不足	shi bu zu	1
+是豺狼也	shi chai lang ye	1
+使臣将王命	shi chen jiang wang ming	1
+始臣之解牛之时	shi chen zhi jie niu zhi shi	1
+是诚不能也	shi cheng bu neng ye	1
+是诚何心哉	shi cheng he xin zai	1
+诗成笑傲凌沧洲	shi cheng xiao ao ling cang zhou	1
+是重阳	shi chong yang	1
+是处青山可埋骨	shi chu qing shan ke mai gu	1
+世传吕览	shi chuan lv lan	1
+视此而已	shi ci er yi	1
+施从良人之所之	shi cong liang ren zhi suo zhi	1
+士大夫之族	shi da fu zhi zu	1
+适当其时	shi dang qi shi	1
+失道而后德	shi dao er hou de	1
+失道非关出襄野	shi dao fei guan chu xiang ye	1
+师道之不复	shi dao zhi bu fu	1
+失德而后仁	shi de er hou ren	1
+适得府君书	shi de fu jun shu	1
+始得西山宴游记	shi de xi shan yan you ji	1
+时登大楼山	shi deng da lou shan	1
+试登绝顶望乡国	shi deng jue ding wang xiang guo	1
+时滴枝上露	shi di zhi shang lu	1
+适冬之望日前后	shi dong zhi wang ri qian hou	1
+失而不忧	shi er bu you	1
+视尔不臧	shi er bu zang	1
+十二红	shi er hong	1
+士而怀居	shi er huai ju	1
+十二郎	shi er lang	1
+十二楼五城	shi er lou wu cheng	1
+十二楼中尽晓妆	shi er lou zhong jin xiao zhuang	1
+士贰其行	shi er qi xing	1
+十二侵	shi er qin	1
+十二时	shi er shi	1
+十二文	shi er wen	1
+十二锡	shi er xi	1
+仕而优则学	shi er you ze xue	1
+十方法界	shi fang fa jie	1
+使舫载之	shi fang zai zhi	1
+是非君子之道	shi fei jun zi zhi dao	1
+是非之涂	shi fei zhi tu	1
+十分诚挚	shi fen cheng zhi	1
+十分寒冷	shi fen han leng	1
+史凤	shi feng	1
+式负版者	shi fu ban zhe	1
+使负栋之柱	shi fu dong zhi zhu	1
+事父母几谏	shi fu mu ji jian	1
+试拂铁衣如雪色	shi fu tie yi ru xue se	1
+士甘焚死不公侯	shi gan fen si bu gong hou	1
+势高竞奔注	shi gao jing ben zhu	1
+试共野人言	shi gong ye ren yan	1
+石鼓歌	shi gu ge	1
+是故哂之	shi gu shen zhi	1
+事姑贻我忧	shi gu yi wo you	1
+石鼓之歌止于此	shi gu zhi ge zhi yu ci	1
+十鼓只载数骆驼	shi gu zhi zai shu luo tuo	1
+十卦	shi gua	1
+石贯	shi guan	1
+示官吏	shi guan li	1
+使还	shi hai	1
+是何人也	shi he ren ye	1
+是何言也	shi he yan ye	1
+使乎使乎	shi hu shi hu	1
+石湖仙	shi hu xian	1
+诗画本一律	shi hua ben yi lv	1
+室坏不修	shi huai bu xiu	1
+仕宦于台阁	shi huan yu tai ge	1
+始皇之心	shi huang zhi xin	1
+十灰	shi hui	1
+实获我心	shi huo wo xin	1
+石季龙	shi ji long	1
+石矶西畔问渔船	shi ji xi pan wen yu chuan	1
+诗家清景在新春	shi jia qing jing zai xin chun	1
+世家三十	shi jia san shi	1
+世间出世间	shi jian chu shi jian	1
+时见归村人	shi jian gui cun ren	1
+世间何物比轻盈	shi jian he wu bi qing ying	1
+时见松枥皆十围	shi jian song li jie shi wei	1
+世间行乐亦如此	shi jian xing le yi ru ci	1
+世间已千年	shi jian yi qian nian	1
+时见幽人独往来	shi jian you ren du wang lai	1
+誓将报主静边尘	shi jiang bao zhu jing bian chen	1
+誓将挂冠去	shi jiang gua guan qu	1
+逝将去女	shi jiang qu nv	1
+誓将上雪列圣耻	shi jiang shang xue lie sheng chi	1
+使骄且吝	shi jiao qie lin	1
+世界微尘里	shi jie wei chen li	1
+室仅方丈	shi jin fang zhang	1
+拭尽英雄泪	shi jin ying xiong lei	1
+时景如飘风	shi jing ru piao feng	1
+市井十洲人	shi jing shi zhou ren	1
+诗经卫风	shi jing wei feng	1
+施酒监	shi jiu jian	1
+酾酒临江	shi jiu lin jiang	1
+尸鸠在桑	shi jiu zai sang	1
+是菊花开日	shi ju hua kai ri	1
+始觉有迁谪意	shi jue you qian zhe yi	1
+使君从南来	shi jun cong nan lai	1
+识君恨不早	shi jun hen bu zao	1
+事君尽礼	shi jun jin li	1
+使君自有妇	shi jun zi you fu	1
+试开临水殿	shi kai lin shui dian	1
+试开云梦羔儿酒	shi kai yun meng gao er jiu	1
+试看天地翻覆	shi kan tian di fan fu	1
+石恪	shi ke	1
+是可忍也	shi ke ren ye	1
+诗可以兴	shi ke yi xing	1
+始可与言诗已矣	shi ke yu yan shi yi yi	1
+实可憎	shi ke zeng	1
+十口隔风雪	shi kou ge feng xue	1
+使快弹数曲	shi kuai dan shu qu	1
+师旷之聪	shi kuang zhi cong	1
+诗老不知梅格在	shi lao bu zhi mei ge zai	1
+实劳我心	shi lao wo xin	1
+视历复开书	shi li fu kai shu	1
+十里一走马	shi li yi zou ma	1
+食莲谁不甘	shi lian shui bu gan	1
+始怜幽竹山窗下	shi lian you zhu shan chuang xia	1
+事了拂衣去	shi liao fu yi qu	1
+石麟	shi lin	1
+石廪腾掷堆祝融	shi lin teng zhi dui zhu rong	1
+誓令疏勒出飞泉	shi ling shu le chu fei quan	1
+使六国各爱其人	shi liu guo ge ai qi ren	1
+石榴花	shi liu hua	1
+石榴酒	shi liu jiu	1
+十六君远行	shi liu jun yuan xing	1
+十六诵诗书	shi liu song shi shu	1
+十六叶	shi liu ye	1
+十六字令	shi liu zi ling	1
+十六字令三首	shi liu zi ling san shou	1
+是鲁孔丘与	shi lu kong qiu yu	1
+世路无穷	shi lu wu qiong	1
+世路有屈曲	shi lu you qu qu	1
+世乱各东西	shi luan ge dong xi	1
+世乱同南去	shi luan tong nan qu	1
+适莽苍者	shi mang cang zhe	1
+石门千仞断	shi men qian ren duan	1
+使民不为盗	shi min bu wei dao	1
+使民不争	shi min bu zheng	1
+使民敬忠以劝	shi min jing zhong yi quan	1
+使民如承大祭	shi min ru cheng da ji	1
+使民心不乱	shi min xin bu luan	1
+使民心一	shi min xin yi	1
+使民以时	shi min yi shi	1
+使民战栗	shi min zhan li	1
+时命大谬也	shi ming da miu ye	1
+诗名满天下	shi ming man tian xia	1
+十亩之间	shi mu zhi jian	1
+是难能也	shi nan neng ye	1
+十年曾一别	shi nian ceng yi bie	1
+十年离乱后	shi nian li luan hou	1
+十年栽种百年规	shi nian zai zhong bai nian gui	1
+十年征戍忆辽阳	shi nian zheng shu yi liao yang	1
+士女欢娱万国同	shi nv huan yu wan guo tong	1
+侍女金盘脍鲤鱼	shi nv jin pan kuai li yu	1
+十拍子	shi pai zi	1
+世披靡矣扶之直	shi pi mi yi fu zhi zhi	1
+事其大夫之贤者	shi qi dai fu zhi xian zhe	1
+弑其君者	shi qi jun zhe	1
+失其民也	shi qi min ye	1
+失其民者	shi qi min zhe	1
+视其所以	shi qi suo yi	1
+十七为君妇	shi qi wei jun fu	1
+失其心也	shi qi xin ye	1
+是其言也	shi qi yan ye	1
+适千里者	shi qian li zhe	1
+市桥官柳细	shi qiao guan liu xi	1
+是妾断肠时	shi qie duan chang shi	1
+事亲是也	shi qin shi ye	1
+是禽兽也	shi qin shou ye	1
+事亲为大	shi qin wei da	1
+时清独北还	shi qing du bei hai	1
+世情恶衰歇	shi qing e shuai xie	1
+世情已逐浮云散	shi qing yi zhu fu yun san	1
+事去千年犹恨速	shi qu qian nian you hen su	1
+势曲已回萦	shi qu yi hui ying	1
+失却烟花主	shi que yan hua zhu	1
+世人不识东方朔	shi ren bu shi dong fang shuo	1
+使人成荒淫	shi ren cheng huang yin	1
+失仁而后义	shi ren er hou yi	1
+是人寰	shi ren huan	1
+世人见我轻鸿毛	shi ren jian wo qing hong mao	1
+世人解听不解赏	shi ren jie ting bu jie shang	1
+世人皆欲杀	shi ren jie yu sha	1
+诗人老去莺莺在	shi ren lao qu ying ying zai	1
+诗人例作水曹郎	shi ren li zuo shui cao lang	1
+时人莫小池中水	shi ren mo xiao chi zhong shui	1
+使人听此凋朱颜	shi ren ting ci diao zhu yan	1
+诗人兴会更无前	shi ren xing hui geng wu qian	1
+市人行尽野人行	shi ren xing jin ye ren xing	1
+时人已知处	shi ren yi zhi chu	1
+诗人玉屑	shi ren yu xie	1
+适人之适	shi ren zhi shi	1
+是人之所欲也	shi ren zhi suo yu ye	1
+世人自弃我	shi ren zi qi wo	1
+十日春寒不出门	shi ri chun han bu chu men	1
+十日画一水	shi ri hua yi shui	1
+事如春梦了无痕	shi ru chun meng liao wu hen	1
+事若不成	shi ruo bu cheng	1
+诗三百篇	shi san bai pian	1
+十三能织素	shi san neng zhi su	1
+十三覃	shi san qin	1
+十三问	shi san wen	1
+十三元	shi san yuan	1
+十三职	shi san zhi	1
+世上岂无千里马	shi shang qi wu qian li ma	1
+世上未有如公贫	shi shang wei you ru gong pin	1
+世上无难事	shi shang wu nan shi	1
+世上无知音	shi shang wu zhi yin	1
+十觞亦不醉	shi shang yi bu zui	1
+是社稷之臣也	shi she ji zhi chen ye	1
+史深	shi shen	1
+十生九死到官所	shi sheng jiu si dao guan suo	1
+世事波上舟	shi shi bo shang zhou	1
+士师不能治士	shi shi bu neng zhi shi	1
+世事蹉跎成白首	shi shi cuo tuo cheng bai shou	1
+室始洞然	shi shi dong ran	1
+世事多变幻	shi shi duo bian huan	1
+世事纷纭从君理	shi shi fen yun cong jun li	1
+世事浮云何足问	shi shi fu yun he zu wen	1
+始适还家门	shi shi hai jia men	1
+十世可知也	shi shi ke zhi ye	1
+世事空知学醉歌	shi shi kong zhi xue zui ge	1
+世事两茫茫	shi shi liang mang mang	1
+师师令	shi shi ling	1
+世事茫茫难自料	shi shi mang mang nan zi liao	1
+湜湜其沚	shi shi qi zhi	1
+是时尚多垒	shi shi shang duo lei	1
+事事四五通	shi shi si wu tong	1
+世事随时变	shi shi sui shi bian	1
+时时为安慰	shi shi wei an wei	1
+时时误拂弦	shi shi wu fu xian	1
+十十五五依黄芦	shi shi wu wu yi huang lu	1
+时时引领望天末	shi shi yin ling wang tian mo	1
+世事悠悠	shi shi you you	1
+是事之变	shi shi zhi bian	1
+时时只见龙蛇走	shi shi zhi jian long she zou	1
+士庶人曰	shi shu ren yue	1
+世叔讨论之	shi shu tao lun zhi	1
+事孰为大	shi shu wei da	1
+世衰道微	shi shuai dao wei	1
+是谁之过与	shi shui zhi guo yu	1
+诗思禅心共竹闲	shi si chan xin gong zhu xian	1
+十四寒	shi si han	1
+十四为君妇	shi si wei jun fu	1
+十四学裁衣	shi si xue cai yi	1
+十四盐	shi si yan	1
+世俗之人	shi su zhi ren	1
+十岁裁诗走马成	shi sui cai shi zou ma cheng	1
+士虽有学	shi sui you xue	1
+实所共鉴	shi suo gong jian	1
+世态炎凉甚	shi tai yan liang shen	1
+世态已更千变尽	shi tai yi geng qian bian jin	1
+誓天不相负	shi tian bu xiang fu	1
+使天下之人	shi tian xia zhi ren	1
+十万工农下吉安	shi wan gong nong xia ji an	1
+是罔民也	shi wang min ye	1
+事往日迁	shi wang ri qian	1
+是谓不道	shi wei bu dao	1
+是谓宠辱若惊	shi wei chong ru ruo jing	1
+是谓道纪	shi wei dao ji	1
+是为得之	shi wei de zhi	1
+是谓反其真	shi wei fan qi zhen	1
+是谓过矣	shi wei guo yi	1
+是谓惚恍	shi wei hu huang	1
+实为狼狈	shi wei lang bei	1
+是谓能养	shi wei neng yang	1
+是谓弃之	shi wei qi zhi	1
+是谓天地根	shi wei tian di gen	1
+是谓微明	shi wei wei ming	1
+是谓无状之状	shi wei wu zhuang zhi zhuang	1
+是为袭常	shi wei xi chang	1
+是谓袭明	shi wei xi ming	1
+是谓玄德	shi wei xuan de	1
+是谓玄牝	shi wei xuan pin	1
+是谓要妙	shi wei yao miao	1
+事文类聚	shi wen lei ju	1
+试问岭南应不好	shi wen ling nan ying bu hao	1
+诗文有	shi wen you	1
+使我不能餐兮	shi wo bu neng can xi	1
+使我不能息兮	shi wo bu neng xi xi	1
+食我农夫	shi wo nong fu	1
+使我三军泪如雨	shi wo san jun lei ru yu	1
+使我心痗	shi wo xin mei	1
+适我愿兮	shi wo yuan xi	1
+示我周行	shi wo zhou hang	1
+十五弹箜篌	shi wu dan kong hou	1
+始吾弗信	shi wu fu xin	1
+是无父也	shi wu fu ye	1
+十五观奇书	shi wu guan qi shu	1
+十五合	shi wu he	1
+十五即乘潮	shi wu ji cheng chao	1
+世无难事	shi wu nan shi	1
+十五泣春风	shi wu qi chun feng	1
+十五删	shi wu shan	1
+十五始展眉	shi wu shi zhan mei	1
+世无洗耳翁	shi wu xi er weng	1
+十五咸	shi wu xian	1
+是吾忧也	shi wu you ye	1
+始吾于人也	shi wu yu ren ye	1
+是夕	shi xi	1
+室西连于中闺	shi xi lian yu zhong gui	1
+侍香金童	shi xiang jin tong	1
+失向来之烟霞	shi xiang lai zhi yan xia	1
+饰小说以干县令	shi xiao shuo yi gan xian ling	1
+石孝友	shi xiao you	1
+是醒是醉	shi xing shi zui	1
+失性于俗者	shi xing yu su zhe	1
+侍轩辕	shi xuan yuan	1
+史延	shi yan	1
+石延年	shi yan nian	1
+十样花	shi yang hua	1
+十药	shi yao	1
+事业不同	shi ye bu tong	1
+士也罔极	shi ye wang ji	1
+事业无穷年	shi ye wu qiong nian	1
+是夜越吟苦	shi ye yue yin ku	1
+食野之蒿	shi ye zhi hao	1
+食野之芩	shi ye zhi qin	1
+是亦彼也	shi yi bi ye	1
+是以不去	shi yi bu qu	1
+十一队	shi yi dui	1
+失义而后礼	shi yi er hou li	1
+是以后世无传焉	shi yi hou shi wu chuan yan	1
+是以论其世也	shi yi lun qi shi ye	1
+十一陌	shi yi mo	1
+是以圣人	shi yi sheng ren	1
+是以圣人犹难之	shi yi sheng ren you nan zhi	1
+是以圣人欲上民	shi yi sheng ren yu shang min	1
+是以圣人之治	shi yi sheng ren zhi zhi	1
+是刈是濩	shi yi shi hu	1
+是亦为政	shi yi wei zheng	1
+是以谓之文也	shi yi wei zhi wen ye	1
+是以无德	shi yi wu de	1
+是以陷邻境	shi yi xian lin jing	1
+十一尤	shi yi you	1
+是以有德	shi yi you de	1
+十一真	shi yi zhen	1
+是亦走也	shi yi zou ye	1
+时有落花至	shi you luo hua zhi	1
+十有七年	shi you qi nian	1
+史愚	shi yu	1
+室语	shi yu	1
+是与不是	shi yu bu shi	1
+石鱼湖	shi yu hu	1
+时雨降矣	shi yu jiang yi	1
+适遇牧马童子	shi yu mu ma tong zi	1
+士与女	shi yu nv	1
+始与秦塞通人烟	shi yu qin sai tong ren yan	1
+师与商也孰贤	shi yu shang ye shu xian	1
+使于四方	shi yu si fang	1
+施于有政	shi yu you zheng	1
+是鱼之乐也	shi yu zhi le ye	1
+施于中谷	shi yu zhong gu	1
+施于中林	shi yu zhong lin	1
+十月初二日	shi yue chu er ri	1
+十月获稻	shi yue huo dao	1
+十月纳禾稼	shi yue na he jia	1
+十月时	shi yue shi	1
+十月蟋蟀	shi yue xi shuai	1
+十月之交	shi yue zhi jiao	1
+诗韵合璧	shi yun he bi	1
+时哉时哉	shi zai shi zai	1
+时则不至	shi ze bu zhi	1
+士则以身殉名	shi ze yi shen xun ming	1
+时展尺书看	shi zhan chi shu kan	1
+石召	shi zhao	1
+逝者如斯夫	shi zhe ru si fu	1
+十蒸	shi zheng	1
+事之本也	shi zhi ben ye	1
+实之宾也	shi zhi bin ye	1
+食旨不甘	shi zhi bu gan	1
+视之不见其形	shi zhi bu jian qi xing	1
+视之不足见	shi zhi bu zu jian	1
+士之耽兮	shi zhi dan xi	1
+事直皇天在	shi zhi huang tian zai	1
+是知津矣	shi zhi jin yi	1
+始知李太守	shi zhi li tai shou	1
+是之取尔	shi zhi qu er	1
+时之人	shi zhi ren	1
+始知人老不如花	shi zhi ren lao bu ru hua	1
+失之若惊	shi zhi ruo jing	1
+师之所处	shi zhi suo chu	1
+师之所存也	shi zhi suo cun ye	1
+世之所贵道者	shi zhi suo gui dao zhe	1
+使之闻之	shi zhi wen zhi	1
+始知五岳外	shi zhi wu yue wai	1
+时至轩中	shi zhi xuan zhong	1
+始制有名	shi zhi you ming	1
+士志于道	shi zhi yu dao	1
+师挚之始	shi zhi zhi shi	1
+始终存在	shi zhong cun zai	1
+世中遥望空云山	shi zhong yao wang kong yun shan	1
+石州引	shi zhou yin	1
+湿竹暗浮烟	shi zhu an fu yan	1
+使子路反见之	shi zi lu fan jian zhi	1
+使子婴为相	shi zi ying wei xiang	1
+始卒若环	shi zu ruo huan	1
+始作俑者	shi zuo yong zhe	1
+手把芙蓉朝玉京	shou ba fu rong chao yu jing	1
+手持绿玉杖	shou chi lv yu zhang	1
+首戴方山巾	shou dai fang shan jin	1
+守而勿失	shou er wu shi	1
+受而喜之	shou er xi zhi	1
+收绩开史牒	shou ji kai shi die	1
+守节情不移	shou jie qing bu yi	1
+手卷真珠上玉钩	shou juan zhen zhu shang yu gou	1
+寿楼春	shou lou chun	1
+受母钱帛多	shou mu qian bo duo	1
+寿南山	shou nan shan	1
+瘦怯那禁舞	shou qie na jin wu	1
+守柔曰强	shou rou yue qiang	1
+收汝泪纵横	shou ru lei zong heng	1
+寿山曲	shou shan qu	1
+守身为大	shou shen wei da	1
+收拾金瓯一片	shou shi jin ou yi pian	1
+手提掷还崔大夫	shou ti zhi huan cui dai fu	1
+受天百禄	shou tian bai lu	1
+收天下之兵	shou tian xia zhi bing	1
+守望相助	shou wang xiang zhu	1
+受侮不少	shou wu bu shao	1
+受降城下月如霜	shou xiang cheng xia yue ru shuang	1
+受械于陈	shou xie yu chen	1
+寿星明	shou xing ming	1
+寿阳公主嫁时妆	shou yang gong zhu jia shi zhuang	1
+首阳之下	shou yang zhi xia	1
+寿则多辱	shou ze duo ru	1
+守之本也	shou zhi ben ye	1
+手之所触	shou zhi suo chu	1
+手之舞之	shou zhi wu zhi	1
+授之以政	shou zhi yi zheng	1
+兽之走圹也	shou zhi zou kuang ye	1
+守拙归田园	shou zhuo gui tian yuan	1
+书被催成墨未浓	shu bei cui cheng mo wei nong	1
+书边事	shu bian shi	1
+疏布缠枯骨	shu bu chan ku gu	1
+书不过语	shu bu guo yu	1
+孰不可忍也	shu bu ke ren ye	1
+书不能悉意	shu bu neng xi yi	1
+孰不为事	shu bu wei shi	1
+孰不为守	shu bu wei shou	1
+孰不知礼	shu bu zhi li	1
+数尝於	shu chang yu	1
+数丛沙草群鸥散	shu cong sha cao qun ou san	1
+孰短孰长	shu duan shu chang	1
+疏而不失	shu er bu shi	1
+述而不作	shu er bu zuo	1
+述而第七	shu er di qi	1
+舒而脱脱兮	shu er tuo tuo xi	1
+鼠翻窗网小惊猜	shu fan chuang wang xiao jing cai	1
+数风流人物	shu feng liu ren wu	1
+数峰青	shu feng qing	1
+孰敢不正	shu gan bu zheng	1
+输肝剖胆效英才	shu gan pou dan xiao ying cai	1
+数罟不入洿池	shu gu bu ru hu chi	1
+戍鼓断人行	shu gu duan ren xing	1
+曙光初照演兵场	shu guang chu zhao yan bing chang	1
+蜀国曾闻子规鸟	shu guo ceng wen zi gui niao	1
+蜀国多仙山	shu guo duo xian shan	1
+孰后倦焉	shu hou juan yan	1
+书画家	shu hua jia	1
+书剑两无成	shu jian liang wu cheng	1
+蜀江春水拍江流	shu jiang chun shui pai jiang liu	1
+戍客望边色	shu ke wang bian se	1
+蜀葵花	shu kui hua	1
+输来其间	shu lai qi jian	1
+数里入云峰	shu li ru yun feng	1
+疏粝亦足饱我饥	shu li yi zu bao wo ji	1
+疏帘淡月	shu lian dan yue	1
+庶刘侥幸	shu liu jiao xing	1
+数米而炊	shu mi er chui	1
+树密鸟声幽	shu mi niao sheng you	1
+树杪百重泉	shu miao bai zhong quan	1
+庶民攻之	shu min gong zhi	1
+庶民去之	shu min qu zhi	1
+树木犹为人爱惜	shu mu you wei ren ai xi	1
+孰能为之大	shu neng wei zhi da	1
+孰能御之	shu neng yu zhi	1
+蜀鸟吴花残照里	shu niao wu hua can zhao li	1
+淑气催黄鸟	shu qi cui huang niao	1
+蜀琴欲奏鸳鸯弦	shu qin yu zou yuan yang xian	1
+蜀清守丹穴	shu qing shou dan xue	1
+庶情沿物应	shu qing yan wu ying	1
+淑人君子	shu ren jun zi	1
+数日前	shu ri qian	1
+树色随山迥	shu se sui shan jiong	1
+蜀僧抱绿绮	shu seng bao lv qi	1
+淑慎其身	shu shen qi shen	1
+数声和月到帘栊	shu sheng he yue dao lian long	1
+书生身世今如此	shu sheng shen shi jin ru ci	1
+舒氏	shu shi	1
+鼠屎污羹	shu shi wu geng	1
+树树立风雪	shu shu li feng xue	1
+疏疏一树五更寒	shu shu yi shu wu geng han	1
+啜菽饮水	shu shu yin shui	1
+疏松影落空坛静	shu song ying luo kong tan jing	1
+属他人	shu ta ren	1
+树头树底觅残红	shu tou shu di mi can hong	1
+孰为此者	shu wei ci zhe	1
+孰为夫子	shu wei fu zi	1
+孰谓微生高直	shu wei wei sheng gao zhi	1
+数问夜如何	shu wen ye ru he	1
+叔兮伯兮	shu xi bo xi	1
+蜀溪春	shu xi chun	1
+孰先传焉	shu xian chuan yan	1
+蜀先主庙	shu xian zhu miao	1
+梳晓鬟也	shu xiao huan ye	1
+舒窈纠兮	shu yao jiu xi	1
+树艺五谷	shu yi wu gu	1
+疏雨滴梧桐	shu yu di wu tong	1
+疏雨过中条	shu yu guo zhong tiao	1
+束于教也	shu yu jiao ye	1
+孰与君少长	shu yu jun shao zhang	1
+叔于田	shu yu tian	1
+舒元舆	shu yuan yu	1
+孰云网恢恢	shu yun wang hui hui	1
+孰云吾道非	shu yun wu dao fei	1
+书郑重	shu zheng zhong	1
+孰知不向边庭苦	shu zhi bu xiang bian ting ku	1
+孰知二谢将能事	shu zhi er xie jiang neng shi	1
+熟知茅斋绝低小	shu zhi mao zhai jue di xiao	1
+孰知其极	shu zhi qi ji	1
+树之微风	shu zhi wei feng	1
+树之以桑	shu zhi yi sang	1
+书中复达否	shu zhong fu da fou	1
+蜀主征吴幸三峡	shu zhu zheng wu xing san xia	1
+耍孩儿	shua hai er	1
+率由旧章	shuai you jiu zhang	1
+霜薄花更发	shuang bo hua geng fa	1
+霜晨月	shuang chen yue	1
+双带子	shuang dai zi	1
+双珰丁丁联尺素	shuang dang ding ding lian chi su	1
+双调	shuang diao	1
+双飞西园草	shuang fei xi yuan cao	1
+双荷叶	shuang he ye	1
+双红豆	shuang hong dou	1
+双渐	shuang jian	1
+双桨鸿惊	shuang jiang hong jing	1
+霜降水痕收	shuang jiang shui hen shou	1
+双泪落君前	shuang lei luo jun qian	1
+双鲤迢迢一纸书	shuang li tiao tiao yi zhi shu	1
+霜落荆门江树空	shuang luo jing men jiang shu kong	1
+双目送飞鸿	shuang mu song fei hong	1
+双皮溜雨四十围	shuang pi liu yu si shi wei	1
+霜凄万树风入衣	shuang qi wan shu feng ru yi	1
+双桥落彩虹	shuang qiao luo cai hong	1
+双入镜中开	shuang ru jing zhong kai	1
+双声子	shuang sheng zi	1
+霜天晓	shuang tian xiao	1
+双头莲	shuang tou lian	1
+霜溪冷	shuang xi leng	1
+双悬日月照乾坤	shuang xuan ri yue zhao qian kun	1
+双燕儿	shuang yan er	1
+双燕离	shuang yan li	1
+双烟一气凌紫霞	shuang yan yi qi ling zi xia	1
+双韵子	shuang yun zi	1
+双照泪痕干	shuang zhao lei hen gan	1
+谁爱风流高格调	shui ai feng liu gao ge diao	1
+水碧沙明两岸苔	shui bi sha ming liang an tai	1
+水不深	shui bu shen	1
+水沉浓	shui chen nong	1
+谁持白羽静风尘	shui chi bai yu jing feng chen	1
+谁持彩练当空舞	shui chi cai lian dang kong wu	1
+水赤刃伤手	shui chi ren shang shou	1
+水澹澹兮生烟	shui dan dan xi sheng yan	1
+谁道嵇康懒	shui dao ji kang lan	1
+谁得而族灭也	shui de er zu mie ye	1
+谁得似	shui de si	1
+水滴铜龙昼漏长	shui di tong long zhou lou chang	1
+水调	shui diao	1
+水调歌	shui diao ge	1
+水调歌头游泳	shui diao ge tou you yong	1
+水东流	shui dong liu	1
+水风清	shui feng qing	1
+水覆难再收	shui fu nan zai shou	1
+谁复商量管弦	shui fu shang liang guan xian	1
+水光浮日出	shui guang fu ri chu	1
+水光接天	shui guang jie tian	1
+水国春寒阴复晴	shui guo chun han yin fu qing	1
+水旱不知	shui han bu zhi	1
+水寒风似刀	shui han feng si dao	1
+谁挥鞭策驱四运	shui hui bian ce qu si yun	1
+谁毁谁誉	shui hui shui yu	1
+水击三千里	shui ji san qian li	1
+谁家见月能闲坐	shui jia jian yue neng xian zuo	1
+谁见泣离群	shui jian qi li qun	1
+谁见汀洲上	shui jian ting zhou shang	1
+谁解乘舟寻范蠡	shui jie cheng zhou xun fan li	1
+水晶帘	shui jing lian	1
+水晶帘卷近秋河	shui jing lian juan jin qiu he	1
+水晶帘下看梳头	shui jing lian xia kan shu tou	1
+水静犹明	shui jing you ming	1
+水精之盘行素鳞	shui jing zhi pan xing su lin	1
+谁怜一片影	shui lian yi pian ying	1
+谁怜越女颜如玉	shui lian yue nv yan ru yu	1
+水流心不竞	shui liu xin bu jing	1
+水路疑霜雪	shui lu yi shuang xue	1
+水落鱼梁浅	shui luo yu liang qian	1
+水落鱼龙夜	shui luo yu long ye	1
+水濛濛	shui meng meng	1
+谁能出不由户	shui neng chu bu you hu	1
+谁能将旗鼓	shui neng jiang qi gu	1
+谁能绝人命	shui neng jue ren ming	1
+谁能役役尘中累	shui neng yi yi chen zhong lei	1
+谁念北楼上	shui nian bei lou shang	1
+睡起杨花满绣床	shui qi yang hua man xiu chuang	1
+水浅而舟大也	shui qian er zhou da ye	1
+水清石出鱼可数	shui qing shi chu yu ke shu	1
+水去云回恨不胜	shui qu yun hui hen bu sheng	1
+水泉冷涩弦凝绝	shui quan leng se xian ning jue	1
+水如环佩月如襟	shui ru huan pei yue ru jin	1
+水如一匹练	shui ru yi pi lian	1
+水色南天远	shui se nan tian yuan	1
+水深波浪阔	shui shen bo lang kuo	1
+水深深	shui shen shen	1
+水声激激风吹衣	shui sheng ji ji feng chui yi	1
+谁适为容	shui shi wei rong	1
+谁识卧龙客	shui shi wo long ke	1
+谁似东坡老	shui si dong po lao	1
+水天空阔	shui tian kong kuo	1
+水天清	shui tian qing	1
+谁为表予心	shui wei biao yu xin	1
+谁谓波澜才一水	shui wei bo lan cai yi shui	1
+谁为含愁独不见	shui wei han chou du bu jian	1
+谁谓河广	shui wei he guang	1
+水为佩	shui wei pei	1
+谁谓雀无角	shui wei que wu jiao	1
+谁谓鼠无牙	shui wei shu wu ya	1
+谁谓宋远	shui wei song yuan	1
+谁谓荼苦	shui wei tu ku	1
+水为沼	shui wei zhao	1
+水为之而寒于水	shui wei zhi er han yu shui	1
+水纹珍簟思悠悠	shui wen zhen dian si you you	1
+谁无父母	shui wu fu mu	1
+水仙子	shui xian zi	1
+水泄不通	shui xie bu tong	1
+水荇牵风翠带长	shui xing qian feng cui dai chang	1
+谁言气盖世	shui yan qi gai shi	1
+谁与共平生	shui yu gong ping sheng	1
+水与晴空宜	shui yu qing kong yi	1
+水月通禅寂	shui yue tong chan ji	1
+水云游	shui yun you	1
+谁在秋千	shui zai qiu qian	1
+水哉水哉	shui zai shui zai	1
+水枕能令山俯仰	shui zhen neng ling shan fu yang	1
+谁知林栖者	shui zhi lin qi zhe	1
+谁知我心	shui zhi wo xin	1
+谁知尧与跖	shui zhi yao yu zhi	1
+谁之永号	shui zhi yong hao	1
+谁知真患难	shui zhi zhen huan nan	1
+谁知之者	shui zhi zhi zhe	1
+谁知竹西路	shui zhi zhu xi lu	1
+水中藻荇交横	shui zhong zao xing jiao heng	1
+谁主沉浮	shui zhu chen fu	1
+水浊不可饮	shui zhuo bu ke yin	1
+舜功禹顾养	shun gong yu gu yang	1
+舜何人也	shun he ren ye	1
+顺流而东行	shun liu er dong xing	1
+顺流而东也	shun liu er dong ye	1
+顺人而不失己	shun ren er bu shi ji	1
+舜有天下	shun you tian xia	1
+朔吹翻江意未平	shuo chui fan jiang yi wei ping	1
+硕大且卷	shuo da qie juan	1
+硕大无朋	shuo da wu peng	1
+说道风光在水西	shuo dao feng guang zai shui xi	1
+朔方健儿好身手	shuo fang jian er hao shen shou	1
+硕人	shuo ren	1
+硕人其颀	shuo ren qi qi	1
+硕人之宽	shuo ren zhi kuan	1
+说甚龙争虎斗	shuo shen long zheng hu dou	1
+说怿女美	shuo yi nv mei	1
+朔云边月满西山	shuo yun bian yue man xi shan	1
+说之虽不以道	shuo zhi sui bu yi dao	1
+思悲翁	si bei weng	1
+四边伐鼓雪海涌	si bian fa gu xue hai yong	1
+四边静	si bian jing	1
+死别已吞声	si bie yi tun sheng	1
+驷不及舌	si bu ji she	1
+似不能言者	si bu neng yan zhe	1
+斯不善已	si bu shan yi	1
+思垂空文以自见	si chui kong wen yi zi jian	1
+似从地底来	si cong di di lai	1
+四代好	si dai hao	1
+死当结草	si dang jie cao	1
+斯得民矣	si de min yi	1
+斯得天下矣	si de tian xia yi	1
+思帝乡	si di xiang	1
+似洞庭	si dong ting	1
+死而不祸	si er bu huo	1
+思而不见	si er bu jian	1
+思而不能去也	si er bu neng qu ye	1
+死而不亡者寿	si er bu wang zhe shou	1
+死而无悔者	si er wu hui zhe	1
+四犯令	si fan ling	1
+四方环镇嵩当中	si fang huan zhen song dang zhong	1
+四方是维	si fang shi wei	1
+四方之内	si fang zhi nei	1
+四方之政行焉	si fang zhi zheng xing yan	1
+斯干	si gan	1
+四更山吐月	si geng shan tu yue	1
+四顾但湖泓	si gu dan hu hong	1
+四顾山光接水光	si gu shan guang jie shui guang	1
+思归多苦颜	si gui duo ku yan	1
+思归何必深	si gui he bi shen	1
+思归乐	si gui le	1
+思国之安者	si guo zhi an zhe	1
+四海翻腾云水怒	si hai fan teng yun shui nu	1
+四海困穷	si hai kun qiong	1
+四海遂为家	si hai sui wei jia	1
+四海同寒食	si hai tong han shi	1
+四海为家此路穷	si hai wei jia ci lu qiong	1
+斯害也已	si hai ye yi	1
+四海之内	si hai zhi nei	1
+四豪	si hao	1
+四和春	si he chun	1
+四和香	si he xiang	1
+四换头	si huan tou	1
+嗣皇继圣登夔皋	si huang ji sheng deng kui gao	1
+死灰吹不起	si hui chui bu qi	1
+四季花	si ji hua	1
+思佳客	si jia ke	1
+私见张良	si jian zhang liang	1
+似将海水添宫漏	si jiang hai shui tian gong lou	1
+四角碍白日	si jiao ai bai ri	1
+四角龙子幡	si jiao long zi fan	1
+四郊秋叶惊摵摵	si jiao qiu ye jing se se	1
+四郊未宁静	si jiao wei ning jing	1
+死节从来岂顾勋	si jie cong lai qi gu xun	1
+斯近信矣	si jin xin yi	1
+四境之内不治	si jing zhi nei bu zhi	1
+思君君不来	si jun jun bu lai	1
+思君君不知	si jun jun bu zhi	1
+思君如百草	si jun ru bai cao	1
+思君如明烛	si jun ru ming zhu	1
+思君如夜烛	si jun ru ye zhu	1
+思君若汶水	si jun ruo wen shui	1
+司空曙	si kong shu	1
+司空图	si kong tu	1
+四块玉	si kuai yu	1
+丝罗袄	si luo ao	1
+嘶马出门思故乡	si ma chu men si gu xiang	1
+司马春衫	si ma chun shan	1
+司马德操	si ma de cao	1
+司马光	si ma guang	1
+司马牛问君子	si ma niu wen jun zi	1
+司马牛问仁	si ma niu wen ren	1
+司马牛忧曰	si ma niu you yue	1
+司马图	si ma tu	1
+司马扎	si ma zha	1
+四面芙蓉开	si mian fu rong kai	1
+四明有狂客	si ming you kuang ke	1
+四牡	si mu	1
+四牡骙骙	si mu kui kui	1
+四牡业业	si mu ye ye	1
+四牡翼翼	si mu yi yi	1
+似娘儿	si niang er	1
+斯人不可闻	si ren bu ke wen	1
+斯人独憔悴	si ren du qiao cui	1
+寺人孟子	si ren meng zi	1
+斯人清唱何人和	si ren qing chang he ren he	1
+斯仁至矣	si ren zhi yi	1
+似僧有发	si seng you fa	1
+死生亦大矣	si sheng yi da yi	1
+四时不节	si shi bu jie	1
+四时更变化	si shi geng bian hua	1
+四时好	si shi hao	1
+四时行焉	si shi xing yan	1
+丝丝心欲碎	si si xin yu sui	1
+似诉平生不得志	si su ping sheng bu de zhi	1
+斯速已矣	si su yi yi	1
+嘶酸雏雁失群夜	si suan chu yan shi qun ye	1
+四体不勤	si ti bu qin	1
+四体康且直	si ti kang qie zhi	1
+斯天下之民至焉	si tian xia zhi min zhi yan	1
+驷驖	si tie	1
+似万物之宗	si wan wu zhi zong	1
+斯谓之君子已乎	si wei zhi jun zi yi hu	1
+斯谓之仁已乎	si wei zhi ren yi hu	1
+斯文未丧	si wen wei sang	1
+似闻昨者赤松子	si wen zuo zhe chi song zi	1
+思我小怨	si wo xiao yuan	1
+俟我于城隅	si wo yu cheng yu	1
+俟我於城隅	si wo yu cheng yu	1
+四无人声	si wu ren sheng	1
+思想与精神	si xiang yu jing shen	1
+斯须改变如苍狗	si xu gai bian ru cang gou	1
+斯须九重真龙出	si xu jiu chong zhen long chu	1
+斯焉取斯	si yan qu si	1
+斯亦不足畏也已	si yi bu zu wei ye yi	1
+斯已而已矣	si yi er yi yi	1
+死已三千岁矣	si yi san qian sui yi	1
+思依依	si yi yi	1
+似有人开	si you ren kai	1
+似与不似	si yu bu si	1
+思欲委符节	si yu wei fu jie	1
+斯远暴慢矣	si yuan bao man yi	1
+四园竹	si yuan zhu	1
+四月八日	si yue ba ri	1
+四月南风大麦黄	si yue nan feng da mai huang	1
+思越人	si yue ren	1
+四月时	si yue shi	1
+四月秀葽	si yue xiu yao	1
+似月云中见	si yue yun zhong jian	1
+死则同穴	si ze tong xue	1
+死者为归人	si zhe wei gui ren	1
+四纸	si zhi	1
+四质	si zhi	1
+斯知仁矣	si zhi ren yi	1
+四字令	si zi ling	1
+四座无言星欲稀	si zuo wu yan xing yu xi	1
+松柏本孤直	song bai ben gu zhi	1
+松柏生深山	song bai sheng shen shan	1
+松柏一迳趋灵宫	song bai yi jing qu ling gong	1
+送别	song bie	1
+宋不足征也	song bu zu zheng ye	1
+送陈章甫	song chen zhang fu	1
+送崔九	song cui jiu	1
+宋德广	song de guang	1
+宋迪	song di	1
+宋鼎	song ding	1
+送杜十四之江南	song du shi si zhi jiang nan	1
+松风吹解带	song feng chui jie dai	1
+松高白鹤眠	song gao bai he mian	1
+松寒不改容	song han bu gai rong	1
+宋济	song ji	1
+松际露微月	song ji lu wei yue	1
+松间明月长如此	song jian ming yue chang ru ci	1
+送将归	song jiang gui	1
+宋璟璟	song jing jing	1
+送君灞陵亭	song jun ba ling ting	1
+送君不觉有离伤	song jun bu jue you li shang	1
+送君走马归京师	song jun zou ma gui jing shi	1
+送客湓浦口	song ke pen pu kou	1
+宋李清照	song li qing zhao	1
+送李愿归盘谷序	song li yuan gui pan gu xu	1
+送灵澈	song ling che	1
+送孟浩然之广陵	song meng hao ran zhi guang ling	1
+诵明月之诗	song ming yue zhi shi	1
+宋齐丘	song qi qiu	1
+送秦中诸人引	song qin zhong zhu ren yin	1
+送人东游	song ren dong you	1
+松如盖	song ru gai	1
+宋若华	song ruo hua	1
+宋若昭	song ruo zhao	1
+送僧归日本	song seng gui ri ben	1
+送上人	song shang ren	1
+松梢月	song shao yue	1
+松声晚窗里	song sheng wan chuang li	1
+诵诗三百	song shi san bai	1
+送述古	song shu gu	1
+讼斯在	song si zai	1
+送送多穷路	song song duo qiong lu	1
+宋苏轼	song su shi	1
+宋琬	song wan	1
+送魏万之京	song wei wan zhi jing	1
+送我至剡溪	song wo zhi shan xi	1
+宋务光	song wu guang	1
+松下清斋折露葵	song xia qing zhai zhe lu kui	1
+送行人	song xing ren	1
+送杨氏女	song yang shi nv	1
+松叶堪为酒	song ye kan wei jiu	1
+宋雍	song yong	1
+送友人入蜀	song you ren ru shu	1
+宋昱	song yu	1
+宋玉无愁亦自愁	song yu wu chou yi zi chou	1
+宋媛	song yuan	1
+松月生夜凉	song yue sheng ye liang	1
+松月夜窗墟	song yue ye chuang xu	1
+松月夜窗虚	song yue ye chuang xu	1
+嵩云秦树久离居	song yun qin shu jiu li ju	1
+送征衣	song zheng yi	1
+宋之问	song zhi wen	1
+松洲	song zhou	1
+送朱大入秦	song zhu da ru qin	1
+宋子侯	song zi hou	1
+送子涉淇	song zi she qi	1
+送梓州李使君	song zi zhou li shi jun	1
+送纵宇一郎东行	song zong yu yi lang dong xing	1
+宿白鹭洲	su bai lu zhou	1
+素娥惟与月	su e wei yu yue	1
+宿府	su fu	1
+素冠	su guan	1
+苏广文	su guang wen	1
+苏瑰	su gui	1
+苏涣	su huan	1
+苏检	su jian	1
+苏泂	su jiong	1
+宿鹭起圆沙	su lu qi yuan sha	1
+俗人昭昭	su ren zhao zhao	1
+素善留侯张良	su shan liu hou zhang liang	1
+素手把芙蓉	su shou ba fu rong	1
+素手抽针冷	su shou chou zhen leng	1
+素手青条上	su shou qing tiao shang	1
+素手玉房前	su shou yu fang qian	1
+肃肃莲花界	su su lian hua jie	1
+肃肃其羽	su su qi yu	1
+肃肃兔罝	su su tu ju	1
+肃肃宵征	su su xiao zheng	1
+苏台览古	su tai lan gu	1
+苏绾	su wan	1
+宿王昌龄隐居	su wang chang ling yin ju	1
+苏味道	su wei dao	1
+苏武	su wu	1
+苏武魂销汉使前	su wu hun xiao han shi qian	1
+苏武庙	su wu miao	1
+宿巫山下	su wu shan xia	1
+苏武传	su wu zhuan	1
+宿昔梦见之	su xi meng jian zhi	1
+苏溪亭上草漫漫	su xi ting shang cao man man	1
+苏小门前长短条	su xiao men qian chang duan tiao	1
+夙兴夜寐	su xing ye mei	1
+夙夜在公	su ye zai gong	1
+苏易简	su yi jian	1
+素衣朱绣	su yi zhu xiu	1
+苏寓	su yu	1
+苏郁	su yu	1
+宿于逆旅	su yu ni lv	1
+苏源明	su yuan ming	1
+苏芸	su yun	1
+夙遭闵凶	su zao min xiong	1
+苏拯	su zheng	1
+诉衷情近	su zhong qing jin	1
+苏子愀然	su zi qiao ran	1
+算当年	suan dang nian	1
+虽不得鱼	sui bu de yu	1
+虽不能言	sui bu neng yan	1
+岁不我与	sui bu wo yu	1
+虽不吾以	sui bu wu yi	1
+遂成知己	sui cheng zhi ji	1
+隋堤三月水溶溶	sui di san yue shui rong rong	1
+随风生珠玉	sui feng sheng zhu yu	1
+虽覆一篑	sui fu yi kui	1
+隋宫	sui gong	1
+岁寒知松柏	sui han zhi song bai	1
+虽褐宽博	sui he kuan bo	1
+岁华尽摇落	sui hua jin yao luo	1
+遂及我私	sui ji wo si	1
+随君直到夜郎西	sui jun zhi dao ye lang xi	1
+虽累百世	sui lei bai shi	1
+遂令东海变桑田	sui ling dong hai bian sang tian	1
+遂令东山客	sui ling dong shan ke	1
+遂命酒	sui ming jiu	1
+岁暮归南山	sui mu gui nan shan	1
+岁暮阴阳催短景	sui mu yin yang cui duan jing	1
+虽然在城市	sui ran zai cheng shi	1
+随人作计终后人	sui ren zuo ji zhong hou ren	1
+岁仍大熟	sui reng da shu	1
+岁日	sui ri	1
+随山到水源	sui shan dao shui yuan	1
+随山将万转	sui shan jiang wan zhuan	1
+虽赏之不窃	sui shang zhi bu qie	1
+遂事不谏	sui shi bu jian	1
+随师东	sui shi dong	1
+碎石水磷磷	sui shi shui lin lin	1
+虽受然灯记	sui shou ran deng ji	1
+虽疏食菜羹	sui shu shi cai geng	1
+虽速我讼	sui su wo song	1
+虽速我狱	sui su wo yu	1
+岁岁重阳	sui sui chong yang	1
+岁岁春草生	sui sui chun cao sheng	1
+岁岁金河复玉关	sui sui jin he fu yu guan	1
+虽天地之大	sui tian di zhi da	1
+虽万被戮	sui wan bei lu	1
+虽无宾主意	sui wu bin zhu yi	1
+睢盱侦伺能鞠躬	sui xu zhen si neng ju gong	1
+虽一毫而莫取	sui yi hao er mo qu	1
+岁亦莫止	sui yi mo zhi	1
+岁亦阳止	sui yi yang zhi	1
+虽有槁暴	sui you gao pu	1
+虽有绝顶谁能穷	sui you jue ding shui neng qiong	1
+虽有荣观	sui you rong guan	1
+虽有智慧	sui you zhi hui	1
+虽有周亲	sui you zhou qin	1
+虽与府吏要	sui yu fu li yao	1
+虽欲勿用	sui yu wu yong	1
+遂与之俱出	sui yu zhi ju chu	1
+岁月人间促	sui yue ren jian cu	1
+虽曰未学	sui yue wei xue	1
+虽则如云	sui ze ru yun	1
+随着中华民族的	sui zhe zhong hua min zu de	1
+虽执鞭之士	sui zhi bian zhi shi	1
+虽智大迷	sui zhi da mi	1
+绥之斯来	sui zhi si lai	1
+虽之夷狄	sui zhi yi di	1
+孙处玄	sun chu xuan	1
+孙定	sun ding	1
+孙鲂	sun fang	1
+孙革	sun ge	1
+笋根稚子无人见	sun gen zhi zi wu ren jian	1
+孙顾	sun gu	1
+孙光宪	sun guang xian	1
+孙合	sun he	1
+孙居敬	sun ju jing	1
+孙谋梁国珍	sun mou liang guo zhen	1
+孙佺	sun quan	1
+孙锐	sun rui	1
+孙万寿	sun wan shou	1
+孙纬	sun wei	1
+孙惟信	sun wei xin	1
+孙偓	sun wo	1
+孙吴会	sun wu hui	1
+孙咸	sun xian	1
+孙岘	sun xian	1
+孙以出之	sun yi chu zhi	1
+损者三乐	sun zhe san le	1
+损之又损	sun zhi you sun	1
+孙子膑脚	sun zi bin jiao	1
+孙子断足	sun zi duan zu	1
+锁窗寒	suo chuang han	1
+所得是沾衣	suo de shi zhan yi	1
+所恶勿施尔也	suo e wu shi er ye	1
+琐寒窗	suo han chuang	1
+锁寒窗	suo han chuang	1
+所获颇多	suo huo po duo	1
+所见明知	suo jian ming zhi	1
+所交尽豪雄	suo jiao jin hao xiong	1
+索酒	suo jiu	1
+所居未得邻	suo ju wei de lin	1
+索句渝州叶正黄	suo ju yu zhou ye zheng huang	1
+所守或匪亲	suo shou huo fei qin	1
+所谓故国者	suo wei gu guo zhe	1
+所谓立之斯立	suo wei li zhi si li	1
+所谓前洞也	suo wei qian dong ye	1
+锁衔金兽连环冷	suo xian jin shou lian huan leng	1
+所向无空阔	suo xiang wu kong kuo	1
+锁阳台	suo yang tai	1
+所以遣将守关者	suo yi qian jiang shou guan zhe	1
+所宜深慎	suo yi shen shen	1
+所以隐忍苟活	suo yi yin ren gou huo	1
+所以终日醉	suo yi zhong ri zui	1
+所欲与之聚之	suo yu yu zhi ju zhi	1
+踏遍青山人未老	ta bian qing shan ren wei lao	1
+踏春游	ta chun you	1
+踏歌词	ta ge ci	1
+踏青二三月	ta qing er san yue	1
+踏青游	ta qing you	1
+他人之贤者	ta ren zhi xian zhe	1
+他日如何举似人	ta ri ru he ju si ren	1
+他日再相逢	ta ri zai xiang feng	1
+踏莎美人	ta sha mei ren	1
+他山之石	ta shan zhi shi	1
+他山总不如	ta shan zong bu ru	1
+他生未卜此生休	ta sheng wei bu ci sheng xiu	1
+他生缘会更难期	ta sheng yuan hui geng nan qi	1
+塔势如涌出	ta shi ru yong chu	1
+他席他乡送客杯	ta xi ta xiang song ke bei	1
+他乡复行役	ta xiang fu xing yi	1
+他乡寒食远堪悲	ta xiang han shi yuan kan bei	1
+他乡生白发	ta xiang sheng bai fa	1
+他乡胜故乡	ta xiang sheng gu xiang	1
+踏月	ta yue	1
+踏云行	ta yun xing	1
+踏枝间	ta zhi jian	1
+太白与我语	tai bai yu wo yu	1
+泰伯第八	tai bo di ba	1
+台城路	tai cheng lu	1
+台城游	tai cheng you	1
+泰初有无	tai chu you wu	1
+泰而不骄	tai er bu jiao	1
+太和万物	tai he wan wu	1
+太湖水	tai hu shui	1
+态浓意远淑且真	tai nong yi yuan shu qie zhen	1
+太平令	tai ping ling	1
+太平时	tai ping shi	1
+太平世界	tai ping shi jie	1
+苔色连深竹	tai se lian shen zhu	1
+泰山一掷轻鸿毛	tai shan yi zhi qing hong mao	1
+泰山之下	tai shan zhi xia	1
+太上不辱先	tai shang bu ru xian	1
+苔深不能扫	tai shen bu neng sao	1
+太尉夫人	tai wei fu ren	1
+太尉笑且入	tai wei xiao qie ru	1
+太阳出	tai yang chu	1
+太乙近天都	tai yi jin tian du	1
+太乙真君	tai yi zhen jun	1
+太宰知我乎	tai zai zhi wo hu	1
+太真含笑入帘来	tai zhen han xiao ru lian lai	1
+台州地阔海冥冥	tai zhou di kuo hai ming ming	1
+探春令	tan chun ling	1
+探春慢	tan chun man	1
+坦荡君子	tan dang jun zi	1
+谭方平	tan fang ping	1
+探芳信	tan fang xin	1
+探芳新	tan fang xin	1
+叹凤嗟身否	tan feng jie shen fou	1
+弹剑作歌奏苦声	tan jian zuo ge zou ku sheng	1
+谈空说有夜不眠	tan kong shuo you ye bu mian	1
+摊破采桑子	tan po cai sang zi	1
+谭峭	tan qiao	1
+弹琴	tan qin	1
+潭清疑水浅	tan qing yi shui qian	1
+叹息肠内热	tan xi chang nei re	1
+叹息未应闲	tan xi wei ying xian	1
+谈笑凯歌还	tan xiao kai ge hai	1
+谈笑无还期	tan xiao wu hai qi	1
+潭烟飞溶溶	tan yan fei rong rong	1
+谭意哥	tan yi ge	1
+谭用之	tan yong zhi	1
+贪于财货	tan yu cai huo	1
+谈余天雨花	tan yu tian yu hua	1
+唐备	tang bei	1
+唐棣之华	tang di zhi hua	1
+唐扶	tang fu	1
+唐庚	tang geng	1
+汤恢	tang hui	1
+汤惠休	tang hui xiu	1
+唐廪	tang lin	1
+堂前月色愈清好	tang qian yue se yu qing hao	1
+堂上启阿母	tang shang qi a mu	1
+堂上四库书	tang shang si ku shu	1
+汤思退	tang si tui	1
+堂堂大丈夫	tang tang da zhang fu	1
+堂堂乎张也	tang tang hu zhang ye	1
+堂堂剑气	tang tang jian qi	1
+堂堂如春	tang tang ru chun	1
+搪突鼍獭瞋	tang tu tuo ta chen	1
+汤文璐	tang wen lu	1
+唐温如	tang wen ru	1
+唐五代	tang wu dai	1
+倘秀才	tang xiu cai	1
+唐暄	tang xuan	1
+唐玄宗	tang xuan zong	1
+唐尧臣	tang yao chen	1
+唐怡	tang yi	1
+汤有天下	tang you tian xia	1
+汤悦	tang yue	1
+汤之问棘也是已	tang zhi wen ji ye shi yi	1
+唐宗宋祖	tang zong song zu	1
+陶翰	tao han	1
+桃红复含宿雨	tao hong fu han su yu	1
+桃花飞绿水	tao hua fei lv shui	1
+桃花尽日随流水	tao hua jin ri sui liu shui	1
+桃花开不开	tao hua kai bu kai	1
+桃花历乱李花香	tao hua li luan li hua xiang	1
+桃花流水窅然去	tao hua liu shui yao ran qu	1
+桃花乱落如红雨	tao hua luan luo ru hong yu	1
+桃花马上石榴裙	tao hua ma shang shi liu qun	1
+桃花浅深处	tao hua qian shen chu	1
+桃花人面各相红	tao hua ren mian ge xiang hong	1
+桃花水	tao hua shui	1
+桃花溪	tao hua xi	1
+桃花细逐杨花落	tao hua xi zhu yang hua luo	1
+桃花一簇开无主	tao hua yi cu kai wu zhu	1
+桃花源里可耕田	tao hua yuan li ke geng tian	1
+桃花源里人家	tao hua yuan li ren jia	1
+桃李春风一杯酒	tao li chun feng yi bei jiu	1
+桃李得日开	tao li de ri kai	1
+桃李罗堂前	tao li luo tang qian	1
+桃李无言又何在	tao li wu yan you he zai	1
+桃李阴阴柳絮飞	tao li yin yin liu xu fei	1
+陶令不知何处去	tao ling bu zhi he chu qu	1
+陶令篱边色	tao ling li bian se	1
+陶然共忘机	tao ran gong wang ji	1
+陶然共醉菊花杯	tao ran gong zui ju hua bei	1
+涛似连山喷雪来	tao si lian shan pen xue lai	1
+慆慆不归	tao tao bu gui	1
+陶陶兀兀	tao tao wu wu	1
+陶雍	tao yong	1
+桃园忆故人	tao yuan yi gu ren	1
+桃源忆故人	tao yuan yi gu ren	1
+特为尤甚	te wei you shen	1
+滕白	teng bai	1
+滕迈	teng mai	1
+滕倪	teng ni	1
+滕王高阁临江渚	teng wang gao ge lin jiang zhu	1
+滕王阁序	teng wang ge xu	1
+滕文公上	teng wen gong shang	1
+滕文公下	teng wen gong xia	1
+腾骧磊落三万匹	teng xiang lei luo san wan pi	1
+题村舍	ti cun she	1
+题大庾岭北驿	ti da yu ling bei yi	1
+提刀而立	ti dao er li	1
+题花光画	ti hua guang hua	1
+题金陵渡	ti jin ling du	1
+剔开红焰救飞蛾	ti kai hong yan jiu fei e	1
+涕落百余行	ti luo bai yu xing	1
+题木兰庙	ti mu lan miao	1
+啼鸟惊残梦	ti niao jing can meng	1
+替人愁	ti ren chou	1
+题僧壁	ti seng bi	1
+啼时惊妾梦	ti shi jing qie meng	1
+涕泗滂沱	ti si pang tuo	1
+体无咎言	ti wu jiu yan	1
+体性抱神	ti xing bao shen	1
+题扬州禅智寺	ti yang zhou chan zhi si	1
+剔银灯	ti yin deng	1
+蹄者所以在兔	ti zhe suo yi zai tu	1
+题竹石牧牛	ti zhu shi mu niu	1
+天杯宴重臣	tian bei yan zhong chen	1
+天边树若荠	tian bian shu ruo ji	1
+天兵怒气冲霄汉	tian bing nu qi chong xiao han	1
+天兵照雪下玉关	tian bing zhao xue xia yu guan	1
+天不可测	tian bu ke ce	1
+天长地久	tian chang di jiu	1
+天长地久成埃尘	tian chang di jiu cheng ai chen	1
+天长地阔岭头分	tian chang di kuo ling tou fen	1
+天长路远魂飞苦	tian chang lu yuan hun fei ku	1
+天长水阔厌远涉	tian chang shui kuo yan yuan she	1
+天长与地久	tian chang yu di jiu	1
+田澄	tian cheng	1
+恬淡为上	tian dan wei shang	1
+天淡云闲今古同	tian dan yun xian jin gu tong	1
+天道无知	tian dao wu zhi	1
+天得一以清	tian de yi yi qing	1
+天地本无心	tian di ben wu xin	1
+天地不仁	tian di bu ren	1
+天地合	tian di he	1
+天地既爱酒	tian di ji ai jiu	1
+天地间第一人品	tian di jian di yi ren pin	1
+天地皆得一	tian di jie de yi	1
+天地皆振动	tian di jie zhen dong	1
+天地尚不能久	tian di shang bu neng jiu	1
+天地为之久低昂	tian di wei zhi jiu di ang	1
+天地相合	tian di xiang he	1
+天地一逆旅	tian di yi ni lv	1
+天地一沙鸥	tian di yi sha ou	1
+天地一指也	tian di yi zhi ye	1
+天地与我并生	tian di yu wo bing sheng	1
+天地至广大	tian di zhi guang da	1
+天地之鉴也	tian di zhi jian ye	1
+天地之友	tian di zhi you	1
+天地中间	tian di zhong jian	1
+天地终无情	tian di zhong wu qing	1
+天地转	tian di zhuan	1
+天地庄生马	tian di zhuang sheng ma	1
+田娥	tian e	1
+天而生也	tian er sheng ye	1
+天翻地覆慨而慷	tian fan di fu kai er kang	1
+天翻地覆三生劫	tian fan di fu san sheng jie	1
+田夫荷锄立	tian fu he chu li	1
+田夫荷锄至	tian fu he chu zhi	1
+天高云淡	tian gao yun dan	1
+天工人代	tian gong ren dai	1
+天宫水西寺	tian gong shui xi si	1
+天工与清新	tian gong yu qing xin	1
+天寒翠袖薄	tian han cui xiu bo	1
+天寒梦泽深	tian han meng ze shen	1
+天寒远山净	tian han yuan shan jing	1
+天河挂绿水	tian he gua lv shui	1
+天和将至	tian he jiang zhi	1
+天何言哉	tian he yan zai	1
+天荒地变心虽折	tian huang di bian xin sui zhe	1
+天回北斗挂西楼	tian hui bei dou gua xi lou	1
+田家几日闲	tian jia ji ri xian	1
+田家秋作苦	tian jia qiu zuo ku	1
+田家元日	tian jia yuan ri	1
+田家占气候	tian jia zhan qi hou	1
+天街七襄转	tian jie qi xiang zhuan	1
+天津桥上无人识	tian jin qiao shang wu ren shi	1
+天连五岭银锄落	tian lian wu ling yin chu luo	1
+天禄永终	tian lu yong zhong	1
+天路幽险难追攀	tian lu you xian nan zhui pan	1
+天马凤凰春树里	tian ma feng huang chun shu li	1
+天马歌	tian ma ge	1
+天门开阖	tian men kai he	1
+天门一长啸	tian men yi chang xiao	1
+天明独去无道路	tian ming du qu wu dao lu	1
+天命靡常	tian ming mi chang	1
+天末怀李白	tian mo huai li bai	1
+天姥连天向天横	tian mu lian tian xiang tian heng	1
+天畔独潸然	tian pan du shan ran	1
+天气不和	tian qi bu he	1
+天堑变通途	tian qian bian tong tu	1
+天清风雨闻	tian qing feng yu wen	1
+天清江月白	tian qing jiang yue bai	1
+天秋月又满	tian qiu yue you man	1
+填然鼓之	tian ran gu zhi	1
+天然去雕饰	tian ran qu diao shi	1
+天人清且安	tian ren qing qie an	1
+天容海色本澄清	tian rong hai se ben cheng qing	1
+天若不爱酒	tian ruo bu ai jiu	1
+天山雪后海风寒	tian shan xue hou hai feng han	1
+天上白玉京	tian shang bai yu jing	1
+天上浮云如白衣	tian shang fu yun ru bai yi	1
+天上接行杯	tian shang jie xing bei	1
+天上秋期近	tian shang qiu qi jin	1
+天上去西征	tian shang qu xi zheng	1
+天上人间不相见	tian shang ren jian bu xiang jian	1
+天上人间一样愁	tian shang ren jian yi yang chou	1
+天生德于予	tian sheng de yu yu	1
+天生一个仙人洞	tian sheng yi ge xian ren dong	1
+天势围平野	tian shi wei ping ye	1
+天实为之	tian shi wei zhi	1
+天视自我民视	tian shi zi wo min shi	1
+天书云篆谁所铭	tian shu yun zhuan shui suo ming	1
+甜水令	tian shui ling	1
+天台瀑布寺	tian tai pu bu si	1
+天台四万八千丈	tian tai si wan ba qian zhang	1
+天台晓望	tian tai xiao wang	1
+天台一万八千丈	tian tai yi wan ba qian zhang	1
+天堂地狱	tian tang di yu	1
+天听自我民听	tian ting zi wo min ting	1
+天外黑风吹海立	tian wai hei feng chui hai li	1
+天外三峰削不成	tian wai san feng xue bu cheng	1
+天王圣明	tian wang sheng ming	1
+天无二日	tian wu er ri	1
+天无私覆	tian wu si fu	1
+天无为以之清	tian wu wei yi zhi qing	1
+天下多忌讳	tian xia duo ji hui	1
+天下恶乎定	tian xia e hu ding	1
+天下归仁焉	tian xia gui ren yan	1
+天下国家	tian xia guo jia	1
+天下和	tian xia he	1
+天下横行	tian xia heng xing	1
+天下既已治也	tian xia ji yi zhi ye	1
+天下将自正	tian xia jiang zi zheng	1
+天下皆叛之	tian xia jie pan zhi	1
+天下皆谓我道大	tian xia jie wei wo dao da	1
+天下可运於掌	tian xia ke yun yu zhang	1
+天下乐	tian xia le	1
+天下莫能臣	tian xia mo neng chen	1
+天下莫能与之争	tian xia mo neng yu zhi zheng	1
+天下莫强焉	tian xia mo qiang yan	1
+天下难事	tian xia nan shi	1
+天下朋友皆胶漆	tian xia peng you jie jiao qi	1
+天下伤心处	tian xia shang xin chu	1
+天下神器	tian xia shen qi	1
+天下万物生于有	tian xia wan wu sheng yu you	1
+天下未之有也	tian xia wei zhi you ye	1
+天下无道	tian xia wu dao	1
+天下希及之	tian xia xi ji zhi	1
+天下信之	tian xia xin zhi	1
+天下已定	tian xia yi ding	1
+天下有大戒二	tian xia you da jie er	1
+天下有道	tian xia you dao	1
+天下有道则见	tian xia you dao ze jian	1
+天下有始	tian xia you shi	1
+天下犹未平	tian xia you wei ping	1
+天下云集响应	tian xia yun ji xiang ying	1
+天下之本在国	tian xia zhi ben zai guo	1
+天下之水	tian xia zhi shui	1
+天下之言	tian xia zhi yan	1
+天下之至柔	tian xia zhi zhi rou	1
+天香留凤尾	tian xiang liu feng wei	1
+天香引	tian xiang yin	1
+天香云外飘	tian xiang yun wai piao	1
+天旋地转回龙驭	tian xuan di zhuan hui long yu	1
+天涯孤棹还	tian ya gu zhao hai	1
+天涯哭此时	tian ya ku ci shi	1
+天涯流落思无穷	tian ya liu luo si wu qiong	1
+天涯去不归	tian ya qu bu gui	1
+天涯日又斜	tian ya ri you xie	1
+天涯霜雪霁寒霄	tian ya shuang xue ji han xiao	1
+天涯涕泪一身遥	tian ya ti lei yi shen yao	1
+天涯同此路	tian ya tong ci lu	1
+天涯一望断人肠	tian ya yi wang duan ren chang	1
+天涯占梦数	tian ya zhan meng shu	1
+天意高难问	tian yi gao nan wen	1
+天易见	tian yi jian	1
+天阴雨湿声啾啾	tian yin yu shi sheng jiu jiu	1
+田游岩	tian you yan	1
+天欲堕	tian yu duo	1
+天欲雪	tian yu xue	1
+天欲雨	tian yu yu	1
+天欲坠	tian yu zhui	1
+田园作	tian yuan zuo	1
+田章	tian zhang	1
+天之苍苍	tian zhi cang cang	1
+天知否	tian zhi fou	1
+天之高也	tian zhi gao ye	1
+天之将丧斯文也	tian zhi jiang sang si wen ye	1
+天之历数在尔躬	tian zhi li shu zai er gong	1
+天之未丧斯文也	tian zhi wei sang si wen ye	1
+天之小人	tian zhi xiao ren	1
+天质自森森	tian zhi zi sen sen	1
+田中行	tian zhong xing	1
+天子不仁	tian zi bu ren	1
+添字采桑子	tian zi cai sang zi	1
+天子非常赐颜色	tian zi fei chang ci yan se	1
+天子呼来不上船	tian zi hu lai bu shang chuan	1
+天子穆穆	tian zi mu mu	1
+天尊地卑	tian zun di bei	1
+跳波自相溅	tiao bo zi xiang jian	1
+迢递高城百尺楼	tiao di gao cheng bai chi lou	1
+迢递三巴路	tiao di san ba lu	1
+迢递嵩高下	tiao di song gao xia	1
+迢递送斜晖	tiao di song xie hui	1
+迢迢半紫氛	tiao tiao ban zi fen	1
+迢迢见明星	tiao tiao jian ming xing	1
+迢迢牵牛星	tiao tiao qian niu xing	1
+挑兮达兮	tiao xi da xi	1
+苕溪渔隐丛话	tiao xi yu yin cong hua	1
+调笑	tiao xiao	1
+调笑令	tiao xiao ling	1
+岧峣太华俯咸京	tiao yao tai hua fu xian jing	1
+蜩与学鸠笑之曰	tiao yu xue jiu xiao zhi yue	1
+铁马金戈	tie ma jin ge	1
+铁衣远戍辛勤久	tie yi yuan shu xin qin jiu	1
+听臣微志	ting chen wei zhi	1
+停船暂借问	ting chuan zan jie wen	1
+停舫临孤驿	ting fang lin gu yi	1
+庭空客散人归后	ting kong ke san ren gui hou	1
+庭燎	ting liao	1
+庭燎之光	ting liao zhi guang	1
+听其言而观其行	ting qi yan er guan qi xing	1
+听其言而信其行	ting qi yan er xin qi xing	1
+听其言也	ting qi yan ye	1
+听其言也厉	ting qi yan ye li	1
+听其音	ting qi yin	1
+厅前柳	ting qian liu	1
+庭实	ting shi	1
+听蜀僧浚弹琴	ting shu seng jun tan qin	1
+听蜀僧濬弹琴	ting shu seng jun tan qin	1
+亭亭凤凰台	ting ting feng huang tai	1
+亭午暗阡陌	ting wu an qian mo	1
+庭下如积水空明	ting xia ru ji shui kong ming	1
+亭下水连空	ting xia shui lian kong	1
+庭下梧桐树	ting xia wu tong shu	1
+庭虚近水闻	ting xu jin shui wen	1
+庭有枇杷树	ting you pi pa shu	1
+庭院深深	ting yuan shen shen	1
+听猿实下三声泪	ting yuan shi xia san sheng lei	1
+听筝	ting zheng	1
+听之不闻其声	ting zhi bu wen qi sheng	1
+听之而不闻	ting zhi er bu wen	1
+听之却罢松间琴	ting zhi que ba song jian qin	1
+听之无声	ting zhi wu sheng	1
+听止于耳	ting zhi yu er	1
+听钟未眠客	ting zhong wei mian ke	1
+汀洲无浪复无烟	ting zhou wu lang fu wu yan	1
+停舟暂借问	ting zhou zan jie wen	1
+同悲万古尘	tong bei wan gu chen	1
+彤弓	tong gong	1
+通古今之变	tong gu jin zhi bian	1
+同谷子	tong gu zi	1
+彤管有炜	tong guan you wei	1
+同行皆狼狈	tong hang jie lang bei	1
+同乎无知	tong hu wu zhi	1
+桐花落	tong hua luo	1
+同居长干里	tong ju chang gan li	1
+铜炉华烛烛增辉	tong lu hua zhu zhu zeng hui	1
+同辇随君侍君侧	tong nian sui jun shi jun ce	1
+通其狂惑	tong qi kuang huo	1
+通神明	tong shen ming	1
+同声自相应	tong sheng zi xiang ying	1
+同是长干人	tong shi chang gan ren	1
+同题仙游观	tong ti xian you guan	1
+通天下一气耳	tong tian xia yi qi er	1
+同心干	tong xin gan	1
+同心与我违	tong xin yu wo wei	1
+同学少年多不贱	tong xue shao nian duo bu jian	1
+同穴窅冥何所望	tong xue yao ming he suo wang	1
+童颜若可驻	tong yan ruo ke zhu	1
+同养公田	tong yang gong tian	1
+痛饮狂歌空度日	tong yin kuang ge kong du ri	1
+桐阴转午	tong yin zhuan wu	1
+同于大通	tong yu da tong	1
+同于道者	tong yu dao zhe	1
+同于德者	tong yu de zhe	1
+同于失者	tong yu shi zhe	1
+童稚开荆扉	tong zhi kai jing fei	1
+童子解吟长恨曲	tong zi jie yin chang hen qu	1
+童子六七人	tong zi liu qi ren	1
+同作逐臣君更远	tong zuo zhu chen jun geng yuan	1
+头白好归来	tou bai hao gui lai	1
+投畀豺虎	tou bi chai hu	1
+头发上指	tou fa shang zhi	1
+投荒万死鬓毛斑	tou huang wan si bin mao ban	1
+头颅早悔平生贱	tou lu zao hui ping sheng jian	1
+头上安头	tou shang an tou	1
+头上玳瑁光	tou shang dai mao guang	1
+头上高山	tou shang gao shan	1
+头上何所有	tou shang he suo you	1
+偷声木兰花	tou sheng mu lan hua	1
+投诗赠汨罗	tou shi zeng mi luo	1
+投我以木李	tou wo yi mu li	1
+投我以木桃	tou wo yi mu tao	1
+途次望乡	tu ci wang xiang	1
+徒此挹清芬	tu ci yi qing fen	1
+徒此揖清芬	tu ci yi qing fen	1
+图典失其事	tu dian shi qi shi	1
+土豆烧熟了	tu dou shao shu le	1
+徒法不能以自行	tu fa bu neng yi zi xing	1
+吐故纳新	tu gu na xin	1
+土国城漕	tu guo cheng cao	1
+兔寒蟾冷桂花白	tu han chan leng gui hua bai	1
+兔罝	tu ju	1
+徒劳恨费声	tu lao hen fei sheng	1
+徒令上将挥神笔	tu ling shang jiang hui shen bi	1
+徒留无所施	tu liu wu suo shi	1
+图难于其易	tu nan yu qi yi	1
+涂穷反遭俗眼白	tu qiong fan zao su yan bai	1
+徒善不足以为政	tu shan bu zu yi wei zheng	1
+兔丝	tu si	1
+秃厮儿	tu si er	1
+徒为造化功	tu wei zao hua gong	1
+突兀压神州	tu wu ya shen zhou	1
+徒言树桃李	tu yan shu tao li	1
+兔爰	tu yuan	1
+团扇复迎秋	tuan shan fu ying qiu	1
+团团走	tuan tuan zou	1
+退而论书策	tui er lun shu ce	1
+退而省其私	tui er sheng qi si	1
+推贤进士为务	tui xian jin shi wei wu	1
+吞二周而亡诸侯	tun er zhou er wang zhu hou	1
+脱布衫	tuo bu shan	1
+拖船一何苦	tuo chuan yi he ku	1
+脱剑膝前横	tuo jian xi qian heng	1
+脱帽露顶王公前	tuo mao lu ding wang gong qian	1
+脱身独骑	tuo shen du qi	1
+脱身独去	tuo shen du qu	1
+萚兮	tuo xi	1
+托遗响于悲风	tuo yi xiang yu bei feng	1
+托于同体	tuo yu tong ti	1
+瓦缝参差	wa feng cen ci	1
+外连衡而斗诸侯	wai lian heng er dou zhu hou	1
+外其身而身存	wai qi shen er shen cun	1
+外无旷夫	wai wu kuang fu	1
+晚泊浔阳望庐山	wan bo xun yang wang lu shan	1
+万楚	wan chu	1
+万川归之	wan chuan gui zhi	1
+晚次鄂州	wan ci e zhou	1
+万代千秋仰圣君	wan dai qian qiu yang sheng jun	1
+万法本闲	wan fa ben xian	1
+万方乐奏有于阗	wan fang le zou you yu tian	1
+万方有罪	wan fang you zui	1
+晚风吹行舟	wan feng chui xing zhou	1
+万夫莫开	wan fu mo kai	1
+弯弓辞汉月	wan gong ci han yue	1
+万古可为则	wan gu ke wei ze	1
+万古千秋对洛城	wan gu qian qiu dui luo cheng	1
+万古清风	wan gu qing feng	1
+万古青蒙蒙	wan gu qing meng meng	1
+万古惟留楚客悲	wan gu wei liu chu ke bei	1
+万古永相望	wan gu yong xiang wang	1
+万古云霄一羽毛	wan gu yun xiao yi yu mao	1
+万国尽征戍	wan guo jin zheng shu	1
+万国衣冠拜冕旒	wan guo yi guan bai mian liu	1
+万壑树参天	wan he shu can tian	1
+万户捣衣声	wan hu dao yi sheng	1
+万户千门入画图	wan hu qian men ru hua tu	1
+万户伤心生野烟	wan hu shang xin sheng ye yan	1
+万户萧疏鬼唱歌	wan hu xiao shu gui chang ge	1
+万花纷谢一时稀	wan hua fen xie yi shi xi	1
+万家灯火暖春风	wan jia deng huo nuan chun feng	1
+晚家南山陲	wan jia nan shan chui	1
+晚见雁行频	wan jian yan hang pin	1
+万井出新烟	wan jing chu xin yan	1
+纨袴不饿死	wan ku bu e si	1
+万籁百泉相与秋	wan lai bai quan xiang yu qiu	1
+万籁此俱寂	wan lai ci ju ji	1
+晚来风	wan lai feng	1
+万籁有声	wan lai you sheng	1
+芄兰	wan lan	1
+万类霜天竞自由	wan lei shuang tian jing zi you	1
+万里不惜死	wan li bu xi si	1
+万里长江横渡	wan li chang jiang heng du	1
+万里长征人未还	wan li chang zheng ren wei huan	1
+万里春	wan li chun	1
+万里渡河汾	wan li du he fen	1
+万里奉王事	wan li feng wang shi	1
+万里浮云卷碧山	wan li fu yun juan bi shan	1
+万里浮云阴且晴	wan li fu yun yin qie qing	1
+万里归心对月明	wan li gui xin dui yue ming	1
+万里寒光生积雪	wan li han guang sheng ji xue	1
+万里黄河绕黑山	wan li huang he rao hei shan	1
+万里卷潮来	wan li juan chao lai	1
+万里可横行	wan li ke heng xing	1
+万里来游还望远	wan li lai you hai wang yuan	1
+万里念将归	wan li nian jiang gui	1
+万里飘零两鬓蓬	wan li piao ling liang bin peng	1
+万里桥西一草堂	wan li qiao xi yi cao tang	1
+万里禽兽皆遮罗	wan li qin shou jie zhe luo	1
+万里情	wan li qing	1
+万里清风来	wan li qing feng lai	1
+万里人南去	wan li ren nan qu	1
+万里尚为邻	wan li shang wei lin	1
+万里少行人	wan li shao xing ren	1
+万里望孤舟	wan li wang gu zhou	1
+万里无云月在中	wan li wu yun yue zai zhong	1
+万里西风瀚海沙	wan li xi feng han hai sha	1
+万里西风夜正长	wan li xi feng ye zheng chang	1
+万里相逢欢复泣	wan li xiang feng huan fu qi	1
+万里写入胸怀间	wan li xie ru xiong huai jian	1
+万里雪飘	wan li xue piao	1
+万里眼中明	wan li yan zhong ming	1
+万里云罗一雁飞	wan li yun luo yi yan fei	1
+万马战犹酣	wan ma zhan you han	1
+万木霜天红烂漫	wan mu shuang tian hong lan man	1
+万木已清霜	wan mu yi qing shuang	1
+万年春	wan nian chun	1
+万年秋	wan nian qiu	1
+晚年惟好静	wan nian wei hao jing	1
+万年枝	wan nian zhi	1
+万牛回首丘山重	wan niu hui shou qiu shan zhong	1
+万顷波中得自由	wan qing bo zhong de zi you	1
+万顷江田一鹭飞	wan qing jiang tian yi lu fei	1
+宛丘	wan qiu	1
+宛丘之上兮	wan qiu zhi shang xi	1
+万取千焉	wan qu qian yan	1
+万人不可干	wan ren bu ke gan	1
+万人如海一身藏	wan ren ru hai yi shen cang	1
+万人凿盘石	wan ren zao pan shi	1
+婉如清扬	wan ru qing yang	1
+万山不隔中秋月	wan shan bu ge zhong qiu yue	1
+万乘出黄道	wan sheng chu huang dao	1
+万乘之国	wan sheng zhi guo	1
+万事不关心	wan shi bu guan xin	1
+万事不可料	wan shi bu ke liao	1
+万事到头都是梦	wan shi dao tou dou shi meng	1
+万事皆波澜	wan shi jie bo lan	1
+万事皆如此	wan shi jie ru ci	1
+万事随时更故新	wan shi sui shi geng gu xin	1
+万事随转烛	wan shi sui zhuan zhu	1
+万事悉悠悠	wan shi xi you you	1
+万寿无疆	wan shou wu jiang	1
+万树江边杏	wan shu jiang bian xing	1
+万水千山只等闲	wan shui qian shan zhi deng xian	1
+晚岁迫偷生	wan sui po tou sheng	1
+晚庭摧玉树	wan ting cui yu shu	1
+弯弯月出挂城头	wan wan yue chu gua cheng tou	1
+万物并作	wan wu bing zuo	1
+万物不伤	wan wu bu shang	1
+万物负阴而抱阳	wan wu fu yin er bao yang	1
+万物将自宾	wan wu jiang zi bin	1
+万物将自化	wan wu jiang zi hua	1
+万物霜天竞自由	wan wu shuang tian jing zi you	1
+万物虽多	wan wu sui duo	1
+万物无凋枯	wan wu wu diao ku	1
+万物无以生	wan wu wu yi sheng	1
+万物一马也	wan wu yi ma ye	1
+万物一齐	wan wu yi qi	1
+万物一体	wan wu yi ti	1
+万物云云	wan wu yun yun	1
+万物峥嵘	wan wu zheng rong	1
+万物之本也	wan wu zhi ben ye	1
+万物之多	wan wu zhi duo	1
+万物之镜也	wan wu zhi jing ye	1
+万物作而弗始	wan wu zuo er fu shi	1
+晚霞明	wan xia ming	1
+万绪千条拂落晖	wan xu qian tiao fu luo hui	1
+晚叶红残楚	wan ye hong can chu	1
+晚有弟子传芬芳	wan you di zi chuan fen fang	1
+晚有儿息	wan you er xi	1
+晚雨秋阴酒乍醒	wan yu qiu yin jiu zha xing	1
+晚云烘月	wan yun hong yue	1
+万帐穹庐人醉	wan zhang qiong lu ren zui	1
+宛转蛾眉能几时	wan zhuan e mei neng ji shi	1
+晚妆初过	wan zhuang chu guo	1
+王安礼	wang an li	1
+王安中	wang an zhong	1
+王变乎色	wang bian hu se	1
+王表	wang biao	1
+王播	wang bo	1
+王粲春来更远游	wang can chun lai geng yuan you	1
+望残烟草低迷	wang can yan cao di mi	1
+王苍	wang cang	1
+望长城内外	wang chang cheng nei wai	1
+王昌龄	wang chang ling	1
+望春回	wang chun hui	1
+王绰	wang chuo	1
+王从叔	wang cong shu	1
+汪存	wang cun	1
+网打尽	wang da jin	1
+王道荡荡用无为	wang dao dang dang yong wu wei	1
+枉道而事人	wang dao er shi ren	1
+王道亨	wang dao heng	1
+王道之始也	wang dao zhi shi ye	1
+王德真	wang de zhen	1
+王涤	wang di	1
+望洞庭湖	wang dong ting hu	1
+望断南飞雁	wang duan nan fei yan	1
+望断平时翠辇过	wang duan ping shi cui nian guo	1
+往而不返	wang er bu fan	1
+往而不害	wang er bu hai	1
+忘而复之	wang er fu zhi	1
+亡而为有	wang er wei you	1
+王梵志	wang fan zhi	1
+王风委蔓草	wang feng wei man cao	1
+望夫歌	wang fu ge	1
+王福娘	wang fu niang	1
+望夫石	wang fu shi	1
+王感化	wang gan hua	1
+王庚	wang geng	1
+王拱辰	wang gong chen	1
+王顾左右而言他	wang gu zuo you er yan ta	1
+王光庭	wang guang ting	1
+王硅	wang gui	1
+王翰	wang han	1
+王何必曰利	wang he bi yue li	1
+王赫斯怒	wang he si nu	1
+王槐建	wang huai jian	1
+王涣	wang huan	1
+往还时屡改	wang huan shi lv gai	1
+望黄鹤楼	wang huang he lou	1
+汪极	wang ji	1
+望蓟门	wang ji men	1
+王继鹏	wang ji peng	1
+忘迹世所逐	wang ji shi suo zhu	1
+王季文	wang ji wen	1
+王继勋	wang ji xun	1
+王季友	wang ji you	1
+王建	wang jian	1
+望江东	wang jiang dong	1
+望江梅	wang jiang mei	1
+望江怨	wang jiang yuan	1
+王缙	wang jin	1
+望尽似犹见	wang jin si you jian	1
+王敬伯	wang jing bo	1
+王景中	wang jing zhong	1
+王迥	wang jiong	1
+王琚	wang ju	1
+王居安	wang ju an	1
+王巨仁	wang ju ren	1
+王浚楼船下益州	wang jun lou chuan xia yi zhou	1
+望君烟水阔	wang jun yan shui kuo	1
+望君犹伫立	wang jun you zhu li	1
+王揆	wang kui	1
+往来成古今	wang lai cheng gu jin	1
+王澜	wang lan	1
+王丽真	wang li zhen	1
+王良会	wang liang hui	1
+王良士	wang liang shi	1
+王镣	wang liao	1
+王令	wang ling	1
+王泠然	wang ling ran	1
+望龙山	wang long shan	1
+王鲁	wang lu	1
+王楙	wang mao	1
+望梅	wang mei	1
+望梅花	wang mei hua	1
+望美人兮天一方	wang mei ren xi tian yi fang	1
+汪梦斗	wang meng dou	1
+王梦应	wang meng ying	1
+王勔	wang mian	1
+罔民而可为也	wang min er ke wei ye	1
+王命释俘囚	wang ming shi fu qiu	1
+王母摘桃海上还	wang mu zhai tao hai shang hai	1
+忘年忘义	wang nian wang yi	1
+王雱	wang pang	1
+望蓬莱	wang peng lai	1
+王彭年	wang peng nian	1
+王平子	wang ping zi	1
+王淇	wang qi	1
+王起	wang qi	1
+忘其名	wang qi ming	1
+忘其身以及其亲	wang qi shen yi ji qi qin	1
+望秦川	wang qin chuan	1
+王请度之	wang qing du zhi	1
+王清惠	wang qing hui	1
+王请勿疑	wang qing wu yi	1
+王丘	wang qiu	1
+亡去不义	wang qu bu yi	1
+王仁裕	wang ren yu	1
+往日崎岖还记否	wang ri qi qu hai ji fou	1
+王镕	wang rong	1
+王如知此	wang ru zhi ci	1
+王若岩	wang ruo yan	1
+王僧孺	wang seng ru	1
+王善才	wang shan cai	1
+王赏	wang shang	1
+王邵	wang shao	1
+王绍宗	wang shao zong	1
+王沈	wang shen	1
+王诜	wang shen	1
+王谌	wang shen	1
+王识	wang shi	1
+王适	wang shi	1
+往世不可追也	wang shi bu ke zhui ye	1
+往时翰墨颇横流	wang shi han mo po heng liu	1
+王事靡盬	wang shi mi gu	1
+王氏女	wang shi nv	1
+往事千端	wang shi qian duan	1
+王室如毁	wang shi ru hui	1
+往事越千年	wang shi yue qian nian	1
+往时越千年	wang shi yue qian nian	1
+王枢	wang shu	1
+望书归	wang shu gui	1
+王苏苏	wang su su	1
+王孙归不归	wang sun gui bu gui	1
+王孙善保千金躯	wang sun shan bao qian jin qu	1
+王孙信	wang sun xin	1
+王铤	wang ting	1
+往往得神骨	wang wang de shen gu	1
+往往而是	wang wang er shi	1
+王往而征之	wang wang er zheng zhi	1
+往往有得	wang wang you de	1
+王洧	wang wei	1
+忘味如闻韶	wang wei ru wen shao	1
+忘我大德	wang wo da de	1
+忘我实多	wang wo shi duo	1
+王武陵	wang wu ling	1
+王武子	wang wu zi	1
+王无罪岁	wang wu zui sui	1
+王希羽	wang xi yu	1
+望仙楼	wang xian lou	1
+望仙楼上望君王	wang xian lou shang wang jun wang	1
+望仙门	wang xian men	1
+王仙仙	wang xian xian	1
+汪相如	wang xiang ru	1
+王孝严	wang xiao yan	1
+汪莘	wang xin	1
+王熊	wang xiong	1
+王涯	wang ya	1
+王偃	wang yan	1
+王喦	wang yan	1
+王彦威	wang yan wei	1
+望洋向若而叹曰	wang yang xiang ruo er tan yue	1
+王沂	wang yi	1
+王益柔	wang yi rou	1
+王逸少	wang yi shao	1
+王亿之	wang yi zhi	1
+王邕	wang yong	1
+忘忧碧叶齐	wang you bi ye qi	1
+王右军	wang you jun	1
+王幼玉	wang you yu	1
+王语暴以好乐	wang yu bao yi hao le	1
+王禹偁	wang yu chen	1
+王于兴师	wang yu xing shi	1
+王欲行之	wang yu xing zhi	1
+望远海	wang yuan hai	1
+望远行	wang yuan xing	1
+王约	wang yue	1
+王越宾	wang yue bin	1
+望月怀远	wang yue huai yuan	1
+王岳灵	wang yue ling	1
+王月山	wang yue shan	1
+望月有怀	wang yue you huai	1
+王云焕	wang yun huan	1
+王韫秀	wang yun xiu	1
+王瓒	wang zan	1
+王昭君二首	wang zhao jun er shou	1
+王贞白	wang zhen bai	1
+王正己	wang zheng ji	1
+望之不似人君	wang zhi bu si ren jun	1
+王之不王	wang zhi bu wang	1
+王之好乐甚	wang zhi hao le shen	1
+王之涣	wang zhi huan	1
+往之女家	wang zhi nv jia	1
+罔之生也	wang zhi sheng ye	1
+王之所大欲	wang zhi suo da yu	1
+王之望	wang zhi wang	1
+王智兴	wang zhi xing	1
+望之俨然	wang zhi yan ran	1
+王重	wang zhong	1
+王仲甫	wang zhong fu	1
+望终南山	wang zhong nan shan	1
+王仲舒	wang zhong shu	1
+王胄	wang zhou	1
+王祝	wang zhu	1
+汪晫	wang zhuo	1
+王濯	wang zhuo	1
+王子比干	wang zi bi gan	1
+王子皇孙	wang zi huang sun	1
+王子乔	wang zi qiao	1
+王子容	wang zi rong	1
+王自中	wang zi zhong	1
+汪遵	wang zun	1
+未谙姑食性	wei an gu shi xing	1
+韦安石	wei an shi	1
+为报行人休尽折	wei bao xing ren xiu jin zhe	1
+渭北春天树	wei bei chun tian shu	1
+位卑而言高	wei bei er yan gao	1
+位卑则足羞	wei bei ze zu xiu	1
+未必逢矰缴	wei bi feng zeng jiao	1
+韦冰	wei bing	1
+微步动云衣	wei bu dong yun yi	1
+为不用恩焉	wei bu yong en yan	1
+为不用力焉	wei bu yong li yan	1
+维参与昴	wei can yu mao	1
+为草当作兰	wei cao dang zuo lan	1
+惟草木之零落兮	wei cao mu zhi ling luo xi	1
+韦蟾	wei chan	1
+未尝饱也	wei chang bao ye	1
+未尝不始于是之	wei chang bu shi yu shi zhi	1
+未尝见全牛也	wei chang jian quan niu ye	1
+维常之华	wei chang zhi hua	1
+为臣不易	wei chen bu yi	1
+魏承班	wei cheng ban	1
+渭城朝雨邑轻尘	wei cheng chao yu yi qing chen	1
+韦承庆	wei cheng qing	1
+渭城曲	wei cheng qu	1
+为乘阳气行时令	wei cheng yang qi xing shi ling	1
+唯赤则非邦也与	wei chi ze fei bang ye yu	1
+韦处厚	wei chu hou	1
+渭川田家	wei chuan tian jia	1
+为此春酒	wei ci chun jiu	1
+为此诗者	wei ci shi zhe	1
+未达人气	wei da ren qi	1
+为大于其细	wei da yu qi xi	1
+韦丹	wei dan	1
+唯道集虚	wei dao ji xu	1
+未到江南先一笑	wei dao jiang nan xian yi xiao	1
+为道日损	wei dao ri sun	1
+惟道是从	wei dao shi cong	1
+为道者日损	wei dao zhe ri sun	1
+未得报恩不能归	wei de bao en bu neng gui	1
+未得国能	wei de guo neng	1
+未得与项羽相见	wei de yu xiang yu xiang jian	1
+未抵青袍送玉珂	wei di qing pao song yu ke	1
+为帝王师	wei di wang shi	1
+韦鼎	wei ding	1
+未睹斯民康	wei du si min kang	1
+为恶无近刑	wei e wu jin xing	1
+危而不持	wei er bu chi	1
+危而不扶	wei er bu fu	1
+威而不猛	wei er bu meng	1
+为而弗恃	wei er fu shi	1
+委而去之	wei er qu zhi	1
+为而三叹其一和	wei er san tan qi yi he	1
+尾犯	wei fan	1
+未妨惆怅是清狂	wei fang chou chang shi qing kuang	1
+魏风	wei feng	1
+微风吹兰杜	wei feng chui lan du	1
+微风拂晓	wei feng fu xiao	1
+维风及雨	wei feng ji yu	1
+微风惊暮坐	wei feng jing mu zuo	1
+为富不仁矣	wei fu bu ren yi	1
+魏夫人	wei fu ren	1
+为父为母	wei fu wei mu	1
+为感君王辗转思	wei gan jun wang zhan zhuan si	1
+惟庚寅吾以降	wei geng yin wu yi jiang	1
+为公子裳	wei gong zi shang	1
+危冠广袖楚宫妆	wei guan guang xiu chu gong zhuang	1
+为鬼为蜮	wei gui wei yu	1
+为国效命	wei guo xiao ming	1
+为国以礼	wei guo yi li	1
+韦洪	wei hong	1
+危乎高哉	wei hu gao zai	1
+惟恍惟惚	wei huang wei hu	1
+韦济	wei ji	1
+未几拂荆扉	wei ji fu jing fei	1
+为击破沛公军	wei ji po pei gong jun	1
+未嫁已倾城	wei jia yi qing cheng	1
+韦建	wei jian	1
+韦检	wei jian	1
+未见君子	wei jian jun zi	1
+唯见林花落	wei jian lin hua luo	1
+未见其止也	wei jian qi zhi ye	1
+唯将迟暮供多病	wei jiang chi mu gong duo bing	1
+惟江上之清风	wei jiang shang zhi qing feng	1
+惟将终夜长开眼	wei jiang zhong ye chang kai yan	1
+惟教宋玉擅才华	wei jiao song yu shan cai hua	1
+未解忆长安	wei jie yi chang an	1
+未解庄生天籁	wei jie zhuang sheng tian lai	1
+未尽善也	wei jin shan ye	1
+未就丹砂愧葛洪	wei jiu dan sha kui ge hong	1
+维鸠方之	wei jiu fang zhi	1
+维鸠居之	wei jiu ju zhi	1
+惟酒无量	wei jiu wu liang	1
+惟觉时之枕席	wei jue shi zhi zhen xi	1
+卫君待子而为政	wei jun dai zi er wei zheng	1
+为君零落为君开	wei jun ling luo wei jun kai	1
+为君起松声	wei jun qi song sheng	1
+为君一击	wei jun yi ji	1
+为君吟	wei jun yin	1
+为君之道	wei jun zhi dao	1
+微君之躬	wei jun zhi gong	1
+微君之故	wei jun zhi gu	1
+韦抗	wei kang	1
+未可与立	wei ke yu li	1
+未可与权	wei ke yu quan	1
+未可与适道	wei ke yu shi dao	1
+未可知也	wei ke zhi ye	1
+唯恐有闻	wei kong you wen	1
+谓孔子曰	wei kong zi yue	1
+为礼不敬	wei li bu jing	1
+为力不同科	wei li bu tong ke	1
+惟怜一灯影	wei lian yi deng ying	1
+卫灵公第十五	wei ling gong di shi wu	1
+渭流涨腻	wei liu zhang ni	1
+魏峦	wei luan	1
+尾闾泄之	wei lv xie zhi	1
+谓门弟子曰	wei men di zi yue	1
+唯梦闲人不梦君	wei meng xian ren bu meng jun	1
+未免捶楚尘埃间	wei mian chui chu chen ai jian	1
+微妙玄通	wei miao xuan tong	1
+为民立极	wei min li ji	1
+委命下吏	wei ming xia li	1
+唯命之从	wei ming zhi cong	1
+为木当作松	wei mu dang zuo song	1
+为难能也	wei nan neng ye	1
+未能事人	wei neng shi ren	1
+未能易其节	wei neng yi qi jie	1
+为女民兵题照	wei nv min bing ti zhao	1
+魏朋妻	wei peng qi	1
+帷飘白玉堂	wei piao bai yu tang	1
+帷屏宠爱空	wei ping chong ai kong	1
+魏朴	wei pu	1
+魏杞	wei qi	1
+谓其大夫曰	wei qi dai fu yue	1
+唯其疾之忧	wei qi ji zhi you	1
+谓其君不能者	wei qi jun bu neng zhe	1
+谓其人曰	wei qi ren yue	1
+危樯独夜舟	wei qiang du ye zhou	1
+为秦宫人	wei qin gong ren	1
+卫青不败由天幸	wei qing bu bai you tian xing	1
+唯求则非邦也与	wei qiu ze fei bang ye yu	1
+微躯此外更何求	wei qu ci wai geng he qiu	1
+维鹊有巢	wei que you chao	1
+为仁不富矣	wei ren bu fu yi	1
+为人臣者	wei ren chen zhe	1
+为人臣子者	wei ren chen zi zhe	1
+为人君者	wei ren jun zhe	1
+为人谋而不忠乎	wei ren mou er bu zhong hu	1
+为人性僻耽佳句	wei ren xing pi dan jia ju	1
+唯仁者能好人	wei ren zhe neng hao ren	1
+未入于室也	wei ru yu shi ye	1
+葳蕤自生光	wei rui zi sheng guang	1
+未若贫而乐	wei ruo pin er le	1
+为善无近名	wei shan wu jin ming	1
+为善最乐	wei shan zui le	1
+畏圣人之言	wei sheng ren zhi yan	1
+微生沾忌刻	wei sheng zhan ji ke	1
+韦式	wei shi	1
+微诗等瓦砾	wei shi deng wa li	1
+畏湿红莲衣	wei shi hong lian yi	1
+唯施是畏	wei shi shi wei	1
+惟士为能	wei shi wei neng	1
+维石岩岩	wei shi yan yan	1
+未始有物	wei shi you wu	1
+维士与女	wei shi yu nv	1
+为湿最高花	wei shi zui gao hua	1
+为寿而已矣	wei shou er yi yi	1
+未收天子河湟地	wei shou tian zi he huang di	1
+韦纾	wei shu	1
+韦述	wei shu	1
+为鼠常留饭	wei shu chang liu fan	1
+未数数然也	wei shu shu ran ye	1
+微霜凄凄簟色寒	wei shuang qi qi dian se han	1
+为谁安	wei shui an	1
+为谁成早秀	wei shui cheng zao xiu	1
+渭水东流去	wei shui dong liu qu	1
+为谁零落为谁开	wei shui ling luo wei shui kai	1
+渭水自萦秦塞曲	wei shui zi ying qin sai qu	1
+韦嗣立	wei si li	1
+唯天为大	wei tian wei da	1
+惟天为大	wei tian wei da	1
+为天下谷	wei tian xia gu	1
+为天下式	wei tian xia shi	1
+为天下溪	wei tian xia xi	1
+为天下笑者	wei tian xia xiao zhe	1
+畏涂巉岩不可攀	wei tu chan yan bu ke pan	1
+畏途巉岩不可攀	wei tu chan yan bu ke pan	1
+尉佗	wei tuo	1
+为王前驱	wei wang qian qu	1
+卫王氏	wei wang shi	1
+未闻好学者也	wei wen hao xue zhe ye	1
+为问何时猜得	wei wen he shi cai de	1
+为问门前客	wei wen men qian ke	1
+未闻弑君也	wei wen shi jun ye	1
+为问天戎窦车骑	wei wen tian rong dou che qi	1
+惟我独清	wei wo du qing	1
+畏我复却去	wei wo fu que qu	1
+卫我国权	wei wo guo quan	1
+为我开天关	wei wo kai tian guan	1
+为我们的	wei wo men de	1
+为我书斯文	wei wo shu si wen	1
+帷幄未改神惨伤	wei wo wei gai shen can shang	1
+微我无酒	wei wo wu jiu	1
+为我一挥手	wei wo yi hui shou	1
+为我沾衣	wei wo zhan yi	1
+魏武挥鞭	wei wu hui bian	1
+为吾有身	wei wu you shen	1
+韦夏卿	wei xia qing	1
+韦骧	wei xiang	1
+谓行多露	wei xing duo lu	1
+危行言孙	wei xing yan sun	1
+维熊维罴	wei xiong wei pi	1
+为修而已矣	wei xiu er yi yi	1
+未休关西卒	wei xiu guan xi zu	1
+为学当如流水	wei xue dang ru liu shui	1
+为言地尽天还尽	wei yan di jin tian hai jin	1
+谓言挂席度沧海	wei yan gua xi du cang hai	1
+谓言秋霜落	wei yan qiu shuang luo	1
+危言危行	wei yan wei xing	1
+谓言无罪过	wei yan wu zui guo	1
+渭阳	wei yang	1
+未央前殿月轮高	wei yang qian dian yue lun gao	1
+微阳下楚丘	wei yang xia chu qiu	1
+维扬忆旧游	wei yang yi jiu you	1
+为妖为孽	wei yao wei nie	1
+唯尧则之	wei yao ze zhi	1
+卫叶	wei ye	1
+维叶莫莫	wei ye mo mo	1
+维叶萋萋	wei ye qi qi	1
+维以不永怀	wei yi bu yong huai	1
+威仪棣棣	wei yi di di	1
+薇亦刚止	wei yi gang zhi	1
+薇亦柔止	wei yi rou zhi	1
+惟义所在	wei yi suo zai	1
+猥以微贱	wei yi wei jian	1
+委蛇委蛇	wei yi wei yi	1
+薇亦作止	wei yi zuo zhi	1
+微吟罢	wei yin ba	1
+为营步步嗟何及	wei ying bu bu jie he ji	1
+唯有德者能之	wei you de zhe neng zhi	1
+未有封侯之赏	wei you feng hou zhi shang	1
+惟有风入松	wei you feng ru song	1
+未有涓埃答圣朝	wei you juan ai da sheng chao	1
+惟有清风闲	wei you qing feng xian	1
+未有人知	wei you ren zhi	1
+未有天地	wei you tian di	1
+为有牺牲多壮志	wei you xi sheng duo zhuang zhi	1
+唯有相思似春色	wei you xiang si si chun se	1
+魏有信陵	wei you xin ling	1
+惟有饮者留其名	wei you yin zhe liu qi ming	1
+惟有幽人自来去	wei you you ren zi lai qu	1
+为有云屏无限娇	wei you yun ping wu xian jiao	1
+未有直生枝	wei you zhi sheng zhi	1
+微雨霭芳原	wei yu ai fang yuan	1
+谓予不信	wei yu bu xin	1
+微雨过	wei yu guo	1
+未语可知心	wei yu ke zhi xin	1
+惟馀莽莽	wei yu mang mang	1
+微雨众卉新	wei yu zhong hui xin	1
+惟馀钟磬音	wei yu zhong qing yin	1
+韦元旦	wei yuan dan	1
+唯愿当歌对酒时	wei yuan dang ge dui jiu shi	1
+韦元甫	wei yuan fu	1
+惟愿孩儿愚且鲁	wei yuan hai er yu qie lu	1
+魏元忠	wei yuan zhong	1
+微云淡河汉	wei yun dan he han	1
+未云何龙	wei yun he long	1
+为者败之	wei zhe bai zhi	1
+威振四海	wei zhen si hai	1
+味之不尽	wei zhi bu jin	1
+谓之才	wei zhi cai	1
+为之踌躇满志	wei zhi chou chu man zhi	1
+谓之倒置之民	wei zhi dao zhi zhi min	1
+未至二三里	wei zhi er san li	1
+为治而已矣	wei zhi er yi yi	1
+魏知古	wei zhi gu	1
+谓之何哉	wei zhi he zai	1
+谓之后洞	wei zhi hou dong	1
+为之奈何	wei zhi nai he	1
+未之能行	wei zhi neng xing	1
+唯止能止众止	wei zhi neng zhi zhong zhi	1
+谓之仁	wei zhi ren	1
+谓之人乐	wei zhi ren le	1
+未之思也	wei zhi si ye	1
+谓之天子	wei zhi tian zi	1
+谓之文	wei zhi wen	1
+谓之心	wei zhi xin	1
+谓之学	wei zhi xue	1
+未之学也	wei zhi xue ye	1
+唯之与阿	wei zhi yu a	1
+为之于未有	wei zhi yu wei you	1
+谓之真人	wei zhi zhen ren	1
+韦执中	wei zhi zhong	1
+维舟绿杨岸	wei zhou lv yang an	1
+微注小窗明	wei zhu xiao chuang ming	1
+韦庄	wei zhuang	1
+畏子不敢	wei zi bu gan	1
+微子第十八	wei zi di shi ba	1
+魏子敬	wei zi jing	1
+微子去之	wei zi qu zhi	1
+维子之故	wei zi zhi gu	1
+未足与议也	wei zu yu yi ye	1
+文丙	wen bing	1
+文不在兹乎	wen bu zai zi hu	1
+文采风流今尚存	wen cai feng liu jin shang cun	1
+问苍茫大地	wen cang mang da di	1
+闻蝉但益悲	wen chan dan yi bei	1
+问答乃未已	wen da nai wei yi	1
+文道当大行	wen dao dang da xing	1
+问道归凤翔	wen dao gui feng xiang	1
+闻道黄龙戍	wen dao huang long shu	1
+闻道神仙不可接	wen dao shen xian bu ke jie	1
+闻道欲来相问讯	wen dao yu lai xiang wen xun	1
+闻道玉门犹被遮	wen dao yu men you bei zhe	1
+文风盛	wen feng sheng	1
+闻风坐相悦	wen feng zuo xiang yue	1
+闻歌始觉有人来	wen ge shi jue you ren lai	1
+文鉴	wen jian	1
+文珏	wen jue	1
+问君何事轻离别	wen jun he shi qing li bie	1
+问君何所之	wen jun he suo zhi	1
+问君西游何时还	wen jun xi you he shi hai	1
+问客何为来	wen ke he wei lai	1
+闻乐不乐	wen le bu le	1
+问李云	wen li yun	1
+问其人	wen qi ren	1
+文窃四海声	wen qie si hai sheng	1
+问人于他邦	wen ren yu ta bang	1
+文胜质则史	wen sheng zhi ze shi	1
+文史星历	wen shi xing li	1
+汶水滔滔	wen shui tao tao	1
+闻说梅花早	wen shuo mei hua zao	1
+闻斯二者	wen si er zhe	1
+闻斯行之	wen si xing zhi	1
+闻斯行诸	wen si xing zhu	1
+温汤对雪	wen tang dui xue	1
+问天天不应	wen tian tian bu ying	1
+温庭皓	wen ting hao	1
+文王既没	wen wang ji mei	1
+文王之囿	wen wang zhi you	1
+温王重茂	wen wang zhong mao	1
+温温恭人	wen wen gong ren	1
+文翁翻教授	wen weng fan jiao shou	1
+问我来何方	wen wo lai he fang	1
+文武并用	wen wu bing yong	1
+文武衣冠异昔时	wen wu yi guan yi xi shi	1
+闻吾子达于至道	wen wu zi da yu zhi dao	1
+温宪	wen xian	1
+文献不足故也	wen xian bu zu gu ye	1
+闻弦歌之声	wen xian ge zhi sheng	1
+文行忠信	wen xing zhong xin	1
+问讯吴刚何所有	wen xun wu gang he suo you	1
+文偃	wen yan	1
+文益	wen yi	1
+闻义不能徙	wen yi bu neng xi	1
+问一得三	wen yi de san	1
+揾英雄泪	wen ying xiong lei	1
+闻余大言皆冷笑	wen yu da yan jie leng xiao	1
+问余何意栖碧山	wen yu he yi qi bi shan	1
+问于桀溺	wen yu jie ni	1
+问与孔子	wen yu kong zi	1
+文章千古事	wen zhang qian gu shi	1
+文章憎命达	wen zhang zeng ming da	1
+文质彬彬	wen zhi bin bin	1
+问舟子	wen zhou zi	1
+闻诛一夫纣矣	wen zhu yi fu zhou yi	1
+翁定	weng ding	1
+翁合	weng he	1
+翁宏	weng hong	1
+翁绶	weng shou	1
+翁洮	weng tao	1
+嗡嗡叫	weng weng jiao	1
+瓮牖绳枢之子	weng you sheng shu zhi zi	1
+翁元龙	weng yuan long	1
+我爱其礼	wo ai qi li	1
+我爱夏日长	wo ai xia ri chang	1
+我被聪明误一生	wo bei cong ming wu yi sheng	1
+我辈复登临	wo bei fu deng lin	1
+我辈岂是蓬蒿人	wo bei qi shi peng hao ren	1
+我本不弃世	wo ben bu qi shi	1
+我本楚狂人	wo ben chu kuang ren	1
+我本汉家子	wo ben han jia zi	1
+我车既攻	wo che ji gong	1
+我持长瓢坐巴丘	wo chi chang piao zuo ba qiu	1
+我出我车	wo chu wo che	1
+我粢既洁	wo ci ji jie	1
+我从南方来	wo cong nan fang lai	1
+我徂东山	wo cu dong shan	1
+我待贾者也	wo dai jia zhe ye	1
+我东曰归	wo dong yue gui	1
+我独泊兮	wo du bo xi	1
+我独不得出	wo du bu de chu	1
+我独昏昏	wo du hun hun	1
+我独闷闷	wo du men men	1
+我独南行	wo du nan xing	1
+我读万卷书	wo du wan juan shu	1
+我独异于人	wo du yi yu ren	1
+我非生而知之者	wo fei sheng er zhi zhi zhe	1
+我歌今与君殊科	wo ge jin yu jun shu ke	1
+我歌且谣	wo ge qie yao	1
+我姑酌彼兕觥	wo gu zhuo bi si gong	1
+我行不来	wo hang bu lai	1
+我行其野	wo hang qi ye	1
+我行殊未已	wo hang shu wei yi	1
+卧后清宵细细长	wo hou qing xiao xi xi chang	1
+我家在山西	wo jia zai shan xi	1
+我将得邑金	wo jiang de yi jin	1
+我今停杯一问之	wo jin ting bei yi wen zhi	1
+我居北海君南海	wo ju bei hai jun nan hai	1
+我决起而飞	wo jue qi er fei	1
+我觉秋兴逸	wo jue qiu xing yi	1
+卧看满天云不动	wo kan man tian yun bu dong	1
+我来竟何事	wo lai jing he shi	1
+我来自东	wo lai zi dong	1
+卧龙跃马终黄土	wo long yue ma zhong huang tu	1
+我马白	wo ma bai	1
+我马虺隤	wo ma hui tui	1
+我马瘏矣	wo ma tu yi	1
+我马玄黄	wo ma xuan huang	1
+我们参照了	wo men can zhao le	1
+我命绝今日	wo ming jue jin ri	1
+我仆痡矣	wo pu pu yi	1
+我善治马	wo shan zhi ma	1
+我善治木	wo shan zhi mu	1
+我生不有命	wo sheng bu you ming	1
+我生之初	wo sheng zhi chu	1
+我生之后	wo sheng zhi hou	1
+我诗多是别君词	wo shi duo shi bie jun ci	1
+我失骄杨君失柳	wo shi jiao yang jun shi liu	1
+我是梦中传彩笔	wo shi meng zhong chuan cai bi	1
+我世世为洴澼絖	wo shi shi wei ping pi kuang	1
+我是朱陈旧使君	wo shi zhu chen jiu shi jun	1
+我戍未定	wo shu wei ding	1
+我书意造本无法	wo shu yi zao ben wu fa	1
+我思不远	wo si bu yuan	1
+我思古人	wo si gu ren	1
+我四十不动心	wo si shi bu dong xin	1
+我思仙人	wo si xian ren	1
+我宿黄山碧溪月	wo su huang shan bi xi yue	1
+我虽不敏	wo sui bu min	1
+卧藤萝下	wo teng luo xia	1
+我腾跃而上	wo teng yue er shang	1
+卧听南宫清漏长	wo ting nan gong qing lou chang	1
+我未见好仁者	wo wei jian hao ren zhe	1
+我未见力不足者	wo wei jian li bu zu zhe	1
+我为鱼肉	wo wei yu rou	1
+我未之见也	wo wei zhi jian ye	1
+卧闻点滴如秋雨	wo wen dian di ru qiu yu	1
+卧闻海棠花	wo wen hai tang hua	1
+我无令人	wo wu ling ren	1
+我无能焉	wo wu neng yan	1
+我无是也	wo wu shi ye	1
+我无为	wo wu wei	1
+我武惟扬	wo wu wei yang	1
+我舞影凌乱	wo wu ying ling luan	1
+我昔钓白龙	wo xi diao bai long	1
+我昔东海上	wo xi dong hai shang	1
+我心匪鉴	wo xin fei jian	1
+我心匪席	wo xin fei xi	1
+我心悄悄	wo xin qiao qiao	1
+我心伤悲	wo xin shang bei	1
+我心素已闲	wo xin su yi xian	1
+我心西悲	wo xin xi bei	1
+我心忧伤	wo xin you shang	1
+我心悠悠	wo xin you you	1
+我心则降	wo xin ze jiang	1
+我心则喜	wo xin ze xi	1
+我心则夷	wo xin ze yi	1
+我亦教之	wo yi jiao zhi	1
+我亦举家清	wo yi ju jia qing	1
+我亦人也	wo yi ren ye	1
+我以为君	wo yi wei jun	1
+我以为兄	wo yi wei xiong	1
+我以吾仁	wo yi wu ren	1
+我亦无所求	wo yi wu suo qiu	1
+我有亲父母	wo you qin fu mu	1
+我有亲父兄	wo you qin fu xiong	1
+我有三宝	wo you san bao	1
+我有旨蓄	wo you zhi xu	1
+我欲一挥手	wo yu yi hui shou	1
+我欲因之梦寥廓	wo yu yin zhi meng liao kuo	1
+我欲因之梦吴越	wo yu yin zhi meng wu yue	1
+我欲与君相知	wo yu yu jun xiang zhi	1
+我欲醉眠芳草	wo yu zui mian fang cao	1
+我愿天公怜赤子	wo yuan tian gong lian chi zi	1
+我在路中央	wo zai lu zhong yang	1
+我早生华发	wo zao sheng hua fa	1
+我瞻四方	wo zhan si fang	1
+我丈夫也	wo zhang fu ye	1
+我之不贤与	wo zhi bu xian yu	1
+我之大贤与	wo zhi da xian yu	1
+我之怀矣	wo zhi huai yi	1
+我之谓也	wo zhi wei ye	1
+我知之濠上也	wo zhi zhi hao shang ye	1
+我朱孔阳	wo zhu kong yang	1
+我自岿然不动	wo zi kui ran bu dong	1
+我醉君复乐	wo zui jun fu le	1
+我醉欲眠卿且去	wo zui yu mian qing qie qu	1
+吾爱孟夫子	wu ai meng fu zi	1
+吾爱汝至	wu ai ru zhi	1
+武安君何在	wu an jun he zai	1
+无暴其气	wu bao qi qi	1
+吾必谓之学矣	wu bi wei zhi xue yi	1
+伍彬	wu bin	1
+无不成也	wu bu cheng ye	1
+吾不得而见之矣	wu bu de er jian zhi yi	1
+吾不复梦见周公	wu bu fu meng jian zhou gong	1
+吾不忍其觳觫	wu bu ren qi hu su	1
+吾不如老农	wu bu ru lao nong	1
+吾不如老圃	wu bu ru lao pu	1
+无不忘也	wu bu wang ye	1
+无不为已	wu bu wei yi	1
+吾不信也	wu bu xin ye	1
+五步一楼	wu bu yi lou	1
+无不迎也	wu bu ying ye	1
+无不有也	wu bu you ye	1
+吾不欲观之矣	wu bu yu guan zhi yi	1
+吾不与祭	wu bu yu ji	1
+吾不与也	wu bu yu ye	1
+吾不知其美也	wu bu zhi qi mei ye	1
+吾不知其名	wu bu zhi qi ming	1
+吾不知之矣	wu bu zhi zhi yi	1
+吴彩鸾	wu cai luan	1
+无才日衰老	wu cai ri shuai lao	1
+无恻隐之心	wu ce yin zhi xin	1
+吾尝跂而望矣	wu chang qi er wang yi	1
+吾尝终日不食	wu chang zhong ri bu shi	1
+吾尝终日而思矣	wu chang zhong ri er si yi	1
+五城十二楼	wu cheng shi er lou	1
+无愁可解	wu chou ke jie	1
+无处避螳螂	wu chu bi tang lang	1
+无处问	wu chu wen	1
+吴船录	wu chuan lu	1
+无传其溢言	wu chuan qi yi yan	1
+舞春风	wu chun feng	1
+无辞让之心	wu ci rang zhi xin	1
+吾从而师之	wu cong er shi zhi	1
+毋从俱死也	wu cong ju si ye	1
+无村眺望赊	wu cun tiao wang she	1
+吾党二三子	wu dang er san zi	1
+吾党有直躬者	wu dang you zhi gong zhe	1
+吾党之小子狂简	wu dang zhi xiao zi kuang jian	1
+吾道一以贯之	wu dao yi yi guan zhi	1
+无道则隐	wu dao ze yin	1
+吾得而食诸	wu de er shi zhu	1
+无得而逾焉	wu de er yu yan	1
+吾得兄事之	wu de xiong shi zhi	1
+吴德远	wu de yuan	1
+武帝祠前云欲散	wu di ci qian yun yu san	1
+屋底达官走避胡	wu di da guan zou bi hu	1
+五帝三皇神圣事	wu di san huang shen sheng shi	1
+五帝之所连	wu di zhi suo lian	1
+悟定是吾身	wu ding shi wu shen	1
+无东无西	wu dong wu xi	1
+无冬无夏	wu dong wu xia	1
+吾读	wu du	1
+吾独向黄泉	wu du xiang huang quan	1
+无端散出一天愁	wu duan san chu yi tian chou	1
+无端听画角	wu duan ting hua jiao	1
+无对应的	wu dui ying de	1
+物而不物	wu er bu wu	1
+无非积德	wu fei ji de	1
+无风起浪	wu feng qi lang	1
+无风云出塞	wu feng yun chu sai	1
+无父何怙	wu fu he hu	1
+无复鸡人报晓筹	wu fu ji ren bao xiao chou	1
+五福降中天	wu fu jiang zhong tian	1
+无复射蛟江水中	wu fu she jiao jiang shui zhong	1
+吴感	wu gan	1
+无感我帨兮	wu gan wo shui xi	1
+吴刚捧出桂花酒	wu gang peng chu gui hua jiu	1
+五歌	wu ge	1
+物各有主	wu ge you zhu	1
+五更鼓角声悲壮	wu geng gu jiao sheng bei zhuang	1
+五更疏欲断	wu geng shu yu duan	1
+五更转	wu geng zhuan	1
+吴巩	wu gong	1
+吴宫花草埋幽径	wu gong hua cao mai you jing	1
+无功名而治	wu gong ming er zhi	1
+无攻人之恶	wu gong ren zhi e	1
+五供养	wu gong yang	1
+吴钩霜雪明	wu gou shuang xue ming	1
+五谷不分	wu gu bu fen	1
+无古无今	wu gu wu jin	1
+物固有所可	wu gu you suo ke	1
+物固有所然	wu gu you suo ran	1
+无官一身轻	wu guan yi shen qing	1
+无贵无贱	wu gui wu jian	1
+吾何爱一牛	wu he ai yi niu	1
+吾何以观之哉	wu he yi guan zhi zai	1
+无恒安息	wu heng an xi	1
+无恒产者无恒心	wu heng chan zhe wu heng xin	1
+五侯七贵同杯酒	wu hou qi gui tong bei jiu	1
+呜呼圣皇及圣相	wu hu sheng huang ji sheng xiang	1
+呜呼呜呼	wu hu wu hu	1
+呜呼吾意其蹉跎	wu hu wu yi qi cuo tuo	1
+五湖烟水独忘机	wu hu yan shui du wang ji	1
+五花连钱旋作冰	wu hua lian qian xuan zuo bing	1
+五花马	wu hua ma	1
+五花马千金裘	wu hua ma qian jin qiu	1
+吾华肇造	wu hua zhao zao	1
+无花只有寒	wu hua zhi you han	1
+物换星移几度秋	wu huan xing yi ji du qiu	1
+吴晃	wu huang	1
+武皇开边意未已	wu huang kai bian yi wei yi	1
+物或恶之	wu huo e zhi	1
+吴激	wu ji	1
+无几无时	wu ji wu shi	1
+吴姬压酒唤客尝	wu ji ya jiu huan ke chang	1
+无极之外	wu ji zhi wai	1
+吴季子	wu ji zi	1
+吾家读书久不效	wu jia du shu jiu bu xiao	1
+误佳期	wu jia qi	1
+无家问死生	wu jia wen si sheng	1
+无家与寄衣	wu jia yu ji yi	1
+吾见其不得已	wu jian qi bu de yi	1
+吾见其进也	wu jian qi jin ye	1
+吾见其难为	wu jian qi nan wei	1
+吾见其人矣	wu jian qi ren yi	1
+勿剪勿伐	wu jian wu fa	1
+无见小利	wu jian xiao li	1
+无江海而闲	wu jiang hai er xian	1
+乌江十五兄	wu jiang shi wu xiong	1
+吾将仕矣	wu jiang shi yi	1
+吾将为宾乎	wu jiang wei bin hu	1
+吾将为名乎	wu jiang wei ming hu	1
+吾将曳尾于涂中	wu jiang ye wei yu tu zhong	1
+吾今且报府	wu jin qie bao fu	1
+吾今且赴府	wu jin qie fu fu	1
+五茎	wu jing	1
+吴兢	wu jing	1
+无君于上	wu jun yu shang	1
+吴康	wu kang	1
+无可无不可	wu ke wu bu ke	1
+吾恐季孙之忧	wu kong ji sun zhi you	1
+无苦亦无乐	wu ku yi wu le	1
+无窥其情	wu kui qi qing	1
+无礼无义	wu li wu yi	1
+五里一徘徊	wu li yi pai huai	1
+五里一扬鞭	wu li yi yang bian	1
+吾力足以举百钧	wu li zu yi ju bai jun	1
+武林春	wu lin chun	1
+五陵北原上	wu ling bei yuan shang	1
+五陵佳气无时无	wu ling jia qi wu shi wu	1
+五岭皆炎热	wu ling jie yan re	1
+五陵年少金市东	wu ling nian shao jin shi dong	1
+吾令人望其气	wu ling ren wang qi qi	1
+五岭逶迤腾巨浪	wu ling wei yi teng ju lang	1
+五岭逶迤腾细浪	wu ling wei yi teng xi lang	1
+五陵衣马自轻肥	wu ling yi ma zi qing fei	1
+无漏子	wu lou zi	1
+舞罗衣	wu luo yi	1
+舞马词	wu ma ci	1
+五马莫留连	wu ma mo liu lian	1
+五马如飞龙	wu ma ru fei long	1
+吴迈远	wu mai yuan	1
+雾满龙冈千嶂暗	wu man long gang qian zhang an	1
+无寐	wu mei	1
+寤寐无为	wu mei wu wei	1
+无闷	wu men	1
+无门无毒	wu men wu du	1
+无梦令	wu meng ling	1
+乌蒙磅礴走泥丸	wu meng pang bo zou ni wan	1
+吴秘	wu mi	1
+无灭无生	wu mie wu sheng	1
+吴敏德	wu min de	1
+务民之义	wu min zhi yi	1
+无名鬼	wu ming gui	1
+无名女鬼	wu ming nv gui	1
+无名天地之始	wu ming tian di zhi shi	1
+无名无实	wu ming wu shi	1
+物莫之伤	wu mo zhi shang	1
+吾谋适不用	wu mou shi bu yong	1
+无母何恃	wu mu he shi	1
+五亩之宅	wu mu zhi zhai	1
+无南无北	wu na mo bei	1
+无奈朝来寒雨	wu nai chao lai han yu	1
+无乃尔是过与	wu nai er shi guo yu	1
+无乃为佞乎	wu nai wei ning hu	1
+无奈夜长人不寐	wu nai ye chang ren bu mei	1
+无内无外	wu nei wu wai	1
+毋内诸侯	wu nei zhu hou	1
+五年江上损容颜	wu nian jiang shang sun rong yan	1
+乌鸟私情	wu niao si qing	1
+吾宁爱与憎	wu ning ai yu zeng	1
+吴牛喘月时	wu niu chuan yue shi	1
+五拍	wu pai	1
+误攀织女机	wu pan zhi nv ji	1
+武平一	wu ping yi	1
+舞破中原始下来	wu po zhong yuan shi xia lai	1
+无弃	wu qi	1
+无弃尔辅	wu qi er fu	1
+吾妻归宁	wu qi gui ning	1
+吾妻来归	wu qi lai gui	1
+乌栖曲	wu qi qu	1
+吾其为东周乎	wu qi wei dong zhou hu	1
+吾其与闻之	wu qi yu wen zhi	1
+吴潜	wu qian	1
+吴黔	wu qian	1
+悟清	wu qing	1
+无情送潮归	wu qing song chao gui	1
+无穷无止	wu qiong wu zhi	1
+无求备于一人	wu qiu bei yu yi ren	1
+无求生以害仁	wu qiu sheng yi hai ren	1
+无拳无勇	wu quan wu yong	1
+无人处	wu ren chu	1
+无人收废帐	wu ren shou fei zhang	1
+无人收拾理则那	wu ren shou shi li ze na	1
+无人送酒来	wu ren song jiu lai	1
+无人信高洁	wu ren xin gao jie	1
+无仁义而修	wu ren yi er xiu	1
+无人与我长生术	wu ren yu wo chang sheng shu	1
+无人争晓渡	wu ren zheng xiao du	1
+无人之情	wu ren zhi qing	1
+无人知所去	wu ren zhi suo qu	1
+无日不悠悠	wu ri bu you you	1
+五日画一石	wu ri hua yi dan	1
+吾日三省乎吾身	wu ri san xing hu wu shen	1
+吴融	wu rong	1
+无容质疑	wu rong zhi yi	1
+无肉令人瘦	wu rou ling ren shou	1
+无如醉中真	wu ru zui zhong zhen	1
+五色令人目盲	wu se ling ren mu mang	1
+巫山神女	wu shan shen nv	1
+巫山十二峰	wu shan shi er feng	1
+巫山巫峡气萧森	wu shan wu xia qi xiao sen	1
+巫山一段云	wu shan yi duan yun	1
+巫山一片云	wu shan yi pian yun	1
+巫山云雨飞	wu shan yun yu fei	1
+无伤吾行	wu shang wu xing	1
+无伤吾足	wu shang wu zu	1
+吴少微	wu shao wei	1
+侮圣人之言	wu sheng ren zhi yan	1
+吾生亦有涯	wu sheng yi you ya	1
+无声之中	wu sheng zhi zhong	1
+无事不可言	wu shi bu ke yan	1
+五世而斩	wu shi er zhan	1
+五十而知天命	wu shi er zhi tian ming	1
+无是非之心	wu shi fei zhi xin	1
+无使蛟龙得	wu shi jiao long de	1
+无使尨也吠	wu shi mang ye fei	1
+吴师孟	wu shi meng	1
+五十年间似反掌	wu shi nian jian si fan zhang	1
+无食桑葚	wu shi sang shen	1
+吾失我常与	wu shi wo chang yu	1
+无食我麦	wu shi wo mai	1
+无食我苗	wu shi wo miao	1
+无食我黍	wu shi wo shu	1
+无食无儿一妇人	wu shi wu er yi fu ren	1
+无视无听	wu shi wu ting	1
+无始无终	wu shi wu zhong	1
+五世希不失矣	wu shi xi bu shi yi	1
+勿使燕然上	wu shi yan ran shang	1
+吴十一	wu shi yi	1
+五十以学易	wu shi yi xue yi	1
+吾是以忧	wu shi yi you	1
+五十知天命	wu shi zhi tian ming	1
+五首	wu shou	1
+吴叔	wu shu	1
+吴淑姬	wu shu ji	1
+吾属今为之虏矣	wu shu jin wei zhi lu yi	1
+无数铃声遥过碛	wu shu ling sheng yao guo qi	1
+吴淑真	wu shu zhen	1
+吾衰竟谁陈	wu shuai jing shui chen	1
+无思不服	wu si bu fu	1
+无思远人	wu si yuan ren	1
+吾斯之未能信	wu si zhi wei neng xin	1
+无俗念	wu su nian	1
+乌孙部落家乡远	wu sun bu luo jia xiang yuan	1
+乌孙归去不称王	wu sun gui qu bu cheng wang	1
+无所不极	wu suo bu ji	1
+无所不在	wu suo bu zai	1
+无所祷也	wu suo dao ye	1
+无所苟而已矣	wu suo gou er yi yi	1
+无所可用	wu suo ke yong	1
+无所求心普空寂	wu suo qiu xin pu kong ji	1
+无所取材	wu suo qu cai	1
+吾所以有大患者	wu suo yi you da huan zhe	1
+无所用心	wu suo yong xin	1
+物态本闲暇	wu tai ben xian xia	1
+伍唐	wu tang	1
+误桃源	wu tao yuan	1
+无题二首	wu ti er shou	1
+无题二首之二	wu ti er shou zhi er	1
+无题二首之一	wu ti er shou zhi yi	1
+无题四首	wu ti si shou	1
+乌啼隐杨花	wu ti yin yang hua	1
+无田甫田	wu tian fu tian	1
+梧桐儿	wu tong er	1
+梧桐树	wu tong shu	1
+梧桐相待老	wu tong xiang dai lao	1
+梧桐影	wu tong ying	1
+无万分之一	wu wan fen zhi yi	1
+吴王使之将	wu wang shi zhi jiang	1
+吾王之好鼓乐	wu wang zhi hao gu yue	1
+吾王之好田猎	wu wang zhi hao tian lie	1
+五微	wu wei	1
+五未	wu wei	1
+吾未尝无诲焉	wu wei chang wu hui yan	1
+无为而无不为	wu wei er wu bu wei	1
+无为而已矣	wu wei er yi yi	1
+无为而治者	wu wei er zhi zhe	1
+吾未见刚者	wu wei jian gang zhe	1
+吾未见其明也	wu wei jian qi ming ye	1
+勿违今日言	wu wei jin ri yan	1
+五味令人口爽	wu wei ling ren kou shuang	1
+无为名尸	wu wei ming shi	1
+无为谋府	wu wei mou fu	1
+无为强亲疏	wu wei qiang qin shu	1
+无为事任	wu wei shi ren	1
+误为微物迁	wu wei wei wu qian	1
+无为无形	wu wei wu xing	1
+无为小人儒	wu wei xiao ren ru	1
+勿为醒者传	wu wei xing zhe chuan	1
+吴伟业	wu wei ye	1
+无为在岐路	wu wei zai qi lu	1
+物谓之而然	wu wei zhi er ran	1
+吾未之闻也	wu wei zhi wen ye	1
+无为之益	wu wei zhi yi	1
+勿谓知音稀	wu wei zhi yin xi	1
+无为知主	wu wei zhi zhu	1
+无为中有为	wu wei zhong you wei	1
+吾闻楚有神龟	wu wen chu you shen gui	1
+无问其名	wu wen qi ming	1
+吾闻其语矣	wu wen qi yu yi	1
+吴文若	wu wen ruo	1
+吾闻上帝心	wu wen shang di xin	1
+吾问无为谓	wu wen wu wei wei	1
+吾闻之也	wu wen zhi ye	1
+吾闻诸夫子	wu wen zhu fu zi	1
+五物	wu wu	1
+无物不可	wu wu bu ke	1
+无物不然	wu wu bu ran	1
+物物而不物于物	wu wu er bu wu yu wu	1
+物无非彼	wu wu fei bi	1
+物无非是	wu wu fei shi	1
+物无贵贱	wu wu gui jian	1
+吾无间然矣	wu wu jian ran yi	1
+无物结同心	wu wu jie tong xin	1
+吴武陵	wu wu ling	1
+吾无以为质矣	wu wu yi wei zhi yi	1
+毋吾以也	wu wu yi ye	1
+吾无隐乎尔	wu wu yin hu er	1
+物物者非物	wu wu zhe fei wu	1
+无物之象	wu wu zhi xiang	1
+无锡景	wu xi jing	1
+五溪衣服共云山	wu xi yi fu gong yun shan	1
+巫峡啼猿数行泪	wu xia ti yuan shu hang lei	1
+无限风光在险峰	wu xian feng guang zai xian feng	1
+吾心不忍	wu xin bu ren	1
+无心可猜	wu xin ke cai	1
+吾心甚慰	wu xin shen wei	1
+无羞恶之心	wu xiu wu zhi xin	1
+无须伤感	wu xu shang gan	1
+寤言不寐	wu yan bu mei	1
+五言绝句	wu yan jue ju	1
+五言乐府	wu yan yue fu	1
+无羊	wu yang	1
+舞杨花	wu yang hua	1
+舞腰	wu yao	1
+无夜不相思	wu ye bu xiang si	1
+梧叶儿	wu ye er	1
+吴亿	wu yi	1
+吴益	wu yi	1
+无意不可入	wu yi bu ke ru	1
+无以成江海	wu yi cheng jiang hai	1
+吾意独怜才	wu yi du lian cai	1
+无以故灭命	wu yi gu mie ming	1
+吾以观复	wu yi guan fu	1
+无以立也	wu yi li ye	1
+乌衣门第	wu yi men di	1
+无以命之	wu yi ming zhi	1
+无以人灭天	wu yi ren mie tian	1
+无以汝色骄人哉	wu yi ru se jiao ren zai	1
+吾亦善之	wu yi shan zhi	1
+无遗身殃	wu yi shen yang	1
+吾已失恩义	wu yi shi en yi	1
+无以万方	wu yi wan fang	1
+无以为君子	wu yi wei jun zi	1
+无以为也	wu yi wei ye	1
+无衣无褐	wu yi wu he	1
+无以下体	wu yi xia ti	1
+吾亦信之	wu yi xin zhi	1
+吾已矣夫	wu yi yi fu	1
+无以异也	wu yi yi ye	1
+吾亦欲无加诸人	wu yi yu wu jia zhu ren	1
+无以至今日	wu yi zhi jin ri	1
+无以知人也	wu yi zhi ren ye	1
+无以终余年	wu yi zhong yu nian	1
+吾以子为异之问	wu yi zi wei yi zhi wen	1
+五音令人耳聋	wu yin ling ren er long	1
+吴隐之	wu yin zhi	1
+吴泳	wu yong	1
+无友不如己者	wu you bu ru ji zhe	1
+毋友不如己者	wu you bu ru ji zhe	1
+吾犹不足	wu you bu zu	1
+无由达江浒	wu you da jiang hu	1
+吾有大树	wu you da shu	1
+吾又何患	wu you he huan	1
+舞幽壑之潜蛟	wu you he zhi qian jiao	1
+吾犹人也	wu you ren ye	1
+无有入无间	wu you ru wu jian	1
+物有死生	wu you si sheng	1
+无有无名	wu you wu ming	1
+吾友张也	wu you zhang ye	1
+吾有知乎哉	wu you zhi hu zai	1
+吾与回言终日	wu yu hui yan zhong ri	1
+无与士耽	wu yu shi dan	1
+无逾我里	wu yu wo li	1
+无逾我墙	wu yu wo qiang	1
+吾欲云云	wu yu yun yun	1
+吴圆	wu yuan	1
+无怨	wu yuan	1
+五原春色旧来迟	wu yuan chun se jiu lai chi	1
+吴苑宫闱今冷落	wu yuan gong wei jin leng luo	1
+武元衡	wu yuan heng	1
+无远勿届	wu yuan wu jie	1
+五月不可触	wu yue bu ke chu	1
+五岳倒为轻	wu yue dao wei qing	1
+五岳祭秩皆三公	wu yue ji zhi jie san gong	1
+五月金石铄	wu yue jin shi shuo	1
+五月鸣蜩	wu yue ming tiao	1
+五月七日	wu yue qi ri	1
+五月时	wu yue shi	1
+五月思貂裘	wu yue si diao qiu	1
+五月天山雪	wu yue tian shan xue	1
+五月五日天晴明	wu yue wu ri tian qing ming	1
+五月西施采	wu yue xi shi cai	1
+悟悦心自足	wu yue xin zi zu	1
+五岳寻仙不辞远	wu yue xun xian bu ci yuan	1
+五云垂晖耀紫清	wu yun chui hui yao zi qing	1
+吴云寒	wu yun han	1
+五杂组	wu za zu	1
+无灾无难到公卿	wu zai wu nan dao gong qing	1
+吾在于天地之间	wu zai yu tian di zhi jian	1
+吾至爱汝	wu zhi ai ru	1
+物之残也	wu zhi can ye	1
+物之粗也	wu zhi cu ye	1
+物之情也	wu zhi qing ye	1
+物之生也	wu zhi sheng ye	1
+恶之欲其死	wu zhi yu qi si	1
+吾之于人也	wu zhi yu ren ye	1
+吾执御矣	wu zhi yu yi	1
+物之质也	wu zhi zhi ye	1
+吴中盛文史	wu zhong sheng wen shi	1
+吴中张翰称达生	wu zhong zhang han cheng da sheng	1
+五洲震荡风雷激	wu zhou zhen dang feng lei ji	1
+吴烛	wu zhu	1
+无主荷花到处开	wu zhu he hua dao chu kai	1
+误逐世间乐	wu zhu shi jian le	1
+雾濯清辉苦	wu zhuo qing hui ku	1
+吴子来	wu zi lai	1
+无自辱焉	wu zi ru yan	1
+吾自卫反鲁	wu zi wei fan lu	1
+戏罢曾无理曲时	xi ba ceng wu li qu shi	1
+西北有高楼	xi bei you gao lou	1
+夕避长蛇	xi bi chang she	1
+西鄙人	xi bi ren	1
+昔别君未婚	xi bie jun wei hun	1
+洗兵条支海上波	xi bing tiao zhi hai shang bo	1
+席不暖君床	xi bu nuan jun chuang	1
+细草微风岸	xi cao wei feng an	1
+细草香闲小洞幽	xi cao xiang xian xiao dong you	1
+喜朝天	xi chao tian	1
+昔乘匹马去	xi cheng pi ma qu	1
+习池风景异	xi chi feng jing yi	1
+西川有杜鹃	xi chuan you du juan	1
+喜春来	xi chun lai	1
+惜春郎	xi chun lang	1
+惜春令	xi chun ling	1
+惜此花间月	xi ci hua jian yue	1
+夕次盱眙县	xi ci xu yi xian	1
+西当太白有鸟道	xi dang tai bai you niao dao	1
+希道	xi dao	1
+西地锦	xi di jin	1
+奚而不丧	xi er bu sang	1
+惜芳菲	xi fang fei	1
+西方学者	xi fang xue zhe	1
+西风愁起绿波间	xi feng chou qi lv bo jian	1
+西风吹老丹枫树	xi feng chui lao dan feng shu	1
+西风多少恨	xi feng duo shao hen	1
+西风烈	xi feng lie	1
+西风漫卷孤城	xi feng man juan gu cheng	1
+西风生翠萝	xi feng sheng cui luo	1
+吸风饮露	xi feng yin lu	1
+西宫南内多秋草	xi gong nan nei duo qiu cao	1
+西宫夜静百花香	xi gong ye jing bai hua xiang	1
+西挂咸阳树	xi gua xian yang shu	1
+昔归相识少	xi gui xiang shi shao	1
+西还	xi hai	1
+羲和羲和	xi he xi he	1
+惜红衣	xi hong yi	1
+西湖	xi hu	1
+西湖边	xi hu bian	1
+西湖春	xi hu chun	1
+西湖路	xi hu lu	1
+西湖天下景	xi hu tian xia jing	1
+西湖月	xi hu yue	1
+溪花与禅意	xi hua yu chan yi	1
+惜黄花	xi huang hua	1
+溪涧岂能留得住	xi jian qi neng liu de zhu	1
+喜见外弟又言别	xi jian wai di you yan bie	1
+西江怀古	xi jiang huai gu	1
+西江接锦城	xi jiang jie jin cheng	1
+西江上	xi jiang shang	1
+西江月井冈山	xi jiang yue jing gang shan	1
+洗尽古今人不倦	xi jin gu jin ren bu juan	1
+溪居	xi ju	1
+喜君贻我一枝春	xi jun yi wo yi zhi chun	1
+喜看稻菽千重浪	xi kan dao shu qian chong lang	1
+细看来	xi kan lai	1
+细看涛生云灭	xi kan tao sheng yun mie	1
+席夔	xi kui	1
+夕揽洲之宿莽	xi lan zhou zhi su mang	1
+西陵下	xi ling xia	1
+细柳新蒲为谁绿	xi liu xin pu wei shui lv	1
+细柳营前叶漫新	xi liu ying qian ye man xin	1
+溪柳自摇沙水清	xi liu zi yao sha shui qing	1
+西楼望月几回圆	xi lou wang yue ji hui yuan	1
+西楼子	xi lou zi	1
+西路蝉声唱	xi lu chan sheng chang	1
+西陆蝉声唱	xi lu chan sheng chang	1
+系马高楼垂柳边	xi ma gao lou chui liu bian	1
+西梦令	xi meng ling	1
+西南火星如弹丸	xi nan huo xing ru dan wan	1
+西南其户	xi nan qi hu	1
+昔年亲友半凋零	xi nian qin you ban diao ling	1
+昔年有狂客	xi nian you kuang ke	1
+熙宁三年	xi ning san nian	1
+喜怒哀乐	xi nu ai le	1
+惜奴娇	xi nu jiao	1
+犀辟尘埃玉辟寒	xi pi chen ai yu pi han	1
+西平乐	xi ping le	1
+惜其不成	xi qi bu cheng	1
+奚其为为政	xi qi wei wei zheng	1
+咥其笑矣	xi qi xiao yi	1
+惜秦皇汉武	xi qin huang han wu	1
+惜琼花	xi qiong hua	1
+奚取于三家之堂	xi qu yu san jia zhi tang	1
+昔人已乘白云去	xi ren yi cheng bai yun qu	1
+昔日长城战	xi ri chang cheng zhan	1
+昔日芙蓉花	xi ri fu rong hua	1
+昔日横波目	xi ri heng bo mu	1
+昔日青青今在否	xi ri qing qing jin zai fou	1
+昔日太宗拳毛騧	xi ri tai zong quan mao gua	1
+昔日戏言身后事	xi ri xi yan shen hou shi	1
+昔三后之纯粹兮	xi san hou zhi chun cui xi	1
+西山白雪三城戍	xi shan bai xue san cheng shu	1
+西山鸾鹤群	xi shan luan he qun	1
+西上太白峰	xi shang tai bai feng	1
+溪上遥闻精舍钟	xi shang yao wen jing she zhong	1
+席上作	xi shang zuo	1
+希圣如有立	xi sheng ru you li	1
+昔时飞箭无全目	xi shi fei jian wu quan mu	1
+昔时金阶白玉堂	xi shi jin jie bai yu tang	1
+西施宁久微	xi shi ning jiu wei	1
+昔时人已没	xi shi ren yi mei	1
+昔时燕家重郭隗	xi shi yan jia zhong guo wei	1
+西施宜笑复宜颦	xi shi yi xiao fu yi pin	1
+西施咏	xi shi yong	1
+西施越溪女	xi shi yue xi nv	1
+洗手作羹汤	xi shou zuo geng tang	1
+蟋蟀在堂	xi shuai zai tang	1
+惜双双	xi shuang shuang	1
+希叟	xi sou	1
+昔岁逢太平	xi sui feng tai ping	1
+昔随刘氏定长安	xi sui liu shi ding chang an	1
+西屠石堡取紫袍	xi tu shi bao qu zi pao	1
+细推物理须行乐	xi tui wu li xu xing le	1
+喜外弟卢纶见宿	xi wai di lu lun jian su	1
+西望长安不见家	xi wang chang an bu jian jia	1
+西望瑶池降王母	xi wang yao chi jiang wang mu	1
+昔闻洞庭水	xi wen dong ting shui	1
+息我以死	xi wo yi si	1
+溪午不闻钟	xi wu bu wen zhong	1
+习习谷风	xi xi gu feng	1
+嬉戏莫相忘	xi xi mo xiang wang	1
+栖栖一代中	xi xi yi dai zhong	1
+西溪子	xi xi zi	1
+西下峨眉峰	xi xia e mei feng	1
+奚暇治礼义哉	xi xia zhi li yi zai	1
+习相远也	xi xiang yuan ye	1
+嬉笑怒骂	xi xiao nu ma	1
+西笑吟	xi xiao yin	1
+洗心向溪月	xi xin xiang xi yue	1
+西兴浦口	xi xing pu kou	1
+稀星乍有无	xi xing zha you wu	1
+希言自然	xi yan zi ran	1
+夕阳度西岭	xi yang du xi ling	1
+夕阳连雨足	xi yang lian yu zu	1
+夕阳楼	xi yang lou	1
+夕阳千万峰	xi yang qian wan feng	1
+夕阳依旧垒	xi yang yi jiu lei	1
+西忆故人不可见	xi yi gu ren bu ke jian	1
+徙倚湖山欲暮时	xi yi hu shan yu mu shi	1
+西意曲	xi yi qu	1
+奚以知其然也	xi yi zhi qi ran ye	1
+隰有苌楚	xi you chang chu	1
+戏有此赠	xi you ci zeng	1
+隰有荷华	xi you he hua	1
+昔有佳人公孙氏	xi you jia ren gong sun shi	1
+席豫	xi yu	1
+惜余春	xi yu chun	1
+细雨春风花落时	xi yu chun feng hua luo shi	1
+细雨霏微	xi yu fei wei	1
+惜与故人违	xi yu gu ren wei	1
+惜余欢	xi yu huan	1
+细雨梦回鸡塞远	xi yu meng hui ji sai yuan	1
+细雨濛濛欲湿衣	xi yu meng meng yu shi yi	1
+细语人不闻	xi yu ren bu wen	1
+细雨湿流光	xi yu shi liu guang	1
+细雨湿衣看不见	xi yu shi yi kan bu jian	1
+细雨无人我独来	xi yu wu ren wo du lai	1
+西园翰墨林	xi yuan han mo lin	1
+西原贼入道州	xi yuan zei ru dao zhou	1
+西岳莲花山	xi yue lian hua shan	1
+西岳峥嵘何壮哉	xi yue zheng rong he zhuang zai	1
+昔在长安醉花柳	xi zai chang an zui hua liu	1
+昔在九江上	xi zai jiu jiang shang	1
+隰则有泮	xi ze you pan	1
+洗盏更酌	xi zhan geng zhuo	1
+西征问烽火	xi zheng wen feng huo	1
+昔之得一者	xi zhi de yi zhe	1
+膝之所倚	xi zhi suo yi	1
+系舟仙宅下	xi zhou xian zhai xia	1
+犀箸厌饫久未下	xi zhu yan yu jiu wei xia	1
+西子	xi zi	1
+西子蒙不洁	xi zi meng bu jie	1
+西子妆	xi zi zhuang	1
+西子妆慢	xi zi zhuang man	1
+昔作女儿时	xi zuo nv er shi	1
+下笔如有神	xia bi ru you shen	1
+夏初临	xia chu lin	1
+下床畏蛇食畏药	xia chuang wei she shi wei yao	1
+吓倒蓬间雀	xia dao peng jian que	1
+下德不失德	xia de bu shi de	1
+遐方怨	xia fang yuan	1
+夏风多暖暖	xia feng duo nuan nuan	1
+夏歌	xia ge	1
+夏鸿	xia hong	1
+夏侯审	xia hou shen	1
+夏侯孜	xia hou zi	1
+下江陵	xia jiang ling	1
+夏景	xia jing	1
+侠客行	xia ke xing	1
+下窥指高鸟	xia kui zhi gao niao	1
+匣里金刀血未干	xia li jin dao xue wei gan	1
+峡里谁知有人事	xia li shui zhi you ren shi	1
+夏礼吾能言之	xia li wu neng yan zhi	1
+下临仍欲坠	xia lin reng yu zhui	1
+下流多谤议	xia liu duo bang yi	1
+下马入车中	xia ma ru che zhong	1
+下马饮君酒	xia ma yin jun jiu	1
+夏倪	xia ni	1
+下平声	xia ping sheng	1
+下潜黄泉	xia qian huang quan	1
+夏日南亭怀辛大	xia ri nan ting huai xin da	1
+夏日消溶	xia ri xiao rong	1
+夏日消融	xia ri xiao rong	1
+下上其音	xia shang qi yin	1
+下士闻道	xia shi wen dao	1
+下手迟	xia shou chi	1
+下水船	xia shui chuan	1
+夏水欲满君山青	xia shui yu man jun shan qing	1
+下学而上达	xia xue er shang da	1
+夏莺千啭弄蔷薇	xia ying qian zhuan nong qiang wei	1
+下有长流之川	xia you chang liu zhi chuan	1
+下有渌水之波澜	xia you lu shui zhi bo lan	1
+下有伤心之春草	xia you shang xin zhi chun cao	1
+夏雨雪	xia yu xue	1
+夏云峰	xia yun feng	1
+夏之日	xia zhi ri	1
+下至于兹	xia zhi yu zi	1
+夏州	xia zhou	1
+闲爱孤云静爱僧	xian ai gu yun jing ai seng	1
+衔杯乐圣称世贤	xian bei yue sheng cheng shi xian	1
+羡长江之无穷	xian chang jiang zhi wu qiong	1
+咸池	xian chi	1
+闲持贝叶书	xian chi bei ye shu	1
+险处不须看	xian chu bu xu kan	1
+先大母婢也	xian da mu bi ye	1
+先帝侍女八千人	xian di shi nv ba qian ren	1
+先帝天马玉花骢	xian di tian ma yu hua cong	1
+闲读道书慵未起	xian du dao shu yong wei qi	1
+仙娥今下嫁	xian e jin xia jia	1
+鲜肥属时禁	xian fei shu shi jin	1
+仙风吹下御炉香	xian feng chui xia yu lu xiang	1
+仙风道骨今谁有	xian feng dao gu jin shui you	1
+先拂声弦后角羽	xian fu sheng xian hou jiao yu	1
+献赋十年犹未遇	xian fu shi nian you wei yu	1
+县官急索租	xian guan ji suo zu	1
+闲过信陵饮	xian guo xin ling yin	1
+献何人	xian he ren	1
+闲花落地听无声	xian hua luo de ting wu sheng	1
+闲即傍边立	xian ji bang bian li	1
+先进第十一	xian jin di shi yi	1
+先进于礼乐	xian jin yu li yue	1
+闲居三月	xian ju san yue	1
+闲看秋水心无事	xian kan qiu shui xin wu shi	1
+闲窥石镜清我心	xian kui shi jing qing wo xin	1
+闲鹭栖常早	xian lu qi chang zao	1
+闲门向山路	xian men xiang shan lu	1
+先难而后获	xian nan er hou huo	1
+衔泥巢君屋	xian ni chao jun wu	1
+衔泥燕	xian ni yan	1
+先期汗漫九垓上	xian qi han man jiu gai shang	1
+先期零落更愁人	xian qi ling luo geng chou ren	1
+咸其自取	xian qi zi qu	1
+先遣小姑尝	xian qian xiao gu chang	1
+仙人抚我顶	xian ren fu wo ding	1
+仙人拊我顶	xian ren fu wo ding	1
+仙人如爱我	xian ren ru ai wo	1
+仙人十五爱吹笙	xian ren shi wu ai chui sheng	1
+仙人有待乘黄鹤	xian ren you dai cheng huang he	1
+仙人掌上雨初晴	xian ren zhang shang yu chu qing	1
+岘山怀古	xian shan huai gu	1
+先圣后圣	xian sheng hou sheng	1
+先事后得	xian shi hou de	1
+咸酸杂众好	xian suan za zhong hao	1
+仙台初见五城楼	xian tai chu jian wu cheng lou	1
+仙桃正发花	xian tao zheng fa hua	1
+先汪	xian wang	1
+先王之道斯为美	xian wang zhi dao si wei mei	1
+宪问第十四	xian wen di shi si	1
+掀舞一叶白头翁	xian wu yi ye bai tou weng	1
+闲暇者之所好也	xian xia zhe zhi suo hao ye	1
+闲闲令	xian xian ling	1
+贤贤易色	xian xian yi se	1
+献仙音	xian xian yin	1
+纤纤作细步	xian xian zuo xi bu	1
+县小更无丁	xian xiao geng wu ding	1
+咸言意气高	xian yan yi qi gao	1
+咸阳古道音尘绝	xian yang gu dao yin chen jue	1
+咸阳游侠多少年	xian yang you xia duo shao nian	1
+闲依农圃邻	xian yi nong pu lin	1
+闲倚一枝藤	xian yi yi zhi teng	1
+仙游未曾歇	xian you wei ceng xie	1
+贤与不肖	xian yu bu xiao	1
+贤愚千载知谁是	xian yu qian zai zhi shui shi	1
+闲与仙人扫落花	xian yu xian ren sao luo hua	1
+纤云四卷天无河	xian yun si juan tian wu he	1
+闲云潭影日悠悠	xian yun tan ying ri you you	1
+贤哉回也	xian zai hui ye	1
+贤者而后乐此	xian zhe er hou le ci	1
+贤者识其大者	xian zhe shi qi da zhe	1
+贤者在位	xian zhe zai wei	1
+先知风起月含晕	xian zhi feng qi yue han yun	1
+先至洛阳城	xian zhi luo yang cheng	1
+仙之人兮列如麻	xian zhi ren xi lie ru ma	1
+闲中好	xian zhong hao	1
+献衷心	xian zhong xin	1
+先主武侯同閟宫	xian zhu wu hou tong bi gong	1
+先醉	xian zui	1
+闲坐悲君亦自悲	xian zuo bei jun yi zi bei	1
+闲坐说玄宗	xian zuo shuo xuan zong	1
+相悲各问年	xiang bei ge wen nian	1
+相彼鸟矣	xiang bi niao yi	1
+巷伯	xiang bo	1
+项伯杀人	xiang bo sha ren	1
+项伯许诺	xiang bo xu nuo	1
+项伯亦拔剑起舞	xiang bo yi ba jian qi wu	1
+相传称乱石	xiang chuan cheng luan shi	1
+乡党第十	xiang dang di shi	1
+想得读书头已白	xiang de du shu tou yi bai	1
+象帝之先	xiang di zhi xian	1
+香殿早迎春	xiang dian zao ying chun	1
+相对如梦寐	xiang dui ru meng mei	1
+想对心凄然	xiang dui xin qi ran	1
+相对亦忘言	xiang dui yi wang yan	1
+翔而后集	xiang er hou ji	1
+湘妃雨后来池看	xiang fei yu hou lai chi kan	1
+湘妃怨	xiang fei yuan	1
+相逢不相识	xiang feng bu xiang shi	1
+相逢不用忙归去	xiang feng bu yong mang gui qu	1
+相逢方一笑	xiang feng fang yi xiao	1
+相逢红尘内	xiang feng hong chen nei	1
+相逢每醉还	xiang feng mei zui hai	1
+相逢秋月满	xiang feng qiu yue man	1
+相逢畏相失	xiang feng wei xiang shi	1
+相逢行	xiang feng xing	1
+相逢意气为君饮	xiang feng yi qi wei jun yin	1
+象服是宜	xiang fu shi yi	1
+相公归	xiang gong gui	1
+相顾怜无声	xiang gu lian wu sheng	1
+向滈	xiang hao	1
+相恨不如潮有信	xiang hen bu ru chao you xin	1
+向湖边	xiang hu bian	1
+项脊生曰	xiang ji sheng yue	1
+相见不得亲	xiang jian bu de qin	1
+相见不相知	xiang jian bu xiang zhi	1
+相见情已深	xiang jian qing yi shen	1
+相见少	xiang jian shao	1
+相见语依依	xiang jian yu yi yi	1
+湘江北去	xiang jiang bei qu	1
+湘江竹上痕无限	xiang jiang zhu shang hen wu xian	1
+相敬如宾不相睹	xiang jing ru bin bu xiang du	1
+相看白刃血纷纷	xiang kan bai ren xue fen fen	1
+向来吟秀句	xiang lai yin xiu ju	1
+箱帘六七十	xiang lian liu qi shi	1
+香炉初上日	xiang lu chu shang ri	1
+香炉瀑布遥相望	xiang lu pu bu yao xiang wang	1
+乡路迢迢	xiang lu tiao tiao	1
+香罗拭手春事违	xiang luo shi shou chun shi wei	1
+象弭鱼服	xiang mi yu fu	1
+香气为谁发	xiang qi wei shui fa	1
+相亲相近水中鸥	xiang qin xiang jin shui zhong ou	1
+香球	xiang qiu	1
+相去若何	xiang qu ruo he	1
+相去四十里	xiang qu si shi li	1
+相去远矣	xiang qu yuan yi	1
+乡人皆恶之	xiang ren jie e zhi	1
+乡人皆好之	xiang ren jie hao zhi	1
+向人微露丁香颗	xiang ren wei lou ding xiang ke	1
+乡人饮酒	xiang ren yin jiu	1
+相濡以沫	xiang ru yi mo	1
+相如作赋得黄金	xiang ru zuo fu de huang jin	1
+香山会	xiang shan hui	1
+相识三十年	xiang shi san shi nian	1
+相失万重云	xiang shi wan chong yun	1
+相守夜欢哗	xiang shou ye huan hua	1
+相鼠	xiang shu	1
+乡书不可寄	xiang shu bu ke ji	1
+相鼠有齿	xiang shu you chi	1
+相鼠有皮	xiang shu you pi	1
+相鼠有体	xiang shu you ti	1
+湘水无情吊岂知	xiang shui wu qing diao qi zhi	1
+项斯	xiang si	1
+相思不相见	xiang si bu xiang jian	1
+相思愁白苹	xiang si chou bai ping	1
+相思苦	xiang si ku	1
+相思泪成行	xiang si lei cheng xing	1
+相思令	xiang si ling	1
+相思明月夜	xiang si ming yue ye	1
+相思难见面	xiang si nan jian mian	1
+相思始觉海非深	xiang si shi jue hai fei shen	1
+相思无终极	xiang si wu zhong ji	1
+相思相见知何日	xiang si xiang jian zhi he ri	1
+相思一夜梅花发	xiang si yi ye mei hua fa	1
+相思远	xiang si yuan	1
+相思在何处	xiang si zai he chu	1
+相思子	xiang si zi	1
+相送还成泣	xiang song hai cheng qi	1
+相送情无限	xiang song qing wu xian	1
+向天盏	xiang tian zhan	1
+向晚横吹悲	xiang wan heng chui bei	1
+向晚猩猩啼	xiang wan xing xing ti	1
+项王按剑而跽曰	xiang wang an jian er ji yue	1
+襄王安在哉	xiang wang an zai zai	1
+项王军在鸿门下	xiang wang jun zai hong men xia	1
+项王默然不应	xiang wang mo ran bu ying	1
+相望始登高	xiang wang shi deng gao	1
+相望试登高	xiang wang shi deng gao	1
+项王未有以应	xiang wang wei you yi ying	1
+相望限风烟	xiang wang xian feng yan	1
+相望相思不相见	xiang wang xiang si bu xiang jian	1
+项王则受壁	xiang wang ze shou bi	1
+相维辟公	xiang wei pi gong	1
+香雾霏霏月转廊	xiang wu fei fei yue zhuan lang	1
+巷无居人	xiang wu ju ren	1
+象喜亦喜	xiang xi yi xi	1
+相携及田家	xiang xie ji tian jia	1
+乡心新岁切	xiang xin xin sui qie	1
+庠序之教	xiang xu zhi jiao	1
+襄阳道	xiang yang dao	1
+襄阳歌	xiang yang ge	1
+襄阳好风日	xiang yang hao feng ri	1
+相邀归渡头	xiang yao gui du tou	1
+香叶终经宿鸾凤	xiang ye zhong jing su luan feng	1
+相忆采芙蓉	xiang yi cai fu rong	1
+湘驿女子	xiang yi nv zi	1
+香印成灰	xiang yin cheng hui	1
+乡音难改鬓毛衰	xiang yin nan gai bin mao shuai	1
+相迎不道远	xiang ying bu dao yuan	1
+象忧亦忧	xiang you yi you	1
+相与步于中庭	xiang yu bu yu zhong ting	1
+项羽季父也	xiang yu ji fu ye	1
+相与烜赫流淳熙	xiang yu xuan he liu chun xi	1
+相与枕藉乎舟中	xiang yu zhen jie hu zhou zhong	1
+湘月	xiang yue	1
+相月	xiang yue	1
+相知何用早	xiang zhi he yong zao	1
+相知无远近	xiang zhi wu yuan jin	1
+项庄拔剑起舞	xiang zhuang ba jian qi wu	1
+向子諲	xiang zi yin	1
+向尊前	xiang zun qian	1
+小弁	xiao bian	1
+小不忍则乱大谋	xiao bu ren ze luan da mou	1
+小冲山	xiao chong shan	1
+小重山令	xiao chong shan ling	1
+销愁斗几千	xiao chou dou ji qian	1
+笑春风	xiao chun feng	1
+孝慈则忠	xiao ci ze zhong	1
+小大由之	xiao da you zhi	1
+笑而不答心自闲	xiao er bu da xin zi xian	1
+小儿时节	xiao er shi jie	1
+小儿误喜朱颜在	xiao er wu xi zhu yan zai	1
+萧妃	xiao fei	1
+晓耕翻露草	xiao geng fan lu cao	1
+孝公既没	xiao gong ji mei	1
+孝恭遵妇道	xiao gong zun fu dao	1
+箫鼓哀吟感鬼神	xiao gu ai yin gan gui shen	1
+小姑居处本无郎	xiao gu ju chu ben wu lang	1
+小姑如我长	xiao gu ru wo chang	1
+小姑始扶床	xiao gu shi fu chuang	1
+箫鼓喧喧汉将营	xiao gu xuan xuan han jiang ying	1
+箫管迎龙水庙前	xiao guan ying long shui miao qian	1
+霄汉长怀捧日心	xiao han chang huai peng ri xin	1
+小荷翻	xiao he fan	1
+萧回	xiao hui	1
+宵济越洪波	xiao ji yue hong bo	1
+萧建	xiao jian	1
+笑渐不闻声渐悄	xiao jian bu wen sheng jian qiao	1
+晓见寒溪有炊烟	xiao jian han xi you chui yan	1
+萧结	xiao jie	1
+笑尽一杯酒	xiao jin yi bei jiu	1
+萧静	xiao jing	1
+萧旷	xiao kuang	1
+晓来百念都灰尽	xiao lai bai nian dou hui jin	1
+小阑干	xiao lan gan	1
+笑揽清溪月	xiao lan qing xi yue	1
+笑里轻轻语	xiao li qing qing yu	1
+小梁州	xiao liang zhou	1
+小楼吹彻玉笙寒	xiao lou chui che yu sheng han	1
+小楼新月	xiao lou xin yue	1
+小梅花	xiao mei hua	1
+宵眠抱玉鞍	xiao mian bao yu an	1
+小旻	xiao min	1
+箫鸣凤下空	xiao ming feng xia kong	1
+小年不及大年	xiao nian bu ji da nian	1
+小鸟时来啄食	xiao niao shi lai zhuo shi	1
+效颦安可希	xiao pin an ke xi	1
+小秦王	xiao qin wang	1
+萧悫	xiao que	1
+小人比而不周	xiao ren bi er bu zhou	1
+小人反是	xiao ren fan shi	1
+小人甘以绝	xiao ren gan yi jue	1
+小人骄而不泰	xiao ren jiao er bu tai	1
+小人穷斯滥矣	xiao ren qiong si lan yi	1
+小人求诸人	xiao ren qiu zhu ren	1
+小人所腓	xiao ren suo fei	1
+小人同而不和	xiao ren tong er bu he	1
+小人下达	xiao ren xia da	1
+小人则以身殉利	xiao ren ze yi shen xun li	1
+小人之德草	xiao ren zhi de cao	1
+小人之过也必文	xiao ren zhi guo ye bi wen	1
+小戎	xiao rong	1
+笑入荷花去	xiao ru he hua qu	1
+笑入胡姬酒肆中	xiao ru hu ji jiu si zhong	1
+萧瑟动寒林	xiao se dong han lin	1
+萧瑟秋风今又是	xiao se qiu feng jin you shi	1
+晓山青	xiao shan qing	1
+小圣乐	xiao sheng yue	1
+笑时犹带岭梅香	xiao shi you dai ling mei xiang	1
+萧疏鬓已斑	xiao shu bin yi ban	1
+孝思维则	xiao si wei ze	1
+效死勿去	xiao si wu qu	1
+小松初数尺	xiao song chu shu chi	1
+小碎	xiao sui	1
+晓随天仗入	xiao sui tian zhang ru	1
+小桃红	xiao tao hong	1
+小桃花	xiao tao hua	1
+骁腾有如此	xiao teng you ru ci	1
+孝悌也者	xiao ti ye zhe	1
+萧条异代不同时	xiao tiao yi dai bu tong shi	1
+小庭花	xiao ting hua	1
+小宛	xiao wan	1
+萧微	xiao wei	1
+校尉羽书飞瀚海	xiao wei yu shu fei han hai	1
+消息盈虚	xiao xi ying xu	1
+萧项	xiao xiang	1
+潇湘何事等闲回	xiao xiang he shi deng xian hui	1
+潇湘曲	xiao xiang qu	1
+潇湘神	xiao xiang shen	1
+潇湘水北流	xiao xiang shui bei liu	1
+笑向檀郎唾	xiao xiang tan lang tuo	1
+潇湘夜雨	xiao xiang ye yu	1
+潇湘一夜雨	xiao xiang yi ye yu	1
+萧萧发彩凉	xiao xiao fa cai liang	1
+萧萧枫树林	xiao xiao feng shu lin	1
+小小寰球	xiao xiao huan qiu	1
+萧萧马鸣	xiao xiao ma ming	1
+潇潇雨	xiao xiao yu	1
+萧萧雨	xiao xiao yu	1
+萧昕	xiao xin	1
+小心学忠孝	xiao xin xue zhong xiao	1
+小学而大遗	xiao xue er da yi	1
+笑掩微妆入梦来	xiao yan wei zhuang ru meng lai	1
+小言詹詹	xiao yan zhan zhan	1
+逍遥不记年	xiao yao bu ji nian	1
+逍遥池阁凉	xiao yao chi ge liang	1
+逍遥九州	xiao yao jiu zhou	1
+逍遥乐	xiao yao le	1
+逍遥如何	xiao yao ru he	1
+萧意	xiao yi	1
+萧翼	xiao yi	1
+笑矣乎	xiao yi hu	1
+小邑犹藏万家室	xiao yi you cang wan jia shi	1
+萧颖士	xiao ying shi	1
+萧彧	xiao yu	1
+小园独酌	xiao yuan du zhuo	1
+小园赋	xiao yuan fu	1
+小园花乱飞	xiao yuan hua luan fei	1
+小苑莺歌歇	xiao yuan ying ge xie	1
+晓月过残垒	xiao yue guo can lei	1
+晓战随金鼓	xiao zhan sui jin gu	1
+小镇西	xiao zhen xi	1
+小知不及大知	xiao zhi bu ji da zhi	1
+小知间间	xiao zhi jian jian	1
+孝之至也	xiao zhi zhi ye	1
+萧至忠	xiao zhi zhong	1
+孝子之至	xiao zi zhi zhi	1
+斜拔玉钗灯影畔	xie ba yu chai deng ying pan	1
+撷芳词	xie fang ci	1
+挟飞仙以遨游	xie fei xian yi ao you	1
+谢傅门庭旧末行	xie fu men ting jiu mo hang	1
+谢福娘	xie fu niang	1
+谢公离别处	xie gong li bie chu	1
+谢公宿处今尚在	xie gong su chu jin shang zai	1
+谢公行处苍苔没	xie gong xing chu cang tai mei	1
+谢公最小偏怜女	xie gong zui xiao pian lian nv	1
+斜光照墟落	xie guang zhao xu luo	1
+邂逅相遇	xie hou xiang yu	1
+携妓东山去	xie ji dong shan qu	1
+谢家来贵门	xie jia lai gui men	1
+谢家事夫婿	xie jia shi fu xu	1
+胁肩谄笑	xie jian chan xiao	1
+谢绛	xie jiang	1
+谢克家	xie ke jia	1
+携来百侣曾游	xie lai bai lv ceng you	1
+谢良辅	xie liang fu	1
+谢懋	xie mao	1
+谢邈	xie miao	1
+谢明远	xie ming yuan	1
+谢娘别后谁能惜	xie niang bie hou shui neng xi	1
+谢秋娘	xie qiu niang	1
+携手佳人	xie shou jia ren	1
+携手江村	xie shou jiang cun	1
+携手日同行	xie shou ri tong hang	1
+携手上河梁	xie shou shang he liang	1
+携手同归	xie shou tong gui	1
+挟太山以超北海	xie tai shan yi chao bei hai	1
+谢陶	xie tao	1
+谢燮	xie xie	1
+谢新恩	xie xin en	1
+斜阳千万树	xie yang qian wan shu	1
+斜阳下	xie yang xia	1
+斜阳下小楼	xie yang xia xiao lou	1
+斜阳照墟落	xie yang zhao xu luo	1
+谢直	xie zhi	1
+颉之颃之	xie zhi hang zhi	1
+谐之言曰	xie zhi yan yue	1
+新安路	xin an lu	1
+信不足焉	xin bu zu yan	1
+心潮逐浪高	xin chao zhu lang gao	1
+心惆怅	xin chou chang	1
+新愁往恨何穷	xin chou wang hen he qiong	1
+新炊间黄粱	xin chui jian huang liang	1
+信道不笃	xin dao bu du	1
+心断绝	xin duan jue	1
+心断新丰酒	xin duan xin feng jiu	1
+信而好古	xin er hao gu	1
+信而后谏	xin er hou jian	1
+新丰美酒斗十千	xin feng mei jiu dou shi qian	1
+新妇车在后	xin fu che zai hou	1
+新妇初来时	xin fu chu lai shi	1
+新妇起严妆	xin fu qi yan zhuang	1
+新妇识马声	xin fu shi ma sheng	1
+新妇谓府吏	xin fu wei fu li	1
+新谷既升	xin gu ji sheng	1
+新鬼烦冤旧鬼哭	xin gui fan yuan jiu gui ku	1
+新荷弄晚凉	xin he nong wan liang	1
+辛宏	xin hong	1
+新嫁娘	xin jia niang	1
+信近于义	xin jin yu yi	1
+新开一夜风	xin kai yi ye feng	1
+新柳	xin liu	1
+心莫若和	xin mo ruo he	1
+新念别	xin nian bie	1
+新年作	xin nian zuo	1
+心期卧亦赊	xin qi wo yi she	1
+心怯空房不忍归	xin qie kong fang bu ren gui	1
+心轻万事皆鸿毛	xin qing wan shi jie hong mao	1
+心清闻妙香	xin qing wen miao xiang	1
+新晴原野旷	xin qing yuan ye kuang	1
+欣然起行	xin ran qi xing	1
+新人不如旧	xin ren bu ru jiu	1
+新人美如玉	xin ren mei ru yu	1
+心如结兮	xin ru jie xi	1
+信如君不君	xin ru jun bu jun	1
+心如铁石	xin ru tie shi	1
+心若死灰	xin ruo si hui	1
+新梢才出墙	xin shao cai chu qiang	1
+信誓旦旦	xin shi dan dan	1
+新诗改罢自长吟	xin shi gai ba zi chang yin	1
+心使气曰强	xin shi qi yue qiang	1
+心事数茎白发	xin shi shu jing bai fa	1
+心事同漂泊	xin shi tong piao bo	1
+心事一杯中	xin shi yi bei zhong	1
+新水令	xin shui ling	1
+信斯言也	xin si yan ye	1
+信宿渔人还泛泛	xin su yu ren hai fan fan	1
+心随长风去	xin sui chang feng qu	1
+心随湖水共悠悠	xin sui hu shui gong you you	1
+心随朗日高	xin sui lang ri gao	1
+心随明月到胡天	xin sui ming yue dao hu tian	1
+心随雁飞灭	xin sui yan fei mie	1
+新滩莫悟游人意	xin tan mo wu you ren yi	1
+心同野鹤与尘远	xin tong ye he yu chen yuan	1
+心无所知	xin wu suo zhi	1
+心相许	xin xiang xu	1
+欣欣此生意	xin xin ci sheng yi	1
+心绪逢摇落	xin xu feng yao luo	1
+心绪乱已久	xin xu luan yi jiu	1
+新雁过妆楼	xin yan guo zhuang lou	1
+辛延年	xin yan nian	1
+信以成之	xin yi cheng zhi	1
+辛夷花尽杏花飞	xin yi hua jin xing hua fei	1
+心亦忧止	xin yi you zhi	1
+信有人间行路难	xin you ren jian xing lu nan	1
+心有天游	xin you tian you	1
+新雨带秋岚	xin yu dai qiu lan	1
+心与浮云闲	xin yu fu yun xian	1
+心与广川闲	xin yu guang chuan xian	1
+新月如佳人	xin yue ru jia ren	1
+信则民任焉	xin ze min ren yan	1
+信则人任焉	xin ze ren ren yan	1
+心折此淹留	xin zhe ci yan liu	1
+信者效其忠	xin zhe xiao qi zhong	1
+新政县	xin zheng xian	1
+心知白云外	xin zhi bai yun wai	1
+心知长别离	xin zhi chang bie li	1
+信知生男恶	xin zhi sheng nan e	1
+心之忧矣	xin zhi you yi	1
+心止于符	xin zhi yu fu	1
+新知遭薄俗	xin zhi zao bo su	1
+心中悲	xin zhong bei	1
+心中常苦悲	xin zhong chang ku bei	1
+心中自不平	xin zhong zi bu ping	1
+新妆曲未终	xin zhuang qu wei zhong	1
+新妆宜面下朱楼	xin zhuang yi mian xia zhu lou	1
+行百里者半九十	xing bai li zhe ban jiu shi	1
+行比一乡	xing bi yi xiang	1
+行不得	xing bu de	1
+行不笃敬	xing bu du jing	1
+行不履阈	xing bu lv yu	1
+行不忍人之政	xing bu ren ren zhi zheng	1
+行不言之教	xing bu yan zhi jiao	1
+行不由径	xing bu you jing	1
+行藏在我	xing cang zai wo	1
+星躔牛斗北	xing chan niu dou bei	1
+星垂平野阔	xing chui ping ye kuo	1
+幸此南夷谪	xing ci nan yi zhe	1
+性达形迹忘	xing da xing ji wang	1
+行到安西更向西	xing dao an xi geng xiang xi	1
+行道迟迟	xing dao chi chi	1
+行端	xing duan	1
+性短非所续	xing duan fei suo xu	1
+幸而得之	xing er de zhi	1
+邢凤	xing feng	1
+行逢落花长叹息	xing feng luo hua chang tan xi	1
+幸复得此妇	xing fu de ci fu	1
+行歌尽落梅	xing ge jin luo mei	1
+行宫	xing gong	1
+星宫之君醉琼浆	xing gong zhi jun zui qiong jiang	1
+形固可使如槁木	xing gu ke shi ru gao mu	1
+性豪业嗜酒	xing hao ye shi jiu	1
+星河秋一雁	xing he qiu yi yan	1
+杏花风	xing hua feng	1
+杏花两株能白红	xing hua liang zhu neng bai hong	1
+兴尽方下山	xing jin fang xia shan	1
+行尽胡天千万里	xing jin hu tian qian wan li	1
+行尽江南数千里	xing jin jiang nan shu qian li	1
+行尽青溪不见人	xing jin qing xi bu jian ren	1
+行经华阴	xing jing hua yin	1
+邢巨	xing ju	1
+邢俊臣	xing jun chen	1
+行军司马智且勇	xing jun si ma zhi qie yong	1
+行军用兵之道	xing jun yong bing zhi dao	1
+幸可广问讯	xing ke guang wen xun	1
+兴来今日尽君欢	xing lai jin ri jin jun huan	1
+兴来每独往	xing lai mei du wang	1
+兴来美独往	xing lai mei du wang	1
+兴来无远近	xing lai wu yuan jin	1
+星临万户动	xing lin wan hu dong	1
+性灵出万象	xing ling chu wan xiang	1
+行露	xing lu	1
+行路难三首	xing lu nan san shou	1
+行路难三首之一	xing lu nan san shou zhi yi	1
+行路难行路难	xing lu nan xing lu nan	1
+行迈靡靡	xing mai mi mi	1
+形莫若就	xing mo ruo jiu	1
+行年四岁	xing nian si sui	1
+行其义也	xing qi yi ye	1
+星桥铁锁开	xing qiao tie suo kai	1
+邢群	xing qun	1
+行人但云点行频	xing ren dan yun dian hang pin	1
+行人刁斗风沙暗	xing ren diao dou feng sha an	1
+行人弓箭各在腰	xing ren gong jian ge zai yao	1
+行人皆怵惕	xing ren jie chu ti	1
+刑人如恐不胜	xing ren ru kong bu sheng	1
+行人驻足听	xing ren zhu zu ting	1
+形若槁骸	xing ruo gao hai	1
+邢邵	xing shao	1
+兴是清秋发	xing shi qing qiu fa	1
+醒时同交欢	xing shi tong jiao huan	1
+行天下之大道	xing tian xia zhi da dao	1
+幸勿为过	xing wu wei guo	1
+行夏之时	xing xia zhi shi	1
+形象很美	xing xiang hen mei	1
+性相近也	xing xiang jin ye	1
+星象衔新宠	xing xiang xian xin chong	1
+行香子	xing xiang zi	1
+性行暴如雷	xing xing bao ru lei	1
+行行如也	xing xing ru ye	1
+行一不义	xing yi bu yi	1
+行义以达其道	xing yi yi da qi dao	1
+兴因庐山发	xing yin lu shan fa	1
+星影摇摇欲坠	xing ying yao yao yu zhui	1
+行有不得者	xing you bu de zhe	1
+行于大道	xing yu da dao	1
+星月掩映云朣胧	xing yue yan ying yun tong long	1
+形之不形	xing zhi bu xing	1
+行止皆无地	xing zhi jie wu di	1
+行之以忠	xing zhi yi zhong	1
+熊大经	xiong da jing	1
+兄弟不知	xiong di bu zhi	1
+兄弟急难	xiong di ji nan	1
+兄弟孔怀	xiong di kong huai	1
+兄弟离散	xiong di li san	1
+兄弟妻子离散	xiong di qi zi li san	1
+兄弟阋于墙	xiong di xi yu qiang	1
+兄弟遭杀戮	xiong di zao sha lu	1
+雄飞雌从绕林间	xiong fei ci cong rao lin jian	1
+雄关漫道真如铁	xiong guan man dao zhen ru tie	1
+熊节	xiong jie	1
+熊经鸟申	xiong jing niao shen	1
+雄立东方	xiong li dong fang	1
+匈奴围酒泉	xiong nu wei jiu quan	1
+匈奴未灭	xiong nu wei mie	1
+熊咆龙吟殷岩泉	xiong pao long yin yin yan quan	1
+雄心日千里	xiong xin ri qian li	1
+熊曜	xiong yao	1
+兄曰	xiong yue	1
+雄雉	xiong zhi	1
+胸中不正	xiong zhong bu zheng	1
+胸中日月常新美	xiong zhong ri yue chang xin mei	1
+胸中之竹	xiong zhong zhi zhu	1
+秀出九芙蓉	xiu chu jiu fu rong	1
+绣床斜凭娇无那	xiu chuang xie ping jiao wu na	1
+绣带儿	xiu dai er	1
+修德不期获报	xiu de bu qi huo bao	1
+羞而不为也	xiu er bu wei ye	1
+绣户	xiu hu	1
+修己以安百姓	xiu ji yi an bai xing	1
+修己以安人	xiu ji yi an ren	1
+修己以敬	xiu ji yi jing	1
+羞将白发对华簪	xiu jiang bai fa dui hua zan	1
+羞将短发还吹帽	xiu jiang duan fa hai chui mao	1
+休夸此地分天下	xiu kua ci di fen tian xia	1
+绣罗衫	xiu luo shan	1
+绣罗衣裳照暮春	xiu luo yi shang zhao mu chun	1
+修睦	xiu mu	1
+朽木不可雕	xiu mu bu ke diao	1
+朽木不折	xiu mu bu zhe	1
+秀木含秀气	xiu mu han xiu qi	1
+秀色空绝世	xiu se kong jue shi	1
+秀色掩今古	xiu se yan jin gu	1
+修身不言命	xiu shen bu yan ming	1
+袖手何妨闲处看	xiu shou he fang xian chu kan	1
+修守战之具	xiu shou zhan zhi ju	1
+绣停针	xiu ting zhen	1
+修我戈矛	xiu wo ge mao	1
+修我甲兵	xiu wo jia bing	1
+修我矛戟	xiu wo mao ji	1
+修雅	xiu ya	1
+羞颜未尝开	xiu yan wei chang kai	1
+修之于家	xiu zhi yu jia	1
+修之于身	xiu zhi yu shen	1
+修之于天下	xiu zhi yu tian xia	1
+修之于乡	xiu zhi yu xiang	1
+羞逐长安社中儿	xiu zhu chang an she zhong er	1
+徐安国	xu an guo	1
+徐安贞	xu an zhen	1
+序八州而朝同列	xu ba zhou er chao tong lie	1
+徐珌	xu bi	1
+徐璧	xu bi	1
+虚步蹑太清	xu bu nie tai qing	1
+徐敞	xu chang	1
+许大	xu da	1
+许鼎	xu ding	1
+虚而待物者也	xu er dai wu zhe ye	1
+虚而为盈	xu er wei ying	1
+徐干	xu gan	1
+徐浩	xu hao	1
+徐皓	xu hao	1
+徐珩	xu heng	1
+徐浑	xu hun	1
+许浑	xu hun	1
+徐积	xu ji	1
+许坚	xu jian	1
+许将	xu jiang	1
+徐介	xu jie	1
+须尽丘壑美	xu jin qiu he mei	1
+徐经孙	xu jing sun	1
+许敬宗	xu jing zong	1
+徐九皋	xu jiu gao	1
+徐君宝妻	xu jun bao qi	1
+徐侃	xu kan	1
+虚老严陵	xu lao yan ling	1
+徐理	xu li	1
+墟里上孤烟	xu li shang gu yan	1
+许玫	xu mei	1
+徐梦龙	xu meng long	1
+许孟容	xu meng rong	1
+徐勉	xu mian	1
+许岷	xu min	1
+徐凝	xu ning	1
+须晴日	xu qing ri	1
+许碏	xu que	1
+徐仁友	xu ren you	1
+旭日临窗	xu ri lin chuang	1
+须如猬毛磔	xu ru wei mao zhe	1
+徐商	xu shang	1
+虚室有余闲	xu shi you yu xian	1
+许棠	xu tang	1
+许庭	xu ting	1
+徐文长传	xu wen chang chuan	1
+徐斡	xu wo	1
+虚无恬淡	xu wu tian dan	1
+徐希仁	xu xi ren	1
+徐贤妃	xu xian fei	1
+徐行不必驷马	xu xing bu bi si ma	1
+须行即骑访名山	xu xing ji qi fang ming shan	1
+徐徐更谓之	xu xu geng wei zhi	1
+许宣平	xu xuan ping	1
+许学士	xu xue shi	1
+徐彦伯	xu yan bo	1
+徐彦若	xu yan ruo	1
+徐延寿	xu yan shou	1
+许瑶	xu yao	1
+许尧佐	xu yao zuo	1
+徐一初	xu yi chu	1
+徐夤	xu yin	1
+须臾发成丝	xu yu fa cheng si	1
+须臾鹤发乱如丝	xu yu he fa luan ru si	1
+须臾静扫众峰出	xu yu jing sao zhong feng chu	1
+须臾日射燕脂颊	xu yu ri she yan zhi jia	1
+许圉师	xu yu shi	1
+徐元杰	xu yuan jie	1
+徐月英	xu yue ying	1
+勖哉沧洲心	xu zai cang zhou xin	1
+徐至	xu zhi	1
+徐之才	xu zhi cai	1
+徐知仁	xu zhi ren	1
+续之则忧	xu zhi ze you	1
+虚中	xu zhong	1
+徐仲雅	xu zhong ya	1
+许子冠乎	xu zi guan hu	1
+玄宝	xuan bao	1
+玄蝉去尽叶黄落	xuan chan qu jin ye huang luo	1
+轩车昔曾满	xuan che xi ceng man	1
+宣城还见杜鹃花	xuan cheng hai jian du juan hua	1
+玄德深矣	xuan de shen yi	1
+旋风四面起	xuan feng si mian qi	1
+宣父犹能畏后生	xuan fu you neng wei hou sheng	1
+煊赫大梁城	xuan he da liang cheng	1
+旋抹红妆看使君	xuan mo hong zhuang kan shi jun	1
+宣情	xuan qing	1
+轩然大波起	xuan ran da bo qi	1
+宣室求贤访逐臣	xuan shi qiu xian fang zhu chen	1
+悬危悉可惊	xuan wei xi ke jing	1
+轩楹势可呼	xuan ying shi ke hu	1
+玄幽	xuan you	1
+轩辕弥明	xuan yuan mi ming	1
+玄之又玄	xuan zhi you xuan	1
+宣宗宫人	xuan zong gong ren	1
+学不成名誓不还	xue bu cheng ming shi bu hai	1
+薛存诚	xue cun cheng	1
+学道不倦	xue dao bu juan	1
+薛道衡	xue dao heng	1
+学而优则仕	xue er you ze shi	1
+学而知之者次也	xue er zhi zhi zhe ci ye	1
+雪芳草	xue fang cao	1
+雪飞炎海变清凉	xue fei yan hai bian qing liang	1
+薛逢	xue feng	1
+薛光耀	xue guang yao	1
+雪花大如手	xue hua da ru shou	1
+雪花飞	xue hua fei	1
+雪花照芙蓉	xue hua zhao fu rong	1
+薛据	xue ju	1
+谑浪笑敖	xue lang xiao ao	1
+雪里开花	xue li kai hua	1
+雪里题诗泪满衣	xue li ti shi lei man yi	1
+雪里行军情更迫	xue li xing jun qing geng po	1
+薛令之	xue ling zhi	1
+薛蒙	xue meng	1
+削木为吏	xue mu wei li	1
+薛能	xue neng	1
+血气方刚	xue qi fang gang	1
+薛奇童	xue qi tong	1
+血气未定	xue qi wei ding	1
+薛琼	xue qiong	1
+薛戎	xue rong	1
+学如不及	xue ru bu ji	1
+薛昚惑	xue shen huo	1
+薛式	xue shi	1
+雪狮儿	xue shi er	1
+学士吟	xue shi yin	1
+学书初学卫夫人	xue shu chu xue wei fu ren	1
+薛涛	xue tao	1
+薛涛诗	xue tao shi	1
+薛王沉醉寿王醒	xue wang chen zui shou wang xing	1
+学问类	xue wen lei	1
+学问文章	xue wen wen zhang	1
+血污游魂归不得	xue wu you hun gui bu de	1
+学仙贵功亦贵精	xue xian gui gong yi gui jing	1
+雪压冬云白絮飞	xue ya dong yun bai xu fei	1
+薛曜	xue yao	1
+薛瑶	xue yao	1
+薛业	xue ye	1
+雪衣雪发青玉嘴	xue yi xue fa qing yu zui	1
+薛莹	xue ying	1
+薛泳	xue yong	1
+薛元超	xue yuan chao	1
+雪月交光	xue yue jiao guang	1
+薛昭蕴	xue zhao yun	1
+学之不讲	xue zhi bu jiang	1
+薛准	xue zhun	1
+寻芳不觉醉流霞	xun fang bu jue zui liu xia	1
+熏风初入弦	xun feng chu ru xian	1
+熏风自南来	xun feng zi nan lai	1
+寻古登阳台	xun gu deng yang tai	1
+循环不可寻	xun huan bu ke xun	1
+熏笼玉枕无颜色	xun long yu zhen wu yan se	1
+寻陆鸿渐不遇	xun lu hong jian bu yu	1
+寻梅	xun mei	1
+洵美且都	xun mei qie dou	1
+洵美且仁	xun mei qie ren	1
+洵美且异	xun mei qie yi	1
+寻蒙国恩	xun meng guo en	1
+驯雀今可嗣	xun que jin ke si	1
+寻思起	xun si qi	1
+巡天遥看一千河	xun tian yao kan yi qian he	1
+寻西山隐者不遇	xun xi shan yin zhe bu yu	1
+恂恂如也	xun xun ru ye	1
+浔言江头夜送客	xun yan jiang tou ye song ke	1
+浔阳地僻无音乐	xun yang di pi wu yin yue	1
+寻瑶草	xun yao cao	1
+洵有情兮	xun you qing xi	1
+旬有五日而后反	xun you wu ri er hou fan	1
+亚饭干适楚	ya fan gan shi chu	1
+亚父受玉斗	ya fu shou yu dou	1
+崖口上新月	ya kou shang xin yue	1
+雅量涵高远	ya liang han gao yuan	1
+揠苗者也	ya miao zhe ye	1
+雅琴飞白雪	ya qin fei bai xue	1
+鸭头绿	ya tou lv	1
+亚相勤王甘苦辛	ya xiang qin wang gan ku xin	1
+雅音方可悦	ya yin fang ke yue	1
+雅志莫相违	ya zhi mo xiang wei	1
+言必有中	yan bi you zhong	1
+言辩而不及	yan bian er bu ji	1
+颜博文	yan bo wen	1
+言不及义	yan bu ji yi	1
+言不可不慎也	yan bu ke bu shen ye	1
+言不辱者	yan bu ru zhe	1
+言不顺则事不成	yan bu shun ze shi bu cheng	1
+言不忠信	yan bu zhong xin	1
+言采其薇	yan cai qi wei	1
+颜粲	yan can	1
+燕草如碧丝	yan cao ru bi si	1
+阎朝隐	yan chao yin	1
+言迟更速皆应手	yan chi geng su jie ying shou	1
+燕处超然	yan chu chao ran	1
+眼穿仍欲归	yan chuan reng yu gui	1
+燕春台	yan chun tai	1
+焉得谖草	yan de xuan cao	1
+焉得置之贡玉堂	yan de zhi zhi gong yu tang	1
+言而不足	yan er bu zu	1
+言而非也	yan er fei ye	1
+宴尔新婚	yan er xin hun	1
+言而有信	yan er you xin	1
+岩扉松径长寂寥	yan fei song jing chang ji liao	1
+言告师氏	yan gao shi shi	1
+眼高四海空无人	yan gao si hai kong wu ren	1
+言告言归	yan gao yan gui	1
+颜公变法出新意	yan gong bian fa chu xin yi	1
+燕归来	yan gui lai	1
+燕归梁	yan gui liang	1
+雁后归	yan hou gui	1
+眼花耳热后	yan hua er re hou	1
+眼花落井水底眠	yan hua luo jing shui di mian	1
+沿洄安得住	yan hui an de zhu	1
+言既遂矣	yan ji sui yi	1
+眼见客愁愁不醒	yan jian ke chou chou bu xing	1
+眼角眉梢都似恨	yan jiao mei shao dou si hen	1
+雁尽书难寄	yan jin shu nan ji	1
+盐角儿	yan jue er	1
+眼看人尽醉	yan kan ren jin zui	1
+言可复也	yan ke fu ye	1
+焉可诬也	yan ke wu ye	1
+眼枯即见骨	yan ku ji jian gu	1
+阎宽	yan kuan	1
+颜奎	yan kui	1
+雁来人不来	yan lai ren bu lai	1
+掩泪悲千古	yan lei bei qian gu	1
+掩泪空相向	yan lei kong xiang xiang	1
+烟敛云收	yan lian yun shou	1
+颜令宾	yan ling bin	1
+言秣其马	yan mo qi ma	1
+燕南壮士吴门豪	yan nan zhuang shi wu men hao	1
+焉能事鬼	yan neng shi gui	1
+焉能为有	yan neng wei you	1
+言念君子	yan nian jun zi	1
+烟鸟栖初定	yan niao qi chu ding	1
+掩泣空相向	yan qi kong xiang xiang	1
+眼前事	yan qian shi	1
+眼前一杯酒	yan qian yi bei jiu	1
+宴寝凝清香	yan qin ning qing xiang	1
+宴琼林	yan qiong lin	1
+嫣然一笑竹篱间	yan ran yi xiao zhu li jian	1
+颜仁郁	yan ren yu	1
+言入黄花川	yan ru huang hua chuan	1
+颜如舜华	yan ru shun hua	1
+颜如舜英	yan ru shun ying	1
+颜如渥丹	yan ru wo dan	1
+颜色不变	yan se bu bian	1
+艳色天下重	yan se tian xia zhong	1
+燕山亭	yan shan ting	1
+岩上无心云相逐	yan shang wu xin yun xiang zhu	1
+颜舒	yan shu	1
+偃鼠饮河	yan shu yin he	1
+言树之背	yan shu zhi bei	1
+严霜结庭兰	yan shuang jie ting lan	1
+燕台四首	yan tai si shou	1
+燕台一去客心惊	yan tai yi qu ke xin jing	1
+宴陶家亭子	yan tao jia ting zi	1
+烟涛微茫信难求	yan tao wei mang xin nan qiu	1
+宴桃源	yan tao yuan	1
+燕婉之求	yan wan zhi qiu	1
+焉往而不三黜	yan wang er bu san chu	1
+严维	yan wei	1
+燕尾绣蝥弧	yan wei xiu mao hu	1
+雁下芦洲白	yan xia lu zhou bai	1
+烟销日出不见人	yan xiao ri chu bu jian ren	1
+言笑晏晏	yan xiao yan yan	1
+燕笑语兮	yan xiao yu xi	1
+烟斜雾横	yan xie wu heng	1
+阎选	yan xuan	1
+颜萱	yan xuan	1
+言旋言归	yan xuan yan gui	1
+言寻谷口来	yan xun gu kou lai	1
+檐牙高啄	yan ya gao zhuo	1
+厌厌良人	yan yan liang ren	1
+偃仰啸歌	yan yang xiao ge	1
+演漾在窗户	yan yang zai chuang hu	1
+宴瑶池	yan yao chi	1
+严抑	yan yi	1
+言刈其楚	yan yi qi chu	1
+言刈其蒌	yan yi qi lou	1
+厌浥行露	yan yi xing lu	1
+雁引愁心去	yan yin chou xin qu	1
+言隐于荣华	yan yin yu rong hua	1
+燕莺语	yan ying yu	1
+言游过矣	yan you guo yi	1
+焉有仁人在位	yan you ren ren zai wei	1
+奄有天下	yan you tian xia	1
+烟雨莽苍苍	yan yu mang cang cang	1
+颜渊第十二	yan yuan di shi er	1
+颜渊季路侍	yan yuan ji lu shi	1
+颜渊喟然叹曰	yan yuan kui ran tan yue	1
+颜渊问仁	yan yuan wen ren	1
+严恽	yan yun	1
+燕昭王求士	yan zhao wang qiu shi	1
+燕赵之收藏	yan zhao zhi shou cang	1
+言者所以在意	yan zhe suo yi zai yi	1
+言者有言	yan zhe you yan	1
+严震	yan zhen	1
+颜真卿	yan zhen qing	1
+言之必可行也	yan zhi bi ke xing ye	1
+焉知二十载	yan zhi er shi zai	1
+颜之厚矣	yan zhi hou yi	1
+偃之言是也	yan zhi yan shi ye	1
+埏埴以为器	yan zhi yi wei qi	1
+燕子不归春事晚	yan zi bu gui chun shi wan	1
+晏子对曰	yan zi dui yue	1
+燕子合金瓯	yan zi he jin ou	1
+燕子衔泥两度新	yan zi xian ni liang du xin	1
+晏子治东阿	yan zi zhi dong e	1
+杨白花	yang bai hua	1
+杨伯岩	yang bo yan	1
+仰不足以事父母	yang bu zu yi shi fu mu	1
+杨乘	yang cheng	1
+杨持	yang chi	1
+阳春	yang chun	1
+阳春歌	yang chun ge	1
+阳春曲	yang chun qu	1
+阳春一曲和皆难	yang chun yi qu he jie nan	1
+杨德麟	yang de lin	1
+仰而视之曰	yang er shi zhi yue	1
+杨玢	yang fen	1
+羊公碑字在	yang gong bei zi zai	1
+杨冠卿	yang guan qing	1
+阳关曲	yang guan qu	1
+阳关万里道	yang guan wan li dao	1
+阳关引	yang guan yin	1
+杨汉公	yang han gong	1
+阳和不散穷途恨	yang he bu san qiong tu hen	1
+杨衡	yang heng	1
+杨厚	yang hou	1
+杨花更吹满	yang hua geng chui man	1
+杨花绕江啼晓莺	yang hua rao jiang ti xiao ying	1
+杨花似雪	yang hua si xue	1
+杨花雪落覆白苹	yang hua xue luo fu bai ping	1
+杨绘	yang hui	1
+杨徽之	yang hui zhi	1
+阳货第十七	yang huo di shi qi	1
+阳货欲见孔子	yang huo yu jian kong zi	1
+杨谏	yang jian	1
+杨景	yang jing	1
+杨敬述	yang jing shu	1
+杨敬之	yang jing zhi	1
+杨巨源	yang ju yuan	1
+杨均	yang jun	1
+杨浚	yang jun	1
+杨夔	yang kui	1
+仰聆金玉章	yang ling jin yu zhang	1
+杨柳东风树	yang liu dong feng shu	1
+杨柳渡头行客稀	yang liu du tou xing ke xi	1
+杨柳散和风	yang liu san he feng	1
+杨柳阴阴细雨晴	yang liu yin yin xi yu qing	1
+杨柳枝芳菲节	yang liu zhi fang fei jie	1
+杨鸾	yang luan	1
+扬眉结义黄金台	yang mei jie yi huang jin tai	1
+仰面贪看鸟	yang mian tan kan niao	1
+杨凝式	yang ning shi	1
+羊牛下括	yang niu xia kuo	1
+羊牛下来	yang niu xia lai	1
+杨叛儿	yang pan er	1
+仰攀人屡息	yang pan ren lv xi	1
+杨朴	yang pu	1
+杨樵云	yang qiao yun	1
+杨容华	yang rong hua	1
+杨汝士	yang ru shi	1
+养生丧死无憾	yang sheng sang si wu han	1
+杨适	yang shi	1
+仰视百鸟飞	yang shi bai niao fei	1
+杨师道	yang shi dao	1
+羊士谔	yang shi e	1
+杨氏为我	yang shi wei wo	1
+杨收	yang shou	1
+杨嗣复	yang si fu	1
+杨素	yang su	1
+杨损	yang sun	1
+阳台路	yang tai lu	1
+阳台梦	yang tai meng	1
+杨太尉	yang tai wei	1
+仰天大笑出门去	yang tian da xiao chu men qu	1
+仰天而叹	yang tian er tan	1
+仰天而嘘	yang tian er xu	1
+杨廷玉	yang ting yu	1
+仰头相向鸣	yang tou xiang xiang ming	1
+杨系	yang xi	1
+养形之人	yang xing zhi ren	1
+佯羞不出来	yang xiu bu chu lai	1
+杨续	yang xu	1
+杨颜	yang yan	1
+杨炎正	yang yan zheng	1
+漾漾泛菱荇	yang yang fan ling xing	1
+扬扬其香	yang yang qi xiang	1
+洋洋洒洒	yang yang sa sa	1
+扬扬燕新乳	yang yang yan xin ru	1
+杨於陵	yang yu ling	1
+杨虞卿	yang yu qing	1
+扬于王庭	yang yu wang ting	1
+阳月南飞雁	yang yue nan fei yan	1
+杨泽民	yang ze min	1
+扬之水	yang zhi shui	1
+扬州三首	yang zhou san shou	1
+阳子之宋	yang zi zhi song	1
+杳不知其所之也	yao bu zhi qi suo zhi ye	1
+瑶池阿母绮窗开	yao chi a mu qi chuang kai	1
+瑶池宴	yao chi yan	1
+瑶池燕	yao chi yan	1
+姚发	yao fa	1
+姚合	yao he	1
+肴核既尽	yao he ji jin	1
+姚鹄	yao hu	1
+瑶花	yao hua	1
+瑶花慢	yao hua man	1
+遥寄海西头	yao ji hai xi tou	1
+遥见仙人彩云里	yao jian xian ren cai yun li	1
+要将宇宙看稊米	yao jiang yu zhou kan ti mi	1
+遥看一处攒云树	yao kan yi chu cuan yun shu	1
+姚揆	yao kui	1
+遥窥正殿帘开处	yao kui zheng dian lian kai chu	1
+遥怜故园菊	yao lian gu yuan ju	1
+遥怜小儿女	yao lian xiao er nv	1
+姚伦	yao lun	1
+摇落深知宋玉悲	yao luo shen zhi song yu bei	1
+姚勉	yao mian	1
+尧让天下于许由	yao rang tian xia yu xu you	1
+邀人傅脂粉	yao ren fu zhi fen	1
+姚嵘	yao rong	1
+邀入赤松家	yao ru chi song jia	1
+腰若流纨素	yao ruo liu wan su	1
+尧舜其犹病诸	yao shun qi you bing zhu	1
+要似昆仑崩绝壁	yao si kun lun beng jue bi	1
+瑶台聚八仙	yao tai ju ba xian	1
+窈窕丹青户牖空	yao tiao dan qing hu you kong	1
+窈窕世无双	yao tiao shi wu shuang	1
+遥望九华峰	yao wang jiu hua feng	1
+遥望南天	yao wang nan tian	1
+摇尾而求食	yao wei er qiu shi	1
+妖为鬼蜮必成灾	yao wei gui yu bi cheng zai	1
+姚偓	yao wo	1
+邀我登云台	yao wo deng yun tai	1
+姚系	yao xi	1
+窈兮冥兮	yao xi ming xi	1
+腰下有龙泉	yao xia you long quan	1
+姚向	yao xiang	1
+遥想公谨当年	yao xiang gong jin dang nian	1
+遥相思	yao xiang si	1
+遥相望	yao xiang wang	1
+要向潇湘直进	yao xiang xiao xiang zhi jin	1
+腰悬相印作都统	yao xuan xiang yin zuo du tong	1
+喓喓草虫	yao yao cao chong	1
+夭夭如也	yao yao ru ye	1
+杳杳涯欲斑	yao yao ya yu ban	1
+遥遥一水间	yao yao yi shui jian	1
+遥夜泛清瑟	yao ye fan qing se	1
+遥有此寄	yao you ci ji	1
+药院滋苔纹	yao yuan zi tai wen	1
+尧曰第二十	yao yue di er shi	1
+姚月华	yao yue hua	1
+遥指红楼是妾家	yao zhi hong lou shi qie jia	1
+遥知朔漠多风雪	yao zhi shuo mo duo feng xue	1
+要之死日	yao zhi si ri	1
+要知松高洁	yao zhi song gao jie	1
+尧之为君也	yao zhi wei jun ye	1
+夭之沃沃	yao zhi wo wo	1
+要自拔其根	yao zi ba qi gen	1
+夜半真有力	ye ban zhen you li	1
+夜榜响溪石	ye bang xiang xi shi	1
+也被越来越多的	ye bei yue lai yue duo de	1
+叶采	ye cai	1
+也曾因梦送钱财	ye ceng yin meng song qian cai	1
+叶阊	ye chang	1
+夜长天色总难明	ye chang tian se zong nan ming	1
+夜池	ye chi	1
+夜鼎唯煎药	ye ding wei jian yao	1
+夜渡湘水	ye du xiang shui	1
+夜飞乐	ye fei yue	1
+夜复夜	ye fu ye	1
+叶公问政	ye gong wen zheng	1
+叶公语孔子曰	ye gong yu kong zi yue	1
+夜归临皋	ye gui lin gao	1
+夜归鹿门山歌	ye gui lu men shan ge	1
+野航恰受两三人	ye hang qia shou liang san ren	1
+也很特别	ye hen te bie	1
+夜后邀陪明月	ye hou yao pei ming yue	1
+野径入桑麻	ye jing ru sang ma	1
+叶景山	ye jing shan	1
+业就扁舟泛五湖	ye jiu pian zhou fan wu hu	1
+夜久侵罗袜	ye jiu qin luo wa	1
+夜久丝管绝	ye jiu si guan jue	1
+曳裾王门不称情	ye ju wang men bu cheng qing	1
+野哭千家闻战伐	ye ku qian jia wen zhan fa	1
+夜来花	ye lai hua	1
+夜来微雨洗芳尘	ye lai wei yu xi fang chen	1
+夜阑风静谷纹平	ye lan feng jing gu wen ping	1
+夜阑风静欲归时	ye lan feng jing yu gui shi	1
+夜阑更秉烛	ye lan geng bing zhu	1
+夜郎万里道	ye lang wan li dao	1
+野老苍颜一笑温	ye lao cang yan yi xiao wen	1
+野老念牧童	ye lao nian mu tong	1
+野老与人争席罢	ye lao yu ren zheng xi ba	1
+叶李	ye li	1
+野鹿呦呦走堂下	ye lu you you zou tang xia	1
+野幕蔽琼筵	ye mu bi qiong yan	1
+耶娘妻子走相送	ye niang qi zi zou xiang song	1
+叶清臣	ye qing chen	1
+夜如何其	ye ru he qi	1
+夜如何其夜未央	ye ru he qi ye wei yang	1
+夜如年	ye ru nian	1
+叶润	ye run	1
+野色开烟后	ye se kai yan hou	1
+夜上受降城闻笛	ye shang shou xiang cheng wen di	1
+夜深静卧百虫绝	ye shen jing wo bai chong jue	1
+夜市千灯照碧云	ye shi qian deng zhao bi yun	1
+野蔬充膳甘长藿	ye shu chong shan gan chang huo	1
+夜思	ye si	1
+野寺人来少	ye si ren lai shao	1
+夜宿寒山寺	ye su han shan si	1
+野桃含笑竹篱短	ye tao han xiao zhu li duan	1
+野田黄雀行	ye tian huang que xing	1
+夜听风雨声	ye ting feng yu sheng	1
+夜未艾	ye wei ai	1
+夜未央	ye wei yang	1
+夜闻马嘶晓无迹	ye wen ma si xiao wu ji	1
+耶溪采莲女	ye xi cai lian nv	1
+耶溪泛舟	ye xi fan zhou	1
+叶下洞庭初	ye xia dong ting chu	1
+夜下征虏亭	ye xia zheng lu ting	1
+夜乡晨	ye xiang chen	1
+夜行船	ye xing chuan	1
+夜夜不得息	ye ye bu de xi	1
+夜夜达五更	ye ye da wu geng	1
+夜夜当秉烛	ye ye dang bing zhu	1
+叶叶相交通	ye ye xiang jiao tong	1
+烨烨震电	ye ye zhen dian	1
+夜以继日	ye yi ji ri	1
+夜已央	ye yi yang	1
+夜饮	ye yin	1
+夜吟应讶玉绳低	ye yin ying ya yu sheng di	1
+也应攀折他人手	ye ying pan zhe ta ren shou	1
+野营万里无城郭	ye ying wan li wu cheng guo	1
+野有蔓草	ye you man cao	1
+野有死麕	ye you si qun	1
+夜雨剪春韭	ye yu jian chun jiu	1
+夜雨翦春韭	ye yu jian chun jiu	1
+野语有之曰	ye yu you zhi yue	1
+叶元良	ye yuan liang	1
+夜月愁空山	ye yue chou kong shan	1
+野月满庭隅	ye yue man ting yu	1
+野云万里无城郭	ye yun wan li wu cheng guo	1
+野哉由也	ye zai you ye	1
+野战格斗死	ye zhan ge dou si	1
+野竹攒石生	ye zhu cuan shi sheng	1
+叶祖义	ye zu yi	1
+夜坐吟	ye zuo yin	1
+以敖以游	yi ao yi you	1
+以八千岁为春	yi ba qian sui wei chun	1
+一百四十年	yi bai si shi nian	1
+以百姓为刍狗	yi bai xing wei chu gou	1
+以百姓心为心	yi bai xing xin wei xin	1
+一百字	yi bai zi	1
+一般消受	yi ban xiao shou	1
+一半子	yi ban zi	1
+以邦观邦	yi bang guan bang	1
+已报生擒吐谷浑	yi bao sheng qin tu yu hun	1
+一杯春露冷如冰	yi bei chun lu leng ru bing	1
+一杯相属君当歌	yi bei xiang zhu jun dang ge	1
+一杯一杯复一杯	yi bei yi bei fu yi bei	1
+衣弊履穿	yi bi lv chuan	1
+一别二十年	yi bie er shi nian	1
+一别心知两地秋	yi bie xin zhi liang di qiu	1
+一钵千家饭	yi bo qian jia fan	1
+一波三折之笔	yi bo san zhe zhi bi	1
+以补不足	yi bu bu zu	1
+亦不减	yi bu jian	1
+以不教民战	yi bu jiao min zhan	1
+意不尽	yi bu jin	1
+亦不可行也	yi bu ke xing ye	1
+亦不能至也	yi bu neng zhi ye	1
+亦不女从	yi bu nv cong	1
+以不忍人之心	yi bu ren ren zhi xin	1
+亦不入于室	yi bu ru yu shi	1
+亦不甚惜	yi bu shen xi	1
+亦不失言	yi bu shi yan	1
+以不同形相禅	yi bu tong xing xiang chan	1
+一不孝也	yi bu xiao ye	1
+忆长安	yi chang an	1
+一唱都护歌	yi chang du hu ge	1
+一唱雄鸡天下白	yi chang xiong ji tian xia bai	1
+一重山两重山	yi chong shan liang chong shan	1
+伊川令	yi chuan ling	1
+忆吹箫	yi chui xiao	1
+以慈卫之	yi ci wei zhi	1
+以此下心意	yi ci xia xin yi	1
+一从大地起风雷	yi cong da di qi feng lei	1
+依丛适自憩	yi cong shi zi qi	1
+一寸金	yi cun jin	1
+一寸同心缕	yi cun tong xin lv	1
+以待大王来	yi dai da wang lai	1
+一代风流尽	yi dai feng liu jin	1
+一代天骄	yi dai tian jiao	1
+已带斜阳又带蝉	yi dai xie yang you dai chan	1
+一旦不能有	yi dan bu neng you	1
+一旦红颜为君尽	yi dan hong yan wei jun jin	1
+以当南日	yi dang nan ri	1
+以道观之	yi dao guan zhi	1
+以道莅天下	yi dao li tian xia	1
+以道事君	yi dao shi jun	1
+以道佐人主者	yi dao zuo ren zhu zhe	1
+以德报德	yi de bao de	1
+以德报怨	yi de bao yuan	1
+以德分人谓之圣	yi de fen ren wei zhi sheng	1
+以德服人者	yi de fu ren zhe	1
+忆得去年春风至	yi de qu nian chun feng zhi	1
+以德行仁者王	yi de xing ren zhe wang	1
+忆帝京	yi di jing	1
+夷狄之有君	yi di zhi you jun	1
+一点春	yi dian chun	1
+一点分明值万金	yi dian fen ming zhi wan jin	1
+一点浩然气	yi dian hao ran qi	1
+倚迭如山	yi die ru shan	1
+一董	yi dong	1
+忆东山二首	yi dong shan er shou	1
+一斗合自然	yi dou he zi ran	1
+已断燕鸿初起势	yi duan yan hong chu qi shi	1
+猗顿之富	yi dun zhi fu	1
+一朵芙蓉	yi duo fu rong	1
+一朵红苏旋欲融	yi duo hong su xuan yu rong	1
+忆多娇	yi duo jiao	1
+亦多可悲	yi duo ke bei	1
+以多问于寡	yi duo wen yu gua	1
+以尔车来	yi er che lai	1
+一二三四五	yi er san si wu	1
+宜尔室家	yi er shi jia	1
+已而遂晴	yi er sui qing	1
+已而为知者	yi er wei zhi zhe	1
+已而已而	yi er yi er	1
+宜尔子孙	yi er zi sun	1
+伊璠	yi fan	1
+亦泛其流	yi fan qi liu	1
+意方远	yi fang yuan	1
+宜芬公主	yi fen gong zhu	1
+仪封人请见	yi feng ren qing jian	1
+一夫当关	yi fu dang guan	1
+役夫敢申恨	yi fu gan shen hen	1
+以服事殷	yi fu shi yin	1
+弋凫与雁	yi fu yu yan	1
+以告者过也	yi gao zhe guo ye	1
+倚歌而和之	yi ge er he zhi	1
+一个朴素	yi ge pu su	1
+夷歌数处起渔樵	yi ge shu chu qi yu qiao	1
+亦各言其志也	yi ge yan qi zhi ye	1
+一更山吐月	yi geng shan tu yue	1
+一宫之间	yi gong zhi jian	1
+一钩残月向西流	yi gou can yue xiang xi liu	1
+忆故人	yi gu ren	1
+已惯天涯莫浪愁	yi guan tian ya mo lang chou	1
+已过三寒食	yi guo san han shi	1
+一行白鹭上青天	yi hang bai lu shang qing tian	1
+衣笐妆台蛛结网	yi hang zhuang tai zhu jie wang	1
+一鹤东飞过沧海	yi he dong fei guo cang hai	1
+以和为量	yi he wei liang	1
+一痕沙	yi hen sha	1
+遗恨失吞吴	yi hen shi tun wu	1
+异乎三子者之撰	yi hu san zi zhe zhi zhuan	1
+依乎天理	yi hu tian li	1
+异乎吾所闻	yi hu wu suo wen	1
+一斛珠	yi hu zhu	1
+已化而生	yi hua er sheng	1
+以火来照所见稀	yi huo lai zhao suo jian xi	1
+亦既觏止	yi ji gou zhi	1
+亦既见止	yi ji jian zhi	1
+一肌一容	yi ji yi rong	1
+以家观家	yi jia guan jia	1
+移家虽带郭	yi jia sui dai guo	1
+一家有六口	yi jia you liu kou	1
+一剑曾当百万师	yi jian ceng dang bai wan shi	1
+一翦梅	yi jian mei	1
+已见松柏摧为薪	yi jian song bai cui wei xin	1
+一箭正坠双飞翼	yi jian zheng zhui shuang fei yi	1
+意匠惨淡经营中	yi jiang can dan jing ying zhong	1
+一江春水	yi jiang chun shui	1
+一江风	yi jiang feng	1
+以降甘露	yi jiang gan lu	1
+宜将剩勇追穷寇	yi jiang sheng yong zhui qiong kou	1
+宜将胜勇追穷寇	yi jiang sheng yong zhui qiong kou	1
+忆江月	yi jiang yue	1
+一叫千回首	yi jiao qian hui shou	1
+一叫一回肠一断	yi jiao yi hui chang yi duan	1
+猗嗟	yi jie	1
+一截还东国	yi jie hai dong guo	1
+以介眉寿	yi jie mei shou	1
+一截遗欧	yi jie yi ou	1
+一截赠美	yi jie zeng mei	1
+以就有道	yi jiu you dao	1
+逸居而无教	yi ju er wu jiao	1
+一举累十觞	yi ju lei shi shang	1
+一句中	yi ju zhong	1
+已觉山川是两乡	yi jue shan chuan shi liang xiang	1
+贻厥孙谋	yi jue sun mou	1
+忆君泪落东流水	yi jun lei luo dong liu shui	1
+忆君迢迢隔青天	yi jun tiao tiao ge qing tian	1
+忆君王	yi jun wang	1
+伊可怀也	yi ke huai ye	1
+亦可以弗畔矣夫	yi ke yi fu pan yi fu	1
+亦可以为成人矣	yi ke yi wei cheng ren yi	1
+亦可宗也	yi ke zong ye	1
+亦孔之固	yi kong zhi gu	1
+一口吸尽西江水	yi kou xi jin xi jiang shui	1
+一雷惊蛰始	yi lei jing zhe shi	1
+以礼存心	yi li cun xin	1
+以力服人者	yi li fu ren zhe	1
+以利为本	yi li wei ben	1
+倚立自移时	yi li zi yi shi	1
+以临其民	yi lin qi min	1
+一龙一蛇	yi long yi she	1
+倚楼高望极	yi lou gao wang ji	1
+依楼似月悬	yi lou si yue xuan	1
+一路经行处	yi lu jing xing chu	1
+一纶茧缕一轻钩	yi lun jian lv yi qing gou	1
+一络索	yi luo suo	1
+一落索	yi luo suo	1
+忆萝月	yi luo yue	1
+以媚一世	yi mei yi shi	1
+医门多疾	yi men duo ji	1
+遗民几度垂垂老	yi min ji du chui chui lao	1
+异名同实	yi ming tong shi	1
+意难忘	yi nan wang	1
+以能问于不能	yi neng wen yu bu neng	1
+一年春	yi nian chun	1
+一捻红	yi nian hong	1
+一年明月今宵多	yi nian ming yue jin xiao duo	1
+一年能几团圆月	yi nian neng ji tuan yuan yue	1
+一年生意属流尘	yi nian sheng yi shu liu chen	1
+一年衔别怨	yi nian xian bie yuan	1
+一年一度秋风劲	yi nian yi du qiu feng jin	1
+一年一年老去	yi nian yi nian lao qu	1
+一鸟花间鸣	yi niao hua jian ming	1
+一怒而诸侯惧	yi nu er zhu hou ju	1
+一篇读罢头飞雪	yi pian du ba tou fei xue	1
+一片光明	yi pian guang ming	1
+一片神行	yi pian shen xing	1
+一片汪洋都不见	yi pian wang yang dou bu jian	1
+一片西飞一片东	yi pian xi fei yi pian dong	1
+以其不争	yi qi bu zheng	1
+以其不自生	yi qi bu zi sheng	1
+以其存心也	yi qi cun xin ye	1
+夷齐饿死终无成	yi qi e si zhong wu cheng	1
+宜其家人	yi qi jia ren	1
+宜其家室	yi qi jia shi	1
+意气骄奢剧季伦	yi qi jiao she ju ji lun	1
+一七令	yi qi ling	1
+意气勤勤恳恳	yi qi qin qin ken ken	1
+以其求思之深	yi qi qiu si zhi shen	1
+以其善下之	yi qi shan xia zhi	1
+宜其室家	yi qi shi jia	1
+意气素霓生	yi qi su ni sheng	1
+移其粟于河内	yi qi su yu he nei	1
+以其心得其常心	yi qi xin de qi chang xin	1
+以其兄之子妻之	yi qi xiong zhi zi qi zhi	1
+以奇用兵	yi qi yong bing	1
+意气由来排灌夫	yi qi you lai pai guan fu	1
+以其知得其心	yi qi zhi de qi xin	1
+以其智多	yi qi zhi duo	1
+以其子妻之	yi qi zi qi zhi	1
+依前春恨锁重楼	yi qian chun hen suo chong lou	1
+一千顷	yi qian qing	1
+一桥飞架南北	yi qiao fei jia nan bei	1
+忆秦娥娄山关	yi qin e lou shan guan	1
+一清一浊	yi qing yi zhuo	1
+以求长生	yi qiu chang sheng	1
+一丘尝欲卧	yi qiu chang yu wo	1
+一曲清歌	yi qu qing ge	1
+一去一万里	yi qu yi wan li	1
+一去紫台连朔漠	yi qu zi tai lian shuo mo	1
+一群娇鸟共啼花	yi qun jiao niao gong ti hua	1
+义然后取	yi ran hou qu	1
+怡然敬父执	yi ran jing fu zhi	1
+衣染异方尘	yi ran yi fang chen	1
+揖让而升	yi rang er sheng	1
+揖让月在手	yi rang yue zai shou	1
+宜人独桂林	yi ren du gui lin	1
+已忍伶俜十年事	yi ren ling ping shi nian shi	1
+忆人人	yi ren ren	1
+一人之心	yi ren zhi xin	1
+一日克己复礼	yi ri ke ji fu li	1
+一日如三秋	yi ri ru san qiu	1
+一日心期千劫在	yi ri xin qi qian jie zai	1
+一日须倾三百杯	yi ri xu qing san bai bei	1
+一日之内	yi ri zhi nei	1
+翼若垂天之云	yi ruo chui tian zhi yun	1
+亦若此矣	yi ruo ci yi	1
+亦若是则已矣	yi ruo shi ze yi yi	1
+以若所为	yi ruo suo wei	1
+以弱天下之民	yi ruo tian xia zhi min	1
+抑若扬兮	yi ruo yang xi	1
+以色事他人	yi se shi ta ren	1
+一山飞峙大江边	yi shan fei zhi da jiang bian	1
+衣上灞陵雨	yi shang ba ling yu	1
+衣裳楚楚	yi shang chu chu	1
+一晌偎人颤	yi shang wei ren chan	1
+衣裳已施行看尽	yi shang yi shi xing kan jin	1
+一上玉关道	yi shang yu guan dao	1
+一身能擘两雕弧	yi shen neng bo liang diao hu	1
+一身无所求	yi shen wu suo qiu	1
+一身转战三千里	yi shen zhuan zhan san qian li	1
+一生肝胆向人尽	yi sheng gan dan xiang ren jin	1
+一生好入名山游	yi sheng hao ru ming shan you	1
+一声何满子	yi sheng he man zi	1
+一生何所求	yi sheng he suo qiu	1
+一声鸡唱	yi sheng ji chang	1
+一生几许伤心事	yi sheng ji xu shang xin shi	1
+忆生来	yi sheng lai	1
+遗声落西秦	yi sheng luo xi qin	1
+一声羌笛	yi sheng qiang di	1
+一声已动物皆静	yi sheng yi dong wu jie jing	1
+益生曰祥	yi sheng yue xiang	1
+一生长对水晶盘	yi sheng zhang dui shui jing pan	1
+忆事	yi shi	1
+易时不易性	yi shi bu yi xing	1
+疑是故人来	yi shi gu ren lai	1
+义士还乡尽锦衣	yi shi huan xiang jin jin yi	1
+一时回首月中看	yi shi hui shou yue zhong kan	1
+疑是林花昨夜开	yi shi lin hua zuo ye kai	1
+一时起	yi shi qi	1
+一诗千改始心安	yi shi qian gai shi xin an	1
+疑是山阴雪后来	yi shi shan yin xue hou lai	1
+以诗言志	yi shi yan zhi	1
+以手抚膺坐长叹	yi shou fu ying zuo chang tan	1
+以手阖门	yi shou he men	1
+以守则固	yi shou ze gu	1
+一树碧无情	yi shu bi wu qing	1
+倚树沉眠日已斜	yi shu chen mian ri yi xie	1
+一树寒梅白玉条	yi shu han mei bai yu tiao	1
+一树梨花落晚风	yi shu li hua luo wan feng	1
+以舒其愤	yi shu qi fen	1
+驿树西连汉畤平	yi shu xi lian han chou ping	1
+以水救水	yi shui jiu shui	1
+以顺天下	yi shun tian xia	1
+易思	yi si	1
+已似长沙傅	yi si chang sha fu	1
+一丝风	yi si feng	1
+以俟君子	yi si jun zi	1
+一送	yi song	1
+以俗观之	yi su guan zhi	1
+已诉征求贫到骨	yi su zheng qiu pin dao gu	1
+一岁四行役	yi sui si hang yi	1
+忆岁月	yi sui yue	1
+亦遂增胜	yi sui zeng sheng	1
+一索功高缚楚王	yi suo gong gao fu chu wang	1
+揖所与立	yi suo yu li	1
+一弹一十有八拍	yi tan yi shi you ba pai	1
+一弹再三叹	yi tan zai san tan	1
+以天下观天下	yi tian xia guan tian xia	1
+以天下之所顺	yi tian xia zhi suo shun	1
+倚天照海花无数	yi tian zhao hai hua wu shu	1
+一汀烟雨杏花寒	yi ting yan yu xing hua han	1
+已外天下矣	yi wai tian xia yi	1
+一万年太久	yi wan nian tai jiu	1
+以万物为刍狗	yi wan wu wei chu gou	1
+以望复关	yi wang fu guan	1
+一望弥千里	yi wang mi qian li	1
+义往难复留	yi wang nan fu liu	1
+一往情深深几许	yi wang qing shen shen ji xu	1
+抑王兴甲兵	yi wang xing jia bing	1
+以危父母	yi wei fu mu	1
+以为桂林	yi wei gui lin	1
+一苇杭之	yi wei hang zhi	1
+以为莫己若者	yi wei mo ji ruo zhe	1
+一为迁客去长沙	yi wei qian ke qu chang sha	1
+一为取龙城	yi wei qu long cheng	1
+伊威在室	yi wei zai shi	1
+抑为之不厌	yi wei zhi bu yan	1
+已闻清比圣	yi wen qing bi sheng	1
+以我独沉久	yi wo du chen jiu	1
+以我贿迁	yi wo hui qian	1
+移我琉璃榻	yi wo liu li ta	1
+贻我彤管	yi wo tong guan	1
+以我为楷模	yi wo wei kai mo	1
+佚我以老	yi wo yi lao	1
+以我应他人	yi wo ying ta ren	1
+以我御穷	yi wo yu qiong	1
+以五百岁为春	yi wu bai sui wei chun	1
+以吾从大夫之后	yi wu cong dai fu zhi hou	1
+以物观之	yi wu guan zhi	1
+以无厚入有间	yi wu hou ru you jian	1
+一舞剑器动四方	yi wu jian qi dong si fang	1
+一舞剑气动四方	yi wu jian qi dong si fang	1
+揖巫马期而进之	yi wu ma qi er jin zhi	1
+以五十步笑百步	yi wu shi bu xiao bai bu	1
+以无事取天下	yi wu shi qu tian xia	1
+以物为量	yi wu wei liang	1
+以吾一日长乎尔	yi wu yi ri zhang hu er	1
+疑误有新知	yi wu you xin zhi	1
+伊昔红颜美少年	yi xi hong yan mei shao nian	1
+忆昔开元全盛日	yi xi kai yuan quan sheng ri	1
+羿昔落九乌	yi xi luo jiu wu	1
+忆昔霓旌下南苑	yi xi ni jing xia nan yuan	1
+一洗万古凡马空	yi xi wan gu fan ma kong	1
+一夕小敷山下梦	yi xi xiao fu shan xia meng	1
+忆昔巡幸新丰宫	yi xi xun xing xin feng gong	1
+依稀掩映	yi xi yan ying	1
+一西一东	yi xi yi dong	1
+亦奚以为	yi xi yi wei	1
+以下见	yi xia jian	1
+一先	yi xian	1
+一闲对百忙	yi xian dui bai mang	1
+一弦清一心	yi xian qing yi xin	1
+一弦一柱思华年	yi xian yi zhu si hua nian	1
+忆仙姿	yi xian zi	1
+以乡观乡	yi xiang guan xiang	1
+一向花前看白发	yi xiang hua qian kan bai fa	1
+忆向天阶问紫芝	yi xiang tian jie wen zi zhi	1
+一乡之善士	yi xiang zhi shan shi	1
+一笑倾城欢	yi xiao qing cheng huan	1
+一笑相倾国便亡	yi xiao xiang qing guo bian wang	1
+以小易大	yi xiao yi da	1
+以写我忧	yi xie wo you	1
+宜兄宜弟	yi xiong yi di	1
+一宿行人自可愁	yi xiu xing ren zi ke chou	1
+衣绣夜行	yi xiu ye xing	1
+噫吁戏	yi xu xi	1
+噫吁戏危乎高哉	yi xu xi wei hu gao zai	1
+一虚一满	yi xu yi man	1
+一薛居州	yi xue ju zhou	1
+一言而可以兴邦	yi yan er ke yi xing bang	1
+一言而丧邦	yi yan er sang bang	1
+遗言冀可冥	yi yan ji ke ming	1
+一言为重百金轻	yi yan wei chong bai jin qing	1
+一言以蔽之	yi yan yi bi zhi	1
+一言以为不知	yi yan yi wei bu zhi	1
+宜言饮酒	yi yan yin jiu	1
+一样悲欢逐逝波	yi yang bei huan zhu shi bo	1
+宜阳城下草萋萋	yi yang cheng xia cao qi qi	1
+一样花	yi yang hua	1
+一扬眉	yi yang mei	1
+以养民人	yi yang min ren	1
+以羊易之	yi yang yi zhi	1
+忆瑶姬	yi yao ji	1
+一夜飞度镜湖月	yi ye fei du jing hu yue	1
+一夜飞渡镜湖月	yi ye fei du jing hu yue	1
+一夜好风吹	yi ye hao feng chui	1
+一叶落	yi ye luo	1
+一夜梦中香	yi ye meng zhong xiang	1
+一叶随风忽报秋	yi ye sui feng hu bao qiu	1
+一夜絮征袍	yi ye xu zheng pao	1
+一叶叶	yi ye ye	1
+一夜一心死	yi ye yi xin si	1
+一叶舟轻	yi ye zhou qing	1
+以意逆志	yi yi ni zhi	1
+曀曀其阴	yi yi qi yin	1
+怡怡如也	yi yi ru ye	1
+一一生绿苔	yi yi sheng lv tai	1
+抑亦先觉者	yi yi xian jue zhe	1
+依依向物华	yi yi xiang wu hua	1
+疑义相与析	yi yi xiang yu xi	1
+依依墟里烟	yi yi xu li yan	1
+亦已焉哉	yi yi yan zai	1
+意疑倚巴丘	yi yi yi ba qiu	1
+已矣已矣尚何道	yi yi yi yi shang he dao	1
+亦以御冬	yi yi yu dong	1
+已矣哉	yi yi zai	1
+以阴以雨	yi yin yi yu	1
+意映卿卿如晤	yi ying qing qing ru wu	1
+以应无穷	yi ying wu qiong	1
+已映洲前芦荻花	yi ying zhou qian lu di hua	1
+以永今夕	yi yong jin xi	1
+疑有碧桃千树花	yi you bi tao qian shu hua	1
+以友辅仁	yi you fu ren	1
+邑有流亡愧俸钱	yi you liu wang kui feng qian	1
+贻友人	yi you ren	1
+亦有仁义而已矣	yi you ren yi er yi yi	1
+意有所随	yi you suo sui	1
+以游无极之野	yi you wu ji zhi ye	1
+以游无穷者	yi you wu qiong zhe	1
+亦有兄弟	yi you xiong di	1
+以有涯随无涯	yi you ya sui wu ya	1
+忆余杭	yi yu hang	1
+以御今之有	yi yu jin zhi you	1
+意欲凌风翔	yi yu ling feng xiang	1
+以愚黔首	yi yu qian shou	1
+抑与之与	yi yu zhi yu	1
+一月不梳头	yi yue bu shu tou	1
+一月三捷	yi yue san jie	1
+依约是湘灵	yi yue shi xiang ling	1
+以约失之者鲜矣	yi yue shi zhi zhe xian yi	1
+一月又一月	yi yue you yi yue	1
+以阅众甫	yi yue zhong fu	1
+一则以惧	yi ze yi ju	1
+一则以喜	yi ze yi xi	1
+一摘使瓜好	yi zhai shi gua hao	1
+倚杖柴门外	yi zhang chai men wai	1
+倚杖候荆扉	yi zhang hou jing fei	1
+一棹春风一叶舟	yi zhao chun feng yi ye zhou	1
+一朝辞此地	yi zhao ci ci di	1
+一朝得成功	yi zhao de cheng gong	1
+一朝卧病无相识	yi zhao wo bing wu xiang shi	1
+亿兆一心	yi zhao yi xin	1
+一朝之忿	yi zhao zhi fen	1
+弋者何所慕	yi zhe he suo mu	1
+益者三乐	yi zhe san le	1
+倚枕钗横鬓乱	yi zhen chai heng bin luan	1
+一枕初寒梦不成	yi zhen chu han meng bu cheng	1
+忆真妃	yi zhen fei	1
+一枕黄梁再现	yi zhen huang liang zai xian	1
+一枕黄粱再现	yi zhen huang liang zai xian	1
+以正治国	yi zheng zhi guo	1
+以直报怨	yi zhi bao yuan	1
+一枝春	yi zhi chun	1
+义之端也	yi zhi duan ye	1
+一枝红艳露凝香	yi zhi hong yan lu ning xiang	1
+一枝花	yi zhi hua	1
+以知其子	yi zhi qi zi	1
+以致天下之士	yi zhi tian xia zhi shi	1
+以直养而无害	yi zhi yang er wu hai	1
+以至于无为	yi zhi yu wu wei	1
+以指喻指之非指	yi zhi yu zhi zhi fei zhi	1
+已知之矣	yi zhi zhi yi	1
+易重	yi zhong	1
+一种可怜生	yi zhong ke lian sheng	1
+伊州令	yi zhou ling	1
+一字不救饥	yi zi bu jiu ji	1
+一自胡尘入汉关	yi zi hu chen ru han guan	1
+亦自是一家	yi zi shi yi jia	1
+亦足以发	yi zu yi fa	1
+忆醉	yi zui	1
+一醉累月轻王侯	yi zui lei yue qing wang hou	1
+一尊还酹江月	yi zun hai lei jiang yue	1
+以作时世贤	yi zuo shi shi xian	1
+以佐五谷	yi zuo wu gu	1
+银鞍白马度春风	yin an bai ma du chun feng	1
+吟安一个字	yin an yi ge zi	1
+银鞍照白马	yin an zhao bai ma	1
+因步其韵奉和	yin bu qi yun feng he	1
+因不失其亲	yin bu shi qi qin	1
+饮茶粤海未能忘	yin cha yue hai wei neng wang	1
+隐处唯孤云	yin chu wei gu yun	1
+殷琮	yin cong	1
+因而和焉	yin er he yan	1
+因非因是	yin fei yin shi	1
+因风想玉珂	yin feng xiang yu ke	1
+吟风韵更长	yin feng yun geng chang	1
+引竿自刺船	yin gan zi ci chuan	1
+饮高秋之坠露	yin gao qiu zhi zhui lu	1
+饮酣视八极	yin han shi ba ji	1
+银汉无声转玉盘	yin han wu sheng zhuan yu pan	1
+银河吹笙	yin he chui sheng	1
+银河倒挂三石梁	yin he dao gua san shi liang	1
+银河亲挽	yin he qin wan	1
+因河为池	yin he wei chi	1
+尹焕	yin huan	1
+隐患险于明火	yin huan xian yu ming huo	1
+因击沛公于坐	yin ji pei gong yu zuo	1
+引驾行	yin jia xing	1
+殷鉴不远	yin jian bu yuan	1
+阴精此沦惑	yin jing ci lun huo	1
+隐居放言	yin ju fang yan	1
+隐居山	yin ju shan	1
+隐居以求其志	yin ju yi qiu qi zhi	1
+饮君酒	yin jun jiu	1
+因利乘便	yin li cheng bian	1
+殷礼吾能言之	yin li wu neng yan zhi	1
+饮露身何洁	yin lu shen he jie	1
+隐峦	yin luan	1
+饮马渡秋水	yin ma du qiu shui	1
+饮马歌	yin ma ge	1
+引蔓故不长	yin man gu bu chang	1
+尹懋	yin mao	1
+吟弄风月	yin nong feng yue	1
+吟弄天上春	yin nong tian shang chun	1
+尹璞	yin pu	1
+因其固然	yin qi gu ran	1
+殷其雷	yin qi lei	1
+饮其流者怀其源	yin qi liu zhe huai qi yuan	1
+殷七七	yin qi qi	1
+吟乔	yin qiao	1
+殷勤说	yin qin shuo	1
+殷勤移植地	yin qin yi zhi di	1
+殷勤昨夜三更雨	yin qin zuo ye san geng yu	1
+阴晴众壑殊	yin qing zhong he shu	1
+因求假暂归	yin qiu jia zan gui	1
+因人作远游	yin ren zuo yuan you	1
+饮如长鲸吸百川	yin ru chang jing xi bai chuan	1
+隐若白虹起	yin ruo bai hong qi	1
+阴山道	yin shan dao	1
+尹式	yin shi	1
+因是因非	yin shi yin fei	1
+吟诗作赋北窗里	yin shi zuo fu bei chuang li	1
+因望月有感	yin wang yue you gan	1
+因为长句	yin wei chang ju	1
+殷文圭	yin wen gui	1
+因无恒心	yin wu heng xin	1
+蚓无爪牙之利	yin wu zhao ya zhi li	1
+因休暇	yin xiu xia	1
+阴阳调和	yin yang tiao he	1
+殷遥	yin yao	1
+殷尧藩	yin yao fan	1
+殷益	yin yi	1
+殷寅	yin yin	1
+隐隐飞桥隔野烟	yin yin fei qiao ge ye yan	1
+隐隐何甸甸	yin yin he dian dian	1
+阴阴夏木啭黄鹂	yin yin xia mu zhuan huang li	1
+殷因与夏礼	yin yin yu xia li	1
+因招樊哙出	yin zhao fan kuai chu	1
+隐者自怡悦	yin zhe zi yi yue	1
+银筝夜久殷勤弄	yin zheng ye jiu yin qin nong	1
+因之传远情	yin zhi chuan yuan qing	1
+因之以饥馑	yin zhi yi ji jin	1
+银烛吐青烟	yin zhu tu qing yan	1
+应傍战场开	ying bang zhan chang kai	1
+应玚	ying chang	1
+应长天	ying chang tian	1
+迎春来	ying chun lai	1
+应而不藏	ying er bu cang	1
+英风豪气今何在	ying feng hao qi jin he zai	1
+应共冤魂语	ying gong yuan hun yu	1
+莺呼起	ying hu qi	1
+樱花永巷垂杨岸	ying hua yong xiang chui yang an	1
+鹰击长空	ying ji chang kong	1
+应见陇头梅	ying jian long tou mei	1
+应将性命逐轻车	ying jiang xing ming zhu qing che	1
+应尽便须尽	ying jin bian xu jin	1
+婴金铁受辱	ying jin tie shou ru	1
+应景乐	ying jing le	1
+盈科而后进	ying ke er hou jin	1
+应怜半死白头翁	ying lian ban si bai tou weng	1
+应怜脂粉气	ying lian zhi fen qi	1
+赢粮而景从	ying liang er jing cong	1
+英灵尽来归	ying ling jin lai gui	1
+影落明湖青黛光	ying luo ming hu qing dai guang	1
+映门淮水绿	ying men huai shui lv	1
+英气勃勃	ying qi bo bo	1
+嘤其鸣矣	ying qi ming yi	1
+莹若烧玉英	ying ruo shao yu ying	1
+映山红	ying shan hong	1
+莺声绕红楼	ying sheng rao hong lou	1
+应是钓秋水	ying shi diao qiu shui	1
+樱桃花下	ying tao hua xia	1
+樱桃落尽春归去	ying tao luo jin chun gui qu	1
+莺啼如有泪	ying ti ru you lei	1
+莺啼山客犹眠	ying ti shan ke you mian	1
+莺啼送客闻	ying ti song ke wen	1
+莺啼燕语报新年	ying ti yan yu bao xin nian	1
+颖亭留别	ying ting liu bie	1
+应驮白练到安西	ying tuo bai lian dao an xi	1
+应为别离多	ying wei bie li duo	1
+鹦鹉杯	ying wu bei	1
+鹦鹉来过吴江水	ying wu lai guo wu jiang shui	1
+鹦鹉鸟	ying wu niao	1
+鹦鹉前头不敢言	ying wu qian tou bu gan yan	1
+鹦鹉曲	ying wu qu	1
+鹦鹉洲	ying wu zhou	1
+影响所及	ying xiang suo ji	1
+迎新春	ying xin chun	1
+英雄割据虽已矣	ying xiong ge ju sui yi yi	1
+英雄五霸闹春秋	ying xiong wu ba nao chun qiu	1
+英雄业绩	ying xiong ye ji	1
+英雄之言	ying xiong zhi yan	1
+应须记	ying xu ji	1
+盈虚者如彼	ying xu zhe ru bi	1
+荧荧贝叶宫	ying ying bei ye gong	1
+营营何所求	ying ying he suo qiu	1
+应有未招魂	ying you wei zhao hun	1
+影湛波平	ying zhan bo ping	1
+迎之不见其首	ying zhi bu jian qi shou	1
+颖州	ying zhou	1
+营州少年厌原野	ying zhou shao nian yan yuan ye	1
+莺啭皇州春色阑	ying zhuan huang zhou chun se lan	1
+英姿飒爽犹酣战	ying zi sa shuang you han zhan	1
+勇而无礼则乱	yong er wu li ze luan	1
+鄘风	yong feng	1
+咏风兰	yong feng lan	1
+勇夫安识义	yong fu an shi yi	1
+永和三日荡轻舟	yong he san ri dang qing zhou	1
+咏槐	yong huai	1
+永怀愁不寐	yong huai chou bu mei	1
+永怀当此节	yong huai dang ci jie	1
+拥彗折节无嫌猜	yong hui zhe jie wu xian cai	1
+拥炉开酒缸	yong lu kai jiu gang	1
+永念难消释	yong nian nan xiao shi	1
+永日方戚戚	yong ri fang qi qi	1
+用舍由时	yong she you shi	1
+勇士不忘丧其元	yong shi bu wang sang qi yuan	1
+永矢弗谖	yong shi fu xuan	1
+雍虽不敏	yong sui bu min	1
+咏闲	yong xian	1
+永巷长年怨绮罗	yong xiang chang nian yuan qi luo	1
+永相随	yong xiang sui	1
+用心一也	yong xin yi ye	1
+用心躁也	yong xin zao ye	1
+永言配命	yong yan pei ming	1
+永言孝思	yong yan xiao si	1
+用药如用兵	yong yao ru yong bing	1
+雍也第六	yong ye di liu	1
+永夜角声悲自语	yong ye jiao sheng bei zi yu	1
+雍也可使南面	yong ye ke shi nan mian	1
+永夜月同孤	yong ye yue tong gu	1
+咏意	yong yi	1
+永以为好也	yong yi wei hao ye	1
+拥雍州之地	yong yong zhou zhi di	1
+雍裕之	yong yu zhi	1
+踊跃用兵	yong yue yong bing	1
+勇者不必有仁	yong zhe bu bi you ren	1
+勇者竭其力	yong zhe jie qi li	1
+用志不分	yong zhi bu fen	1
+用之不竭	yong zhi bu jie	1
+用之不足既	yong zhi bu zu ji	1
+用之如泥沙	yong zhi ru ni sha	1
+用之所趋异也	yong zhi suo qu yi ye	1
+雍之言然	yong zhi yan ran	1
+泳之游之	yong zhi you zhi	1
+用之则行	yong zhi ze xing	1
+拥肿之与居	yong zhong zhi yu ju	1
+雍州之地	yong zhou zhi di	1
+咏拙	yong zhuo	1
+又被河声搅碎	you bei he sheng jiao sui	1
+有碑仆道	you bei pu dao	1
+有悲往事	you bei wang shi	1
+有本者如是	you ben zhe ru shi	1
+油壁车	you bi che	1
+有鄙夫问于我	you bi fu wen yu wo	1
+有笔头千字	you bi tou qian zi	1
+游必有方	you bi you fang	1
+有不得见者	you bu de jian zhe	1
+犹不见还家	you bu jian huan jia	1
+有不信焉	you bu xin yan	1
+有不虞之誉	you bu yu zhi yu	1
+有草名含羞	you cao ming han xiu	1
+有车之用	you che zhi yong	1
+游城南	you cheng nan	1
+右丞相	you cheng xiang	1
+犹川谷之于江海	you chuan gu zhi yu jiang hai	1
+由此观之	you ci guan zhi	1
+有大人之事	you da ren zhi shi	1
+有大物者	you da wu zhe	1
+有怠而欲出者	you dai er yu chu zhe	1
+犹带昭阳日影来	you dai zhao yang ri ying lai	1
+忧道不忧贫	you dao bu you pin	1
+有道难行不如醉	you dao nan xing bu ru zui	1
+犹得备晨炊	you de bei chen chui	1
+有德者必有言	you de zhe bi you yan	1
+又得浮生一日凉	you dei fu sheng yi ri liang	1
+有弟皆分散	you di jie fen san	1
+有丁不入军	you ding bu ru jun	1
+尤侗	you dong	1
+有东风	you dong feng	1
+幽独空林色	you du kong lin se	1
+忧端齐终南	you duan qi zhong nan	1
+又多能也	you duo neng ye	1
+有杕之杜	you duo zhi du	1
+有耳莫洗颍川水	you er mo xi ying chuan shui	1
+又非君所详	you fei jun suo xiang	1
+有匪君子	you fei jun zi	1
+有斐君子	you fei jun zi	1
+有蕡其实	you fen qi shi	1
+有风传雅韵	you feng chuan ya yun	1
+有父兄在	you fu xiong zai	1
+有妇颜如雪	you fu yan ru xue	1
+尤工远势古莫比	you gong yuan shi gu mo bi	1
+有洸有溃	you guang you kui	1
+有鬼有神	you gui you shen	1
+有国有家者	you guo you jia zhe	1
+有国之母	you guo zhi mu	1
+又还被	you hai bei	1
+又何加焉	you he jia yan	1
+有恨头还白	you hen tou hai bai	1
+有恒产者有恒心	you heng chan zhe you heng xin	1
+有狐	you hu	1
+油葫芦	you hu lu	1
+有狐绥绥	you hu sui sui	1
+有几个苍蝇碰壁	you ji ge cang ying peng bi	1
+幽涧泉	you jian quan	1
+又见桐花发旧枝	you jian tong hua fa jiu zhi	1
+又尽善也	you jin shan ye	1
+游镜泊湖	you jing bo hu	1
+又敬不违	you jing bu wei	1
+有酒不饮奈明何	you jiu bu yin nai ming he	1
+有酒惟浇赵州土	you jiu wei jiao zhao zhou tu	1
+幽居不用名	you ju bu yong ming	1
+幽居在空谷	you ju zai kong gu	1
+由君子观之	you jun zi guan zhi	1
+有君子之道四焉	you jun zi zhi dao si yan	1
+犹堪一战取功勋	you kan yi zhan qu gong xun	1
+犹可说也	you ke shuo ye	1
+犹可逾也	you ke yu ye	1
+又恐被	you kong bei	1
+犹恐巢中饥	you kong chao zhong ji	1
+犹恐失之	you kong shi zhi	1
+有口难言不如睡	you kou nan yan bu ru shui	1
+犹来	you lai	1
+由来碧落银河畔	you lai bi luo yin he pan	1
+忧来其如何	you lai qi ru he	1
+由来轻七尺	you lai qing qi chi	1
+由来征战地	you lai zheng zhan di	1
+幽兰露	you lan lu	1
+幽兰在山谷	you lan zai shan gu	1
+有礼者敬人	you li zhe jing ren	1
+游媚笔泉记	you mei bi quan ji	1
+有美一人	you mei yi ren	1
+有美一人兮	you mei yi ren xi	1
+有美玉于斯	you mei yu yu si	1
+犹蒙矜育	you meng jin yu	1
+有民人焉	you min ren yan	1
+忧民之忧者	you min zhi you zhe	1
+有名而无实	you ming er wu shi	1
+有冥海者	you ming hai zhe	1
+有名万物之母	you ming wan wu zhi mu	1
+有木名凌霄	you mu ming ling xiao	1
+犹能簸却沧溟水	you neng bo que cang ming shui	1
+犹能夜夜气冲天	you neng ye ye qi chong tian	1
+有鸟有鸟	you niao you niao	1
+游女长歌缓缓归	you nv chang ge huan huan gui	1
+有女如玉	you nv ru yu	1
+有女同行	you nv tong hang	1
+又其次也	you qi ci ye	1
+幽栖地僻经过少	you qi di pi jing guo shao	1
+有其实	you qi shi	1
+友其士之仁者	you qi shi zhi ren zhe	1
+犹其有四体也	you qi you si ti ye	1
+有器之用	you qi zhi yong	1
+犹且从师而问焉	you qie cong shi er wen yan	1
+幼卿	you qing	1
+有情而无形	you qing er wu xing	1
+有情风	you qing feng	1
+有求全之毁	you qiu quan zhi hui	1
+犹求友声	you qiu you sheng	1
+犹去孤舟三四里	you qu gu zhou san si li	1
+有泉侧出	you quan ce chu	1
+攸然而逝	you ran er shi	1
+幽人归独卧	you ren gui du wo	1
+友人会宿	you ren hui su	1
+游人几度菊花丛	you ren ji du ju hua cong	1
+游人脚底一声雷	you ren jiao di yi sheng lei	1
+有人泣	you ren qi	1
+有人天游	you ren tian you	1
+有人同病相怜	you ren tong bing xiang lian	1
+游人武陵去	you ren wu ling qu	1
+由仁义行	you ren yi xing	1
+幽人应未眠	you ren ying wei mian	1
+有人于此	you ren yu ci	1
+有人之形	you ren zhi xing	1
+有若对曰	you ruo dui yue	1
+有色同寒冰	you se tong han bing	1
+有杀身以成仁	you sha shen yi cheng ren	1
+由山以上五六里	you shan yi shang wu liu li	1
+有身莫犯飞龙鳞	you shen mo fan fei long lin	1
+有神人居焉	you shen ren ju yan	1
+犹胜曲全钩	you sheng qu quan gou	1
+有时白云起	you shi bai yun qi	1
+由是而言	you shi er yan	1
+犹是孤帆一日程	you shi gu fan yi ri cheng	1
+由是观之	you shi guan zhi	1
+有时忽惆怅	you shi hu chou chang	1
+有时空望孤云高	you shi kong wang gu yun gao	1
+游石门涧	you shi men jian	1
+又失其故行矣	you shi qi gu xing yi	1
+又食武昌鱼	you shi wu chang yu	1
+有是言也	you shi yan ye	1
+由是言之	you shi yan zhi	1
+有始也者	you shi ye zhe	1
+有始有卒者	you shi you zu zhe	1
+有时遭孔穴	you shi zao kong xue	1
+有室之用	you shi zhi yong	1
+右手举	you shou ju	1
+有手莫辫猛虎须	you shou mo bian meng hu xu	1
+幽树晚多花	you shu wan duo hua	1
+有水一池	you shui yi chi	1
+犹水之就下	you shui zhi jiu xia	1
+由水之就下	you shui zhi jiu xia	1
+犹似霓裳羽衣舞	you si ni shang yu yi wu	1
+有所不行	you suo bu xing	1
+有所教	you suo jiao	1
+有所希冀	you suo xi ji	1
+犹沓沓也	you ta ta ye	1
+犹听侍女唱梅花	you ting shi nv chang mei hua	1
+又未尝不可呢	you wei chang bu ke ne	1
+犹为弃井也	you wei qi jing ye	1
+有谓无谓	you wei wu wei	1
+有为则亏	you wei ze kui	1
+有为者亦若是	you wei zhe yi ruo shi	1
+又闻此语重唧唧	you wen ci yu zhong ji ji	1
+又闻子规啼	you wen zi gui ti	1
+又闻子规啼夜月	you wen zi gui ti ye yue	1
+犹吾大夫崔子也	you wu dai fu cui zi ye	1
+有物先天地	you wu xian tian de	1
+有席卷天下	you xi juan tian xia	1
+悠兮其贵言	you xi qi gui yan	1
+犹兮若畏四邻	you xi ruo wei si lin	1
+又奚以自多	you xi yi zi duo	1
+有仙山琼阁	you xian shan qiong ge	1
+有小人之事	you xiao ren zhi shi	1
+游谢氏山亭	you xie shi shan ting	1
+忧心忡忡	you xin chong chong	1
+忧心惙惙	you xin chuo chuo	1
+有心而为之	you xin er wei zhi	1
+忧心孔疚	you xin kong jiu	1
+忧心烈烈	you xin lie lie	1
+忧心靡乐	you xin mi le	1
+忧心钦钦	you xin qin qin	1
+忧心有忡	you xin you chong	1
+有形有名	you xing you ming	1
+有雄文四卷	you xiong wen si juan	1
+有穴窈然	you xue yao ran	1
+有颜回者好学	you yan hui zhe hao xue	1
+有言者不必有德	you yan zhe bu bi you de	1
+由也好勇过我	you ye hao yong guo wo	1
+由也兼人	you ye jian ren	1
+幽咽泉流水下滩	you ye quan liu shui xia tan	1
+由也升堂矣	you ye sheng tang yi	1
+由也为之	you ye wei zhi	1
+有毅力者成	you yi li zhe cheng	1
+犹忆笙歌昨夜欢	you yi sheng ge zuo ye huan	1
+忧以天下	you yi tian xia	1
+幽意无断绝	you yi wu duan jue	1
+有以异乎	you yi yi hu	1
+犹疑照颜色	you yi zhao yan se	1
+有翼自薄	you yi zi bo	1
+幽映每白日	you ying mei bai ri	1
+悠悠苍天	you you cang tian	1
+悠悠隔九天	you you ge jiu tian	1
+悠悠湖上来	you you hu shang lai	1
+悠悠回赤壁	you you hui chi bi	1
+又有江山	you you jiang shan	1
+有有令	you you ling	1
+悠悠洛阳道	you you luo yang dao	1
+悠悠梦里无寻处	you you meng li wu xun chu	1
+幽幽南山	you you nan shan	1
+悠悠生死别经年	you you sheng si bie jing nian	1
+犹有所待者也	you you suo dai zhe ye	1
+悠悠天地间	you you tian di jian	1
+悠悠天宇旷	you you tian yu kuang	1
+犹有未树也	you you wei shu ye	1
+悠悠我心悲	you you wo xin bei	1
+又欲其死	you yu qi si	1
+游于天地	you yu tian di	1
+游于羿之彀中	you yu yi zhi gou zhong	1
+犹缘木而求鱼也	you yuan mu er qiu yu ye	1
+优哉悠哉	you zai you zai	1
+悠哉悠哉	you zai you zai	1
+右招我由房	you zhao wo you fang	1
+有志竟成	you zhi jing cheng	1
+有志与力	you zhi yu li	1
+犹之与人也	you zhi yu ren ye	1
+有志在四方	you zhi zai si fang	1
+又重之以修能	you zhong zhi yi xiu neng	1
+幽州胡马客	you zhou hu ma ke	1
+幽州胡马客歌	you zhou hu ma ke ge	1
+有竹千竿	you zhu qian gan	1
+游子久不至	you zi jiu bu zhi	1
+犹自梦渔樵	you zi meng yu qiao	1
+有子七人	you zi qi ren	1
+游子思故乡	you zi si gu xiang	1
+游子西	you zi xi	1
+犹自音书滞一乡	you zi yin shu zhi yi xiang	1
+有罪不敢赦	you zui bu gan she	1
+有罪无罪	you zui wu zui	1
+有左有右	you zuo you you	1
+于敖	yu ao	1
+欲罢不能	yu ba bu neng	1
+欲罢不能忘	yu ba bu neng wang	1
+语罢暮天钟	yu ba mu tian zhong	1
+欲把一麾江海去	yu ba yi hui jiang hai qu	1
+庾抱	yu bao	1
+玉抱肚	yu bao du	1
+欲报倾城随太守	yu bao qing cheng sui tai shou	1
+欲报之德	yu bao zhi de	1
+郁彼北林	yu bi bei lin	1
+鴥彼晨风	yu bi chen feng	1
+于彼郊矣	yu bi jiao yi	1
+鱼鳖不可胜食也	yu bie bu ke sheng shi ye	1
+欲别频啼四五声	yu bie pin ti si wu sheng	1
+欲别牵郎衣	yu bie qian lang yi	1
+欲并老容羞白发	yu bing lao rong xiu bai fa	1
+玉帛朝回望帝乡	yu bo chao hui wang di xiang	1
+玉帛云乎哉	yu bo yun hu zai	1
+予不得视犹子也	yu bu de shi you zi ye	1
+予不得已也	yu bu de yi ye	1
+语不惊人死不休	yu bu jing ren si bu xiu	1
+鱼不可脱于渊	yu bu ke tuo yu yuan	1
+欲持一瓢酒	yu chi yi piao jiu	1
+虞俦	yu chou	1
+御厨络绎送八珍	yu chu luo yi song ba zhen	1
+余词尽废	yu ci jin fei	1
+于此泣无穷	yu ci qi wu qiong	1
+于从政乎何有	yu cong zheng hu he you	1
+雨打归舟泪万行	yu da gui zhou lei wan hang	1
+御带花	yu dai hua	1
+欲待曲终寻问取	yu dai qu zhong xun wen qu	1
+欲代子相	yu dai zi xiang	1
+玉珰缄札何由达	yu dang jian zha he you da	1
+欲得周郎顾	yu de zhou lang gu	1
+余弟安国平父	yu di an guo ping fu	1
+雨滴梧桐秋夜长	yu di wu tong qiu ye chang	1
+玉簟凉	yu dian liang	1
+玉簟秋	yu dian qiu	1
+玉殿虚无野寺中	yu dian xu wu ye si zhong	1
+玉殿犹分下苑波	yu dian you fen xia yuan bo	1
+玉斗一双	yu dou yi shuang	1
+余独不觉	yu du bu jue	1
+欲渡谁相待	yu du shui xiang dai	1
+欲而不贪	yu er bu tan	1
+与尔同消万古愁	yu er tong xiao wan gu chou	1
+与尔同销万古愁	yu er tong xiao wan gu chou	1
+鱼儿悬宝剑	yu er xuan bao jian	1
+鱼翻藻鉴	yu fan zao jian	1
+于飞乐	yu fei yue	1
+喻凫	yu fu	1
+渔父	yu fu	1
+欲拂尘时簟竟床	yu fu chen shi dian jing chuang	1
+渔父乐	yu fu le	1
+渔歌入浦深	yu ge ru pu shen	1
+庾公之斯	yu gong zhi si	1
+欲苟顺私情	yu gou shun si qing	1
+榆关断音信	yu guan duan yin xin	1
+玉闺青门里	yu gui qing men li	1
+余桂英	yu gui ying	1
+雨过河源隔座看	yu guo he yuan ge zuo kan	1
+余杭门外	yu hang men wai	1
+俞灏	yu hao	1
+予何人也	yu he ren ye	1
+雨后复斜阳	yu hou fu xie yang	1
+雨后全无叶底花	yu hou quan wu ye di hua	1
+于鹄	yu hu	1
+玉壶冰	yu hu bing	1
+郁乎苍苍	yu hu cang cang	1
+玉蝴蝶	yu hu die	1
+玉虎牵丝汲井回	yu hu qian si ji jing hui	1
+玉壶吟	yu hu yin	1
+欲呼张良与俱去	yu hu zhang liang yu ju qu	1
+玉花却在御榻上	yu hua que zai yu ta shang	1
+谕怀	yu huai	1
+欲济苍生未应晚	yu ji cang sheng wei ying wan	1
+欲及时也	yu ji shi ye	1
+余既为此志	yu ji wei ci zhi	1
+欲寄相思千点泪	yu ji xiang si qian dian lei	1
+欲祭疑君在	yu ji yi jun zai	1
+渔家乐	yu jia le	1
+余嘉其能行古道	yu jia qi neng xing gu dao	1
+俞简	yu jian	1
+庾肩吾	yu jian wu	1
+鱼见之深入	yu jian zhi shen ru	1
+于涧之中	yu jian zhi zhong	1
+预将书报家	yu jiang shu bao jia	1
+玉交枝	yu jiao zhi	1
+于嗟乎	yu jie hu	1
+于嗟鸠兮	yu jie jiu xi	1
+于嗟阔兮	yu jie kuo xi	1
+于嗟麟兮	yu jie lin xi	1
+于嗟女兮	yu jie nv xi	1
+欲洁其身	yu jie qi shen	1
+玉阶生白露	yu jie sheng bai lu	1
+于嗟洵兮	yu jie xun xi	1
+玉阶怨	yu jie yuan	1
+于今为庶为青门	yu jin wei shu wei qing men	1
+于今无会因	yu jin wu hui yin	1
+玉筋应啼别离后	yu jin ying ti bie li hou	1
+于今知有谁	yu jin zhi you shui	1
+玉京群帝集北斗	yu jing qun di ji bei dou	1
+玉京谣	yu jing yao	1
+欲就麻姑买沧海	yu jiu ma gu mai cang hai	1
+余久卧病无聊	yu jiu wo bing wu liao	1
+雨具先去	yu ju xian qu	1
+欲卷珠帘春恨长	yu juan zhu lian chun hen chang	1
+欲觉闻晨钟	yu jue wen chen zhong	1
+与君白黑大分明	yu jun bai hei da fen ming	1
+与君发三愿	yu jun fa san yuan	1
+与君歌一曲	yu jun ge yi qu	1
+与君世世为兄弟	yu jun shi shi wei xiong di	1
+与君营奠复营斋	yu jun ying dian fu ying zhai	1
+与君永相望	yu jun yong xiang wang	1
+与可画竹时	yu ke hua zhu shi	1
+与客携壶上翠微	yu ke xie hu shang cui wei	1
+玉阑干	yu lan gan	1
+于兰何伤	yu lan he shang	1
+玉郎会此通仙籍	yu lang hui ci tong xian ji	1
+雨里鸡鸣一两家	yu li ji ming yi liang jia	1
+玉莲花	yu lian hua	1
+玉连环	yu lian huan	1
+渔梁渡头争渡喧	yu liang du tou zheng du xuan	1
+于良史	yu liang shi	1
+雨淋铃	yu lin ling	1
+于林之下	yu lin zhi xia	1
+於陵论价重如金	yu ling lun jia zhong ru jin	1
+欲令诗语妙	yu ling shi yu miao	1
+鱼龙寂寞秋江冷	yu long ji mo qiu jiang leng	1
+鱼龙听梵声	yu long ting fan sheng	1
+玉漏迟	yu lou chi	1
+玉楼春令	yu lou chun ling	1
+玉漏莫相催	yu lou mo xiang cui	1
+玉楼天半起笙歌	yu lou tian ban qi sheng ge	1
+庾楼晓望	yu lou xiao wang	1
+玉楼宴罢醉和春	yu lou yan ba zui he chun	1
+雨落不上天	yu luo bu shang tian	1
+玉貌锦衣	yu mao jin yi	1
+玉梅令	yu mei ling	1
+虞美人令	yu mei ren ling	1
+予美亡此	yu mei wang ci	1
+玉门关	yu men guan	1
+禹庙空山里	yu miao kong shan li	1
+与命与仁	yu ming yu ren	1
+虞某	yu mou	1
+於穆不已	yu mu bu yi	1
+鱼目混珍	yu mu hun zhen	1
+於穆清庙	yu mu qing miao	1
+鱼馁而肉败	yu nei er rou bai	1
+玉辇纵横过主第	yu nian zong heng guo zhu di	1
+玉女摇仙佩	yu nv yao xian pei	1
+玉盘迸泪伤心数	yu pan beng lei shang xin shu	1
+玉盘珍羞值万钱	yu pan zhen xiu zhi wan qian	1
+玉佩天涯远	yu pei tian ya yuan	1
+玉盆纤手弄清泉	yu pen qian shou nong qing quan	1
+与朋友共	yu peng you gong	1
+与朋友交	yu peng you jiao	1
+欲辟土地	yu pi tu di	1
+予岂好辩哉	yu qi hao bian zai	1
+与其进也	yu qi jin ye	1
+与其媚于奥	yu qi mei yu ao	1
+与其奢也	yu qi she ye	1
+于其身也	yu qi shen ye	1
+与其易也	yu qi yi ye	1
+欲其子之齐语也	yu qi zi zhi qi yu ye	1
+于潜七兄	yu qian qi xiong	1
+鱼潜在渊	yu qian zai yuan	1
+与亲	yu qin	1
+与秦始皇	yu qin shi huang	1
+欲倾东海洗乾坤	yu qing dong hai xi qian kun	1
+雨晴烟晚	yu qing yan wan	1
+雨去花光湿	yu qu hua guang shi	1
+欲取鸣琴弹	yu qu ming qin dan	1
+欲去去无由	yu qu qu wu you	1
+欲去问西家	yu qu wen xi jia	1
+欲取芜城作帝家	yu qu wu cheng zuo di jia	1
+欲去惜芳菲	yu qu xi fang fei	1
+欲去又还不去	yu qu you hai bu qu	1
+玉人歌	yu ren ge	1
+与人恭而有礼	yu ren gong er you li	1
+于人何所不容	yu ren he suo bu rong	1
+与人和者	yu ren he zhe	1
+与人乐乐	yu ren le le	1
+於人为可讥	yu ren wei ke ji	1
+御人以口给	yu ren yi kou gei	1
+愚人之所以为愚	yu ren zhi suo yi wei yu	1
+玉容寂寞泪阑干	yu rong ji mo lei lan gan	1
+雨色秋来寒	yu se qiu lai han	1
+羽扇纶巾谈笑间	yu shan guan jin tan xiao jian	1
+与山间之明月	yu shan jian zhi ming yue	1
+玉山颓	yu shan tui	1
+玉山自倒非人推	yu shan zi dao fei ren tui	1
+于邵	yu shao	1
+与少乐乐	yu shao le le	1
+于是废先王之道	yu shi fei xian wang zhi dao	1
+与时俯仰	yu shi fu yang	1
+于是惠子恐	yu shi hui zi kong	1
+与时俱化	yu shi ju hua	1
+于是遂去	yu shi sui qu	1
+于是饮酒乐甚	yu shi yin jiu le shen	1
+欲曙	yu shu	1
+玉树后庭花	yu shu hou ting hua	1
+欲书花叶寄朝云	yu shu hua ye ji zhao yun	1
+禹疏九河	yu shu jiu he	1
+玉树琼花满目春	yu shu qiong hua man mu chun	1
+羽书昨夜过渠黎	yu shu zuo ye guo qu li	1
+玉水明沙	yu shui ming sha	1
+与谁同	yu shui tong	1
+鱼水同欢	yu shui tong huan	1
+于斯三者何先	yu si san zhe he xian	1
+迂叟	yu sou	1
+欲速成者也	yu su cheng zhe ye	1
+欲速则不达	yu su ze bu da	1
+予所否者	yu suo fou zhe	1
+宇泰定者	yu tai ding zhe	1
+玉台体	yu tai ti	1
+玉堂春	yu tang chun	1
+玉梯横绝月中钩	yu ti heng jue yue zhong gou	1
+与天齐寿	yu tian qi shou	1
+与天为徒	yu tian wei tu	1
+与天为一	yu tian wei yi	1
+欲投人处宿	yu tou ren chu su	1
+玉团儿	yu tuan er	1
+玉碗盛来琥珀光	yu wan sheng lai hu po guang	1
+欲往城南望城北	yu wang cheng nan wang cheng bei	1
+欲忘忘未得	yu wang wang wei de	1
+与为人妻	yu wei ren qi	1
+余威震于殊俗	yu wei zhen yu shu su	1
+欲问孤鸿向何处	yu wen gu hong xiang he chu	1
+欲问江南近消息	yu wen jiang nan jin xiao xi	1
+宇文融	yu wen rong	1
+渔翁	yu weng	1
+渔翁夜傍西岩宿	yu weng ye bang xi yan su	1
+雨我公田	yu wo gong tian	1
+于我归处	yu wo gui chu	1
+于我如浮云	yu wo ru fu yun	1
+於我心有戚戚焉	yu wo xin you qi qi yan	1
+与物反矣	yu wu fan yi	1
+予无乐乎为君	yu wu le hu wei jun	1
+予无所用天下为	yu wu suo yong tian xia wei	1
+雨无正	yu wu zheng	1
+玉玺不缘归日角	yu xi bu yuan gui ri jiao	1
+雨洗东坡月色清	yu xi dong po yue se qing	1
+羽檄交驰日夕闻	yu xi jiao chi ri xi wen	1
+雨洗娟娟净	yu xi juan juan jing	1
+虞兮奈若何	yu xi nai ruo he	1
+豫兮若冬涉川	yu xi ruo dong she chuan	1
+虞兮虞兮奈若何	yu xi yu xi nai ruo he	1
+鱼鲜饭细酒香浓	yu xian fan xi jiu xiang nong	1
+欲献项王	yu xian xiang wang	1
+馀响入霜钟	yu xiang ru shuang zhong	1
+鱼相与处于陆	yu xiang yu chu yu lu	1
+鱼相造乎水	yu xiang zao hu shui	1
+玉箫金管坐两头	yu xiao jin guan zuo liang tou	1
+予小子履	yu xiao zi lv	1
+雨歇杨林东渡头	yu xie yang lin dong du tou	1
+庾信平生最萧瑟	yu xin ping sheng zui xiao se	1
+庾信文章老更成	yu xin wen zhang lao geng cheng	1
+舆薪之不见	yu xin zhi bu jian	1
+欲行不行各尽觞	yu xing bu xing ge jin shang	1
+鱼玄机	yu xuan ji	1
+雨雪纷纷连大漠	yu xue fen fen lian da mo	1
+雨雪其雱	yu xue qi pang	1
+玉雪为骨冰为魂	yu xue wei gu bing wei hun	1
+雨雪载途	yu xue zai tu	1
+欲寻芳草去	yu xun fang cao qu	1
+玉颜不及寒鸦色	yu yan bu ji han ya se	1
+玉颜憔悴三年	yu yan qiao cui san nian	1
+寓言十九	yu yan shi jiu	1
+余延寿	yu yan shou	1
+于焉逍遥	yu yan xiao yao	1
+寓言因永吟	yu yan yin yong yin	1
+揄扬九重万乘主	yu yang jiu chong wan sheng zhu	1
+渔阳鼙鼓动地来	yu yang pi gu dong di lai	1
+于邺	yu ye	1
+于以采蘩	yu yi cai fan	1
+余亦乘舟归鹿门	yu yi cheng zhou gui lu men	1
+欲以菲薄明其衷	yu yi fei bo ming qi zhong	1
+欲以观其徼	yu yi guan qi jiao	1
+欲以观其妙	yu yi guan qi miao	1
+余亦能高咏	yu yi neng gao yong	1
+于以求之	yu yi qiu zhi	1
+余亦谢时去	yu yi xie shi qu	1
+予一以贯之	yu yi yi guan zhi	1
+于以用之	yu yi yong zhi	1
+玉英	yu ying	1
+鱼游春水	yu you chun shui	1
+鱼游沸鼎知无日	yu you fei ding zhi wu ri	1
+语有贵也	yu you gui ye	1
+与忧俱生	yu you ju sheng	1
+玉宇澄清万里埃	yu yu cheng qing wan li ai	1
+御宇多年求不得	yu yu duo nian qiu bu de	1
+予与尔言	yu yu er yan	1
+郁郁纷纷	yu yu fen fen	1
+郁郁乎文哉	yu yu hu wen zai	1
+鱼与龙同池	yu yu long tong chi	1
+与与如也	yu yu ru ye	1
+愉愉如也	yu yu ru ye	1
+欲与天公试比高	yu yu tian gong shi bi gao	1
+予欲无言	yu yu wu yan	1
+欲与亚父	yu yu ya fu	1
+鱼鱼雅雅	yu yu ya ya	1
+于予与改是	yu yu yu gai shi	1
+于予与何诛	yu yu yu he zhu	1
+郁郁园中柳	yu yu yuan zhong liu	1
+欲与之言	yu yu zhi yan	1
+御苑砧声向晚多	yu yuan zhen sheng xiang wan duo	1
+欲赠隔远天	yu zeng ge yuan tian	1
+豫章行	yu zhang xing	1
+于沼于沚	yu zhao yu zhi	1
+愚者与有焉	yu zhe yu you yan	1
+予之不仁也	yu zhi bu ren ye	1
+语之而不惰者	yu zhi er bu duo zhe	1
+予之力尚足以入	yu zhi li shang zu yi ru	1
+于志宁	yu zhi ning	1
+语之所贵者	yu zhi suo gui zhe	1
+与之同命	yu zhi tong ming	1
+雨中春树万人家	yu zhong chun shu wan ren jia	1
+雨中花	yu zhong hua	1
+雨中花令	yu zhong hua ling	1
+雨中花慢	yu zhong hua man	1
+雨中黄叶树	yu zhong huang ye shu	1
+雨中禁火空斋冷	yu zhong jin huo kong zhai leng	1
+与众乐乐	yu zhong le le	1
+雨中寥落月中愁	yu zhong liao luo yue zhong chou	1
+雨中山果落	yu zhong shan guo luo	1
+域中有四大	yu zhong you si da	1
+雨中作	yu zhong zuo	1
+宇宙内事	yu zhou nei shi	1
+渔舟逐水爱山春	yu zhou zhu shui ai shan chun	1
+予助苗长矣	yu zhu miao chang yi	1
+玉烛新	yu zhu xin	1
+玉箸应啼别离后	yu zhu ying ti bie li hou	1
+欲诛有功之人	yu zhu you gong zhi ren	1
+玉竹斩	yu zhu zhan	1
+与诸子登岘山	yu zhu zi deng xian shan	1
+欲妆临镜慵	yu zhuang lin jing yong	1
+寓庄于谐	yu zhuang yu xie	1
+余自束发	yu zi shu fa	1
+与子同仇	yu zi tong chou	1
+与子同袍	yu zi tong pao	1
+与子同裳	yu zi tong shang	1
+与子同泽	yu zi tong ze	1
+与子偕行	yu zi xie xing	1
+与子偕臧	yu zi xie zang	1
+与子偕作	yu zi xie zuo	1
+俞紫芝	yu zi zhi	1
+雨足郊原草木柔	yu zu jiao yuan cao mu rou	1
+远岸秋沙白	yuan an qiu sha bai	1
+员半千	yuan ban qian	1
+愿陛下矜愍愚诚	yuan bi xia jin min yu cheng	1
+远别离	yuan bie li	1
+愿补舜衣裳	yuan bu shun yi shang	1
+怨不在大	yuan bu zai da	1
+圆禅师	yuan chan shi	1
+远朝归	yuan chao gui	1
+愿乘泠风去	yuan cheng ling feng qu	1
+愿成双	yuan cheng shuang	1
+远耻辱也	yuan chi ru ye	1
+元淳	yuan chun	1
+怨春风	yuan chun feng	1
+怨春归	yuan chun gui	1
+怨词	yuan ci	1
+元丹丘	yuan dan qiu	1
+远道不可思	yuan dao bu ke si	1
+愿得此身长报国	yuan de ci shen chang bao guo	1
+愿得天子知	yuan de tian zi zhi	1
+爰得我所	yuan de wo suo	1
+爰得我直	yuan de wo zhi	1
+愿得燕弓射大将	yuan de yan gong she da jiang	1
+愿得斩马剑	yuan de zhan ma jian	1
+缘督以为经	yuan du yi wei jing	1
+远放燕支山下	yuan fang yan zhi shan xia	1
+远方之人	yuan fang zhi ren	1
+元孚	yuan fu	1
+愿夫子辅吾志	yuan fu zi fu wu zhi	1
+圆荷浮小叶	yuan he fu xiao ye	1
+元和令	yuan he ling	1
+元和十年	yuan he shi nian	1
+元和天子神武姿	yuan he tian zi shen wu zi	1
+元晦	yuan hui	1
+元寂	yuan ji	1
+元季川	yuan ji chuan	1
+冤家今夜醉	yuan jia jin ye zui	1
+缘涧还复去	yuan jian hai fu qu	1
+元绛	yuan jiang	1
+愿将腰下剑	yuan jiang yao xia jian	1
+袁郊	yuan jiao	1
+元结	yuan jie	1
+愿接卢敖游太清	yuan jie lu ao you tai qing	1
+爰居爰处	yuan ju yuan chu	1
+愿君学长松	yuan jun xue zhang song	1
+远看方知出处高	yuan kan fang zhi chu chu gao	1
+缘路	yuan lu	1
+远路应悲春晼晚	yuan lu ying bei chun wan wan	1
+远梦归侵晓	yuan meng gui qin xiao	1
+猿鸣天上哀	yuan ming tian shang ai	1
+猿鸣钟动不知曙	yuan ming zhong dong bu zhi shu	1
+渊默而雷声	yuan mo er lei sheng	1
+远莫致之	yuan mo zhi zhi	1
+远目非春亦自伤	yuan mu fei chun yi zi shang	1
+缘木求鱼	yuan mu qiu yu	1
+猿猱欲度愁攀援	yuan nao yu du chou pan yuan	1
+猿鸟犹疑畏简书	yuan niao you yi wei jian shu	1
+圆魄上寒空	yuan po shang han kong	1
+愿乞终养	yuan qi zhong yang	1
+源乾曜	yuan qian yao	1
+垣墙周庭	yuan qiang zhou ting	1
+怨情	yuan qing	1
+原壤夷俟	yuan rang yi si	1
+圆如用智	yuan ru yong zhi	1
+怨三三	yuan san san	1
+爰丧其马	yuan sang qi ma	1
+愿扫鹦鹉洲	yuan sao ying wu zhou	1
+远山晴更多	yuan shan qing geng duo	1
+元晟	yuan sheng	1
+猿声不喘鱼龙听	yuan sheng bu chuan yu long ting	1
+猿声天上哀	yuan sheng tian shang ai	1
+远师	yuan shi	1
+怨是用希	yuan shi yong xi	1
+远树带行客	yuan shu dai xing ke	1
+袁恕己	yuan shu ji	1
+愿书万本诵万过	yuan shu wan ben song wan guo	1
+远送从此别	yuan song cong ci bie	1
+远送于南	yuan song yu nan	1
+远送于野	yuan song yu ye	1
+愿随春风寄燕然	yuan sui chun feng ji yan ran	1
+愿随孤月影	yuan sui gu yue ying	1
+远隋流水香	yuan sui liu shui xiang	1
+远随流水香	yuan sui liu shui xiang	1
+袁綯	yuan tao	1
+猿啼洞庭树	yuan ti dong ting shu	1
+猿啼客散暮江头	yuan ti ke san mu jiang tou	1
+远听明君爱逸才	yuan ting ming jun ai yi cai	1
+愿同尘与灰	yuan tong chen yu hui	1
+愿同尧舜意	yuan tong yao shun yi	1
+元万顷	yuan wan qing	1
+怨王孙	yuan wang sun	1
+愿为持竿叟	yuan wei chi gan sou	1
+远慰风雨夕	yuan wei feng yu xi	1
+愿为双鸿鹄	yuan wei shuang hong hu	1
+愿为小相焉	yuan wei xiao xiang yan	1
+愿闻子之志	yuan wen zi zhi zhi	1
+愿无伐善	yuan wu fa shan	1
+沅湘流不尽	yuan xiang liu bu jin	1
+爰笑爰语	yuan xiao yuan yu	1
+远信入门先有泪	yuan xin ru men xian you lei	1
+愿言思伯	yuan yan si bo	1
+愿言思子	yuan yan si zi	1
+愿言则怀	yuan yan ze huai	1
+鸳鸯不独宿	yuan yang bu du su	1
+鸳鸯会双死	yuan yang hui shuang si	1
+鸳鸯梦	yuan yang meng	1
+鸳鸯瓦冷霜华重	yuan yang wa leng shuang hua zhong	1
+鸳鸯相对浴红衣	yuan yang xiang dui yu hong yi	1
+愿以境内累矣	yuan yi jing nei lei yi	1
+元遗山	yuan yi shan	1
+爰有树檀	yuan you shu tan	1
+园有桃	yuan you tao	1
+远于将之	yuan yu jiang zhi	1
+元载	yuan zai	1
+元稹	yuan zhen	1
+爰整其旅	yuan zheng qi lv	1
+远之事君	yuan zhi shi jun	1
+援之以道	yuan zhi yi dao	1
+远之则怨	yuan zhi ze yuan	1
+愿作深山木	yuan zuo shen shan mu	1
+愿作鸳鸯不羡仙	yuan zuo yuan yang bu xian xian	1
+月暗	yue an	1
+月傍九霄多	yue bang jiu xiao duo	1
+月边娇	yue bian jiao	1
+月城春	yue cheng chun	1
+月出	yue chu	1
+月出峨眉照沧海	yue chu e mei zhao cang hai	1
+月出寒通雪山白	yue chu han tong xue shan bai	1
+月出皎兮	yue chu jiao xi	1
+月出于东山之上	yue chu yu dong shan zhi shang	1
+月出照兮	yue chu zhao xi	1
+月出之光	yue chu zhi guang	1
+约从离衡	yue cong li heng	1
+月当窗	yue dang chuang	1
+月点波心一颗珠	yue dian bo xin yi ke zhu	1
+月殿影开闻夜漏	yue dian ying kai wen ye lou	1
+月儿高	yue er gao	1
+约而为泰	yue er wei tai	1
+岳甫	yue fu	1
+月赋	yue fu	1
+越妇言	yue fu yan	1
+月宫春	yue gong chun	1
+月光长照金樽里	yue guang chang zhao jin zun li	1
+曰归曰归	yue gui yue gui	1
+月寒秋竹冷	yue han qiu zhu leng	1
+月华清	yue hua qing	1
+阅江楼记	yue jiang lou ji	1
+越江吟	yue jiang yin	1
+乐节礼乐	yue jie li yue	1
+阅金经	yue jin jing	1
+阅尽人间春色	yue jin ren jian chun se	1
+月露谁教桂叶香	yue lu shui jiao gui ye xiang	1
+月落潮平是去时	yue luo chao ping shi qu shi	1
+月落锦屏虚	yue luo jin ping xu	1
+月落星稀天欲明	yue luo xing xi tian yu ming	1
+月慢	yue man	1
+月明白鹭飞	yue ming bai lu fei	1
+月明荞麦花如雪	yue ming qiao mai hua ru xue	1
+月明松下房栊静	yue ming song xia fang long jing	1
+月明欲素愁不眠	yue ming yu su chou bu mian	1
+月明征虏亭	yue ming zheng lu ting	1
+越娘	yue niang	1
+越鸟巢干后	yue niao chao gan hou	1
+越女镜心	yue nv jing xin	1
+越女天下白	yue nv tian xia bai	1
+月攘一鸡	yue rang yi ji	1
+越人语天姥	yue ren yu tian lao	1
+月如水	yue ru shui	1
+月色入户	yue se ru hu	1
+跃上葱茏四百旋	yue shang cong long si bai xuan	1
+月上海棠	yue shang hai tang	1
+约他年	yue ta nian	1
+月兔空捣药	yue tu kong dao yao	1
+越王勾践破吴归	yue wang gou jian po wu gui	1
+约为婚姻	yue wei hun yin	1
+越巫	yue wu	1
+月无忘其所能	yue wu wang qi suo neng	1
+越溪寒	yue xi han	1
+月溪明	yue xi ming	1
+月下独酌四首	yue xia du zhuo si shou	1
+月下起舞	yue xia qi wu	1
+曰下学	yue xia xue	1
+月榭故香因雨发	yue xie gu xiang yin yu fa	1
+月斜楼上五更钟	yue xie lou shang wu geng zhong	1
+约心	yue xin	1
+月行却与人相随	yue xing que yu ren xiang sui	1
+岳阳楼	yue yang lou	1
+岳阳楼上对君山	yue yang lou shang dui jun shan	1
+月夜忆舍弟	yue ye yi she di	1
+趯趯阜螽	yue yue fu zhong	1
+月照城头乌半飞	yue zhao cheng tou wu ban fei	1
+月照梨花	yue zhao li hua	1
+月照平沙夏夜霜	yue zhao ping sha xia ye shuang	1
+月照一孤舟	yue zhao yi gu zhou	1
+乐正	yue zheng	1
+月中桂	yue zhong gui	1
+月中行	yue zhong hang	1
+越中览古	yue zhong lan gu	1
+越中山色镜中看	yue zhong shan se jing zhong kan	1
+云傍马头生	yun bang ma tou sheng	1
+云边雁断胡天月	yun bian yan duan hu tian yue	1
+云表	yun biao	1
+云鬓半偏新睡觉	yun bin ban pian xin shui jiao	1
+云鬓花颜金步摇	yun bin hua yan jin bu yao	1
+云此最吉馀难同	yun ci zui ji yu nan tong	1
+云淡秋空	yun dan qiu kong	1
+云峰水隔深	yun feng shui ge shen	1
+云和	yun he	1
+云横九派浮黄鹤	yun heng jiu pai fu huang he	1
+云胡不瘳	yun hu bu chou	1
+云胡不夷	yun hu bu yi	1
+云黄雉兔伏	yun huang zhi tu fu	1
+云髻罢梳还对镜	yun ji ba shu hai dui jing	1
+云间连下榻	yun jian lian xia ta	1
+云将东游	yun jiang dong you	1
+运斤成风	yun jin cheng feng	1
+云卷千峰色	yun juan qian feng se	1
+云开衡岳积阴止	yun kai heng yue ji yin zhi	1
+云开远见汉阳城	yun kai yuan jian han yang cheng	1
+云来气接巫峡长	yun lai qi jie wu xia chang	1
+云里帝城双凤阙	yun li di cheng shuang feng que	1
+韵令	yun ling	1
+云龙风虎尽交回	yun long feng hu jin jiao hui	1
+云埋伏兽丛	yun mai fu shou cong	1
+云满湖	yun man hu	1
+云门寺	yun men si	1
+运命唯所遇	yun ming wei suo yu	1
+运命惟所遇	yun ming wei suo yu	1
+云霓明灭或可睹	yun ni ming mie huo ke du	1
+云青青兮欲雨	yun qing qing xi yu yu	1
+云容	yun rong	1
+云散月明谁点缀	yun san yue ming shui dian zhui	1
+云山况是客中过	yun shan kuang shi ke zhong guo	1
+云山乱	yun shan luan	1
+云山万重	yun shan wan chong	1
+云谁之思	yun shui zhi si	1
+云外惊飞四散哀	yun wai jing fei si san ai	1
+云物不殊乡国异	yun wu bu shu xiang guo yi	1
+云雾敛	yun wu lian	1
+云溪友议	yun xi you yi	1
+云霞生薜帷	yun xia sheng bi wei	1
+云想衣裳花相容	yun xiang yi shang hua xiang rong	1
+云阳上征去	yun yang shang zheng qu	1
+运移汉祚终难复	yun yi han zuo zhong nan fu	1
+云雨荒台岂梦思	yun yu huang tai qi meng si	1
+愠于群小	yun yu qun xiao	1
+云雨巫山枉断肠	yun yu wu shan wang duan chang	1
+云在意俱迟	yun zai yi ju chi	1
+云栈萦纡登剑阁	yun zhan ying yu deng jian ge	1
+云之际	yun zhi ji	1
+允执其中	yun zhi qi zhong	1
+云中君不见	yun zhong jun bu jian	1
+韵资天纵	yun zi tian zong	1
+云自无心水自闲	yun zi wu xin shui zi xian	1
+杂佩以赠之	za pei yi zeng zhi	1
+杂申椒与菌桂兮	za shen jiao yu jun gui xi	1
+杂诗七首	za shi qi shou	1
+再拜而送之	zai bai er song zhi	1
+再拜稽首	zai bai qi shou	1
+再拜献大王足下	zai bai xian da wang zu xia	1
+在邦必达	zai bang bi da	1
+在邦必闻	zai bang bi wen	1
+在邦无怨	zai bang wu yuan	1
+在彼空谷	zai bi kong gu	1
+在彼中河	zai bi zhong he	1
+在长安	zai chang an	1
+在长空	zai chang kong	1
+在陈绝粮	zai chen jue liang	1
+载沉载浮	zai chen zai fu	1
+在城阙兮	zai cheng que xi	1
+载驰	zai chi	1
+在德不在险	zai de bu zai xian	1
+宰割天下	zai ge tian xia	1
+在桂林	zai gui lin	1
+载好其音	zai hao qi yin	1
+在好为人师	zai hao wei ren shi	1
+载饥载渴	zai ji zai ke	1
+在家必达	zai jia bi da	1
+在家必闻	zai jia bi wen	1
+在家常早起	zai jia chang zao qi	1
+在家出家	zai jia chu jia	1
+再加牛肉	zai jia niu rou	1
+在家无怨	zai jia wu yuan	1
+载渴载饥	zai ke zai ji	1
+载弄之璋	zai nong zhi zhang	1
+在其板屋	zai qi ban wu	1
+载寝之床	zai qin zhi chuang	1
+载驱	zai qu	1
+在人不在天	zai ren bu zai tian	1
+在山泉水清	zai shan quan shui qing	1
+再使风俗淳	zai shi feng su chun	1
+宰我对曰	zai wo dui yue	1
+宰我问曰	zai wo wen yue	1
+在我学子	zai wo xue zi	1
+在夏后之世	zai xia hou zhi shi	1
+载笑载言	zai xiao zai yan	1
+在新丰鸿门	zai xin feng hong men	1
+载玄载黄	zai xuan zai huang	1
+载营魄抱一	zai ying po bao yi	1
+在予一人	zai yu yi ren	1
+在狱咏蝉并序	zai yu yong chan bing xu	1
+载舟覆舟	zai zhou fu zhou	1
+赞成功	zan cheng gong	1
+暂将弓并曲	zan jiang gong bing qu	1
+暂凭樽酒送无憀	zan ping zun jiu song wu liao	1
+赞浦子	zan pu zi	1
+暂时分手莫踌躇	zan shi fen shou mo chou chu	1
+暂时相赏莫相违	zan shi xiang shang mo xiang wei	1
+暂引樱桃破	zan yin ying tao po	1
+暂游桃源里	zan you tao yuan li	1
+葬之以礼	zang zhi yi li	1
+早被婵娟误	zao bei chan juan wu	1
+早蝉	zao chan	1
+早朝	zao chao	1
+早出晚归	zao chu wan gui	1
+早春	zao chun	1
+早春寄王汉阳	zao chun ji wang han yang	1
+早春晚归	zao chun wan gui	1
+早春怨	zao chun yuan	1
+造次必于是	zao ci bi yu shi	1
+遭此两重阳	zao ci liang chong yang	1
+早冬	zao dong	1
+早服还丹无世情	zao fu huan dan wu shi qing	1
+早服谓之重积德	zao fu wei zhi zhong ji de	1
+早归	zao gui	1
+早归来	zao gui lai	1
+早寒	zao han	1
+凿户牖以为室	zao hu you yi wei shi	1
+枣花未落桐叶长	zao hua wei luo tong ye chang	1
+糟糠养贤才	zao kang yang xian cai	1
+早梅芳	zao mei fang	1
+早秋	zao qiu	1
+早秋惊落叶	zao qiu jing luo ye	1
+早热	zao re	1
+遭时徽纆	zao shi hui mo	1
+早晚复相逢	zao wan fu xiang feng	1
+早晚下三巴	zao wan xia san ba	1
+早望海霞边	zao wang hai xia bian	1
+早兴	zao xing	1
+早雁拂银河	zao yan fu yin he	1
+早已森严壁垒	zao yi sen yan bi lei	1
+躁则失君	zao ze shi jun	1
+早知潮有信	zao zhi chao you xin	1
+早知如此悔归来	zao zhi ru ci hui gui lai	1
+则哀矜而勿喜	ze ai jin er wu xi	1
+泽陂	ze bei	1
+择不处仁	ze bu chu ren	1
+则不能也	ze bu neng ye	1
+则不弃也	ze bu qi ye	1
+则尝闻之矣	ze chang wen zhi yi	1
+责臣逋慢	ze chen bu man	1
+则臣视君如腹心	ze chen shi jun ru fu xin	1
+则耻师焉	ze chi shi yan	1
+则冻馁其妻子	ze dong nei qi qi zi	1
+则告诉不许	ze gao su bu xu	1
+则何以哉	ze he yi zai	1
+则或咎其欲出者	ze huo jiu qi yu chu zhe	1
+泽及天下	ze ji tian xia	1
+泽及万物	ze ji wan wu	1
+则将焉用彼相矣	ze jiang yan yong bi xiang yi	1
+则芥为之舟	ze jie wei zhi zhou	1
+则可谓云尔已矣	ze ke wei yun er yi yi	1
+泽梁无禁	ze liang wu jin	1
+则民不服	ze min bu fu	1
+则民不敬	ze min bu jing	1
+则民不偷	ze min bu tou	1
+则民莫敢不服	ze min mo gan bu fu	1
+则民莫敢不敬	ze min mo gan bu jing	1
+则民莫敢不用情	ze min mo gan bu yong qing	1
+则民易使也	ze min yi shi ye	1
+则难	ze nan	1
+仄平	ze ping	1
+仄平平	ze ping ping	1
+仄平平仄	ze ping ping ze	1
+仄平平仄平	ze ping ping ze ping	1
+仄平平仄仄	ze ping ping ze ze	1
+仄平平仄仄平	ze ping ping ze ze ping	1
+仄平平仄仄平平	ze ping ping ze ze ping ping	1
+仄平仄	ze ping ze	1
+仄平仄仄	ze ping ze ze	1
+仄平仄仄平	ze ping ze ze ping	1
+仄平仄仄平平仄	ze ping ze ze ping ping ze	1
+仄平仄仄仄平平	ze ping ze ze ze ping ping	1
+则仆偿前辱之责	ze pu chang qian ru zhi ze	1
+则齐国其庶几乎	ze qi guo qi shu ji hu	1
+则其至又加少矣	ze qi zhi you jia shao yi	1
+则群聚而笑之	ze qun ju er xiao zhi	1
+责任重于泰山	ze ren zhong yu tai shan	1
+则如之何	ze ru zhi he	1
+择善而从之	ze shan er cong zhi	1
+择师而教之	ze shi er jiao zhi	1
+则是方四十里	ze shi fang si shi li	1
+则庶人不议	ze shu ren bu yi	1
+则为官长	ze wei guan zhang	1
+则为之也难	ze wei zhi ye nan	1
+则吾必在汶上矣	ze wu bi zai wen shang yi	1
+则无不治	ze wu bu zhi	1
+则吾从先进	ze wu cong xian jin	1
+则无恒产	ze wu heng chan	1
+则吾能征之矣	ze wu neng zheng zhi yi	1
+则吾岂敢	ze wu qi gan	1
+则修文德以来之	ze xiu wen de yi lai zhi	1
+则学孔子也	ze xue kong zi ye	1
+则易	ze yi	1
+则移其民于河东	ze yi qi min yu he dong	1
+则以学文	ze yi xue wen	1
+则游者众	ze you zhe zhong	1
+则与斗卮酒	ze yu dou zhi jiu	1
+则远怨矣	ze yuan yuan yi	1
+仄韵	ze yun	1
+仄仄平	ze ze ping	1
+仄仄平平	ze ze ping ping	1
+仄仄平平平仄	ze ze ping ping ping ze	1
+仄仄平平平仄仄	ze ze ping ping ping ze ze	1
+仄仄平平仄	ze ze ping ping ze	1
+仄仄平平仄仄	ze ze ping ping ze ze	1
+仄仄平平仄仄平	ze ze ping ping ze ze ping	1
+仄仄仄	ze ze ze	1
+仄仄仄平	ze ze ze ping	1
+仄仄仄平平	ze ze ze ping ping	1
+仄仄仄平平仄仄	ze ze ze ping ping ze ze	1
+仄仄仄仄	ze ze ze ze	1
+仄仄仄仄仄	ze ze ze ze ze	1
+仄仄仄仄仄仄	ze ze ze ze ze ze	1
+仄仄仄仄仄仄仄	ze ze ze ze ze ze ze	1
+则政不在大夫	ze zheng bu zai dai fu	1
+则智者尽其谋	ze zhi zhe jin qi mou	1
+则至者少	ze zhi zhe shao	1
+则足以拒秦	ze zu yi ju qin	1
+贼平后送人北归	zei ping hou song ren bei gui	1
+贼退示官吏并序	zei tui shi guan li bing xu	1
+贼义者谓之残	zei yi zhe wei zhi can	1
+怎么得了	zen me de liao	1
+赠别二首	zeng bie er shou	1
+赠丁玲	zeng ding ling	1
+赠荷花	zeng he hua	1
+赠君从此去	zeng jun cong ci qu	1
+赠君一法决狐疑	zeng jun yi fa jue hu yi	1
+赠梁汾	zeng liang fen	1
+赠梦得	zeng meng de	1
+赠孟浩然	zeng meng hao ran	1
+赠内	zeng nei	1
+赠内人	zeng nei ren	1
+赠裴十四	zeng pei shi si	1
+赠阙下裴舍人	zeng que xia pei she ren	1
+赠卫八处士	zeng wei ba chu shi	1
+赠言	zeng yan	1
+赠远虚盈手	zeng yuan xu ying shou	1
+赠张丞相	zeng zhang cheng xiang	1
+曾子言曰	zeng zi yan yue	1
+曾子有疾	zeng zi you ji	1
+乍见翻疑梦	zha jian fan yi meng	1
+乍将云岛极	zha jiang yun dao ji	1
+乍可狂歌草泽中	zha ke kuang ge cao ze zhong	1
+札札弄机杼	zha zha nong ji zhu	1
+摘得新	zhai de xin	1
+摘红英	zhai hong ying	1
+摘花不插发	zhai hua bu cha fa	1
+斋戒	zhai jie	1
+斋居	zhai ju	1
+摘来沽酒君肯否	zhai lai gu jiu jun ken fou	1
+摘莲花	zhai lian hua	1
+战罢沙场月色寒	zhan ba sha chang yue se han	1
+湛贲	zhan ben	1
+瞻彼淇奥	zhan bi qi ao	1
+瞻彼日月	zhan bi ri yue	1
+战必胜矣	zhan bi sheng yi	1
+战场白骨缠草根	zhan chang bai gu chan cao gen	1
+斩长鲸	zhan chang jing	1
+战城南	zhan cheng nan	1
+占春芳	zhan chun fang	1
+战地黄花分外香	zhan di huang hua fen wai xiang	1
+瞻顾遗迹	zhan gu yi ji	1
+沾襟比散丝	zhan jin bi san si	1
+湛露	zhan lu	1
+战马欲南归	zhan ma yu nan gui	1
+斩木为兵	zhan mu wei bing	1
+展如之人兮	zhan ru zhi ren xi	1
+战士指看南粤	zhan shi zhi kan nan yue	1
+瞻望弗及	zhan wang fu ji	1
+詹玉	zhan yu	1
+战则必胜	zhan ze bi sheng	1
+战战兢兢	zhan zhan jing jing	1
+瞻之在前	zhan zhi zai qian	1
+辗转念前途	zhan zhuan nian qian tu	1
+张安石	zhang an shi	1
+章八元	zhang ba yuan	1
+张白	zhang bai	1
+张昪	zhang bian	1
+张表臣	zhang biao chen	1
+张伯寿	zhang bo shou	1
+张伯英	zhang bo ying	1
+张昌宗	zhang chang zong	1
+长成须读五车书	zhang cheng xu du wu che shu	1
+张楚金	zhang chu jin	1
+张辞	zhang ci	1
+张丛	zhang cong	1
+张大安	zhang da an	1
+长大一相逢	zhang da yi xiang feng	1
+张道符	zhang dao fu	1
+长得君王带笑看	zhang de jun wang dai xiao kan	1
+张顶	zhang ding	1
+张杜	zhang du	1
+张谔	zhang e	1
+张风子	zhang feng zi	1
+丈夫非无泪	zhang fu fei wu lei	1
+丈夫何事足萦怀	zhang fu he shi zu ying huai	1
+丈夫未可轻年少	zhang fu wei ke qing nian shao	1
+张复元	zhang fu yuan	1
+张纲	zhang gang	1
+张格	zhang ge	1
+张观	zhang guan	1
+张光朝	zhang guang chao	1
+张衮	zhang gun	1
+涨海积稽天	zhang hai ji ji tian	1
+张弘靖	zhang hong jing	1
+张祜	zhang hu	1
+章华即旧台	zhang hua ji jiu tai	1
+张怀庆	zhang huai qing	1
+张汇	zhang hui	1
+张翚	zhang hui	1
+张浑	zhang hun	1
+张垍	zhang ji	1
+张籍	zhang ji	1
+张继	zhang ji	1
+张贾	zhang jia	1
+张嘉贞	zhang jia zhen	1
+张渐	zhang jian	1
+张建封	zhang jian feng	1
+仗剑行千里	zhang jian xing qian li	1
+章楶	zhang jie	1
+章碣	zhang jie	1
+张景修	zhang jing xiu	1
+张景源	zhang jing yuan	1
+张敬斋	zhang jing zhai	1
+张敬忠	zhang jing zhong	1
+张九龄	zhang jiu ling	1
+张矩	zhang ju	1
+张莒	zhang ju	1
+张扩	zhang kuo	1
+张郎中	zhang lang zhong	1
+张耒	zhang lei	1
+杖藜徐步立芳洲	zhang li xu bu li fang zhou	1
+杖藜徐步转斜阳	zhang li xu bu zhuan xie yang	1
+张良臣	zhang liang chen	1
+张良璞	zhang liang pu	1
+张良西向侍	zhang liang xi xiang shi	1
+张濛	zhang meng	1
+张泌	zhang mi	1
+张幕会连沙	zhang mu hui lian sha	1
+张南史	zhang nan shi	1
+障泥未解玉骢骄	zhang ni wei jie yu cong jiao	1
+张蠙	zhang pin	1
+张绮	zhang qi	1
+张起	zhang qi	1
+张齐贤	zhang qi xian	1
+张乔	zhang qiao	1
+张钦敬	zhang qin jing	1
+张仁宝	zhang ren bao	1
+张任国	zhang ren guo	1
+张仁溥	zhang ren pu	1
+张少博	zhang shao bo	1
+张绍文	zhang shao wen	1
+张生手持石鼓文	zhang sheng shou chi shi gu wen	1
+张胜之	zhang sheng zhi	1
+张拭	zhang shi	1
+张时	zhang shi	1
+张轼	zhang shi	1
+张十八	zhang shi ba	1
+张师师	zhang shi shi	1
+张署	zhang shu	1
+张叔良	zhang shu liang	1
+张叔卿	zhang shu qing	1
+张说	zhang shuo	1
+章四句	zhang si ju	1
+张随	zhang sui	1
+张太华	zhang tai hua	1
+章台柳	zhang tai liu	1
+章台夜思	zhang tai ye si	1
+张焘	zhang tao	1
+张万顷	zhang wan qing	1
+张谓	zhang wei	1
+张文琮	zhang wen cong	1
+张文恭	zhang wen gong	1
+张文姬	zhang wen ji	1
+张文收	zhang wen shou	1
+张昔	zhang xi	1
+章孝标	zhang xiao biao	1
+张孝忠	zhang xiao zhong	1
+张协	zhang xie	1
+张修之	zhang xiu zhi	1
+张旭	zhang xu	1
+张旭三杯草圣传	zhang xu san bei cao sheng zhuan	1
+张宣明	zhang xuan ming	1
+张演	zhang yan	1
+张义方	zhang yi fang	1
+张幼谦	zhang you qian	1
+张友仁	zhang you ren	1
+张又新	zhang you xin	1
+张友正	zhang you zheng	1
+长幼之节	zhang you zhi jie	1
+张聿	zhang yu	1
+张元一	zhang yuan yi	1
+张元宗	zhang yuan zong	1
+张韫	zhang yun	1
+张云容	zhang yun rong	1
+张宰	zhang zai	1
+长在汉家营	zhang zai han jia ying	1
+张藻	zhang zao	1
+长者虽有问	zhang zhe sui you wen	1
+张轸	zhang zhen	1
+张正一	zhang zheng yi	1
+张正元	zhang zheng yuan	1
+张直	zhang zhi	1
+张志和	zhang zhi he	1
+张仲方	zhang zhong fang	1
+张仲谋	zhang zhong mou	1
+张仲素	zhang zhong su	1
+张仲孝友	zhang zhong xiao you	1
+张仲宇	zhang zhong yu	1
+张濯	zhang zhuo	1
+张孜	zhang zi	1
+张子容	zhang zi rong	1
+张佐	zhang zuo	1
+赵昂	zhao ang	1
+赵必	zhao bi	1
+朝不虑夕	zhao bu lv xi	1
+招潮	zhao chao	1
+朝辞白帝彩云间	zhao ci bai di cai yun jian	1
+赵冬曦	zhao dong xi	1
+赵铎	zhao duo	1
+赵防	zhao fang	1
+昭告列祖	zhao gao lie zu	1
+朝歌夜弦	zhao ge ye xian	1
+召公谏厉王弭谤	zhao gong jian li wang mi bang	1
+赵嘏	zhao gu	1
+赵光逢	zhao guang feng	1
+照横塘半天残月	zhao heng tang ban tian can yue	1
+召忽死之	zhao hu si zhi	1
+赵骅	zhao hua	1
+赵惠宗	zhao hui zong	1
+照见人如画	zhao jian ren ru hua	1
+照镜	zhao jing	1
+朝菌不知晦朔	zhao jun bu zhi hui shuo	1
+昭君怨	zhao jun yuan	1
+招客	zhao ke	1
+赵客缦胡缨	zhao ke man hu ying	1
+照梁初有情	zhao liang chu you qing	1
+赵良玉	zhao liang yu	1
+照临下土	zhao lin xia tu	1
+赵令畤	zhao ling chou	1
+召门弟子曰	zhao men di zi yue	1
+赵孟谦	zhao meng qian	1
+召南	zhao nan	1
+赵企	zhao qi	1
+照日深红暖见鱼	zhao ri shen hong nuan jian yu	1
+赵汝钠	zhao ru na	1
+朝如青丝暮成雪	zhao ru qing si mu cheng xue	1
+赵汝愚	zhao ru yu	1
+赵瑟初停凤凰柱	zhao se chu ting feng huang zhu	1
+赵士暕	zhao shi jian	1
+赵师侠	zhao shi xia	1
+诏书切峻	zhao shu qie jun	1
+诏书特下	zhao shu te xia	1
+诏书五道出将军	zhao shu wu dao chu jiang jun	1
+照水红蕖细细香	zhao shui hong qu xi xi xiang	1
+昭王白骨萦蔓草	zhao wang bai gu ying man cao	1
+诏谓将军拂绢素	zhao wei jiang jun fu juan su	1
+赵微明	zhao wei ming	1
+赵武建	zhao wu jian	1
+赵希	zhao xi	1
+赵希明	zhao xi ming	1
+肇锡余以嘉名	zhao xi yu yi jia ming	1
+诏下	zhao xia	1
+朝霞晴作雨	zhao xia qing zuo yu	1
+赵湘	zhao xiang	1
+招寻独有君	zhao xun du you jun	1
+赵彦伯	zhao yan bo	1
+赵延寿	zhao yan shou	1
+赵彦昭	zhao yan zhao	1
+昭阳殿里第一人	zhao yang dian li di yi ren	1
+昭阳殿里恩爱绝	zhao yang dian li en ai jue	1
+昭阳殿下捣衣声	zhao yang dian xia dao yi sheng	1
+照野弥弥浅浪	zhao ye mi mi qian lang	1
+赵壹	zhao yi	1
+照映里门非白屋	zhao ying li men fei bai wu	1
+赵有平原	zhao you ping yuan	1
+赵与	zhao yu	1
+照在绿波中	zhao zai lv bo zhong	1
+朝朝空自归	zhao zhao kong zi gui	1
+朝朝马策与刀环	zhao zhao ma ce yu dao huan	1
+朝朝暮暮催疲老	zhao zhao mu mu cui pi lao	1
+朝朝暮暮在眼前	zhao zhao mu mu zai yan qian	1
+朝朝暮暮主人耳	zhao zhao mu mu zhu ren er	1
+朝朝误妾期	zhao zhao wu qie qi	1
+招招舟子	zhao zhao zhou zi	1
+朝朝醉中去	zhao zhao zui zhong qu	1
+赵子发	zhao zi fa	1
+赵宗儒	zhao zong ru	1
+折彼荷花	zhe bi he hua	1
+折丹桂	zhe dan gui	1
+浙东飞雨过江来	zhe dong fei yu guo jiang lai	1
+这个是甚麽	zhe ge shi shen mo	1
+鹧鸪词	zhe gu ci	1
+折桂令	zhe gui ling	1
+折红梅	zhe hong mei	1
+折红英	zhe hong ying	1
+折花令	zhe hua ling	1
+折花门前剧	zhe hua men qian ju	1
+折戟沈沙铁未销	zhe ji shen sha tie wei xiao	1
+折剑头	zhe jian tou	1
+浙江八月何如此	zhe jiang ba yue he ru ci	1
+谪居	zhe ju	1
+谪居卧病浔阳城	zhe ju wo bing xun yang cheng	1
+折柳枝	zhe liu zhi	1
+折藕爱连丝	zhe ou ai lian si	1
+谪戍之众	zhe shu zhi zhong	1
+谪仙怨	zhe xian yuan	1
+折杨柳	zhe yang liu	1
+珍宝尽有之	zhen bao jin you zhi	1
+振长策而御宇内	zhen chang ce er yu yu nei	1
+砧杵夜千家	zhen chu ye qian jia	1
+贞妇贵殉夫	zhen fu gui xun fu	1
+朕躬有罪	zhen gong you zui	1
+甄后	zhen hou	1
+朕皇考曰伯庸	zhen huang kao yue bo yong	1
+真金在	zhen jin zai	1
+真堪托死生	zhen kan tuo si sheng	1
+珍娘	zhen niang	1
+真娘墓	zhen niang mu	1
+真人之息以踵	zhen ren zhi xi yi zhong	1
+枕上片时春梦中	zhen shang pian shi chun meng zhong	1
+枕上作	zhen shang zuo	1
+砧声近报汉宫秋	zhen sheng jin bao han gong qiu	1
+枕石待云归	zhen shi dai yun gui	1
+真是英雄一丈夫	zhen shi ying xiong yi zhang fu	1
+镇西	zhen xi	1
+针线犹存未忍开	zhen xian you cun wei ren kai	1
+振于无竟	zhen yu wu jing	1
+真源了无取	zhen yuan liao wu qu	1
+真丈夫	zhen zhang fu	1
+振振公姓	zhen zhen gong xing	1
+振振公子	zhen zhen gong zi	1
+振振公族	zhen zhen gong zu	1
+振振君子	zhen zhen jun zi	1
+振振兮	zhen zhen xi	1
+振之以威怒	zhen zhi yi wei nu	1
+镇之以无名之朴	zhen zhi yi wu ming zhi pu	1
+真珠帘	zhen zhu lian	1
+珍珠令	zhen zhu ling	1
+郑遨	zheng ao	1
+郑璧	zheng bi	1
+郑伯克段于鄢	zheng bo ke duan yu yan	1
+征部乐	zheng bu le	1
+郑常	zheng chang	1
+郑巢	zheng chao	1
+争城以战	zheng cheng yi zhan	1
+正当今夕断肠处	zheng dang jin xi duan chang chu	1
+正得秋而万宝成	zheng de qiu er wan bao cheng	1
+争地以战	zheng di yi zhan	1
+争渡争渡	zheng du zheng du	1
+整顿衣裳起敛容	zheng dun yi shang qi lian rong	1
+郑愕	zheng e	1
+郑昉	zheng fang	1
+郑风	zheng feng	1
+正风雨	zheng feng yu	1
+郑馥	zheng fu	1
+征夫怀远路	zheng fu huai yuan lu	1
+正复为奇	zheng fu wei qi	1
+郑刚中	zheng gang zhong	1
+争割地而赂秦	zheng ge di er lu qin	1
+郑谷	zheng gu	1
+郑轨	zheng gui	1
+郑颢	zheng hao	1
+郑合	zheng he	1
+政何君而莫与	zheng he jun er mo yu	1
+郑洪业	zheng hong ye	1
+郑昈	zheng hu	1
+争教红粉不成灰	zheng jiao hong fen bu cheng hui	1
+郑据	zheng ju	1
+蒸藜炊黍饷东菑	zheng li chui shu xiang dong zi	1
+征路此相逢	zheng lu ci xiang feng	1
+郑启	zheng qi	1
+正憔悴	zheng qiao cui	1
+郑綮	zheng qing	1
+征人蓟北空回首	zheng ren ji bei kong hui shou	1
+征人倚戍楼	zheng ren yi shu lou	1
+征人一望乡	zheng ren yi wang xiang	1
+征人怨	zheng ren yuan	1
+峥嵘赤云西	zheng rong chi yun xi	1
+峥嵘如鬼工	zheng rong ru gui gong	1
+郑善玉	zheng shan yu	1
+郑绍	zheng shao	1
+郑少微	zheng shao wei	1
+郑审	zheng shen	1
+郑史	zheng shi	1
+郑适	zheng shi	1
+正是长安花落时	zheng shi chang an hua luo shi	1
+正是去年	zheng shi qu nian	1
+正是四国	zheng shi si guo	1
+郑世翼	zheng shi yi	1
+郑庶	zheng shu	1
+郑损	zheng sun	1
+郑颋	zheng ting	1
+征途未尽马蹄尽	zheng tu wei jin ma ti jin	1
+正为鸥盟留醉眼	zheng wei ou meng liu zui yan	1
+郑闻	zheng wen	1
+争向石崇家	zheng xiang shi chong jia	1
+郑獬	zheng xie	1
+郑雪岩	zheng xue yan	1
+郑严	zheng yan	1
+郑愔	zheng yin	1
+郑絪	zheng yin	1
+郑俞	zheng yu	1
+郑愚	zheng yu	1
+郑余庆	zheng yu qing	1
+郑馀庆	zheng yu qing	1
+郑元秀	zheng yuan xiu	1
+正月崇让宅	zheng yue chong rang zhai	1
+正月繁霜	zheng yue fan shuang	1
+正月时	zheng yue shi	1
+正月十三日	zheng yue shi san ri	1
+正月野花开	zheng yue ye hua kai	1
+正月元日	zheng yue yuan ri	1
+征战无已时	zheng zhan wu yi shi	1
+征招	zheng zhao	1
+政者正也	zheng zhe zheng ye	1
+铮铮然有京都声	zheng zheng ran you jing du sheng	1
+正值儿童弄钓舟	zheng zhi er tong nong diao zhou	1
+正直元因造化功	zheng zhi yuan yin zao hua gong	1
+郑准	zheng zhun	1
+郑子玉	zheng zi yu	1
+治安疏	zhi an shu	1
+置杯焉则胶	zhi bei yan ze jiao	1
+陟彼崔嵬	zhi bi cui wei	1
+陟彼高冈	zhi bi gao gang	1
+陟彼砠矣	zhi bi ju yi	1
+陟彼南山	zhi bi nan shan	1
+置彼周行	zhi bi zhou hang	1
+直不百步耳	zhi bu bai bu er	1
+知不可乎骤得	zhi bu ke hu zhou de	1
+知不足则欺	zhi bu zu ze qi	1
+知常曰明	zhi chang yue ming	1
+雉朝飞	zhi chao fei	1
+治成德备	zhi cheng de bei	1
+咫尺应须论万里	zhi chi ying xu lun wan li	1
+直出浮云间	zhi chu fu yun jian	1
+知出乎争	zhi chu hu zheng	1
+纸船明烛照天烧	zhi chuan ming zhu zhao tian shao	1
+至大至刚	zhi da zhi gang	1
+直道而事人	zhi dao er shi ren	1
+直到门前溪水流	zhi dao men qian xi shui liu	1
+直道相思了无益	zhi dao xiang si le wu yi	1
+至道之极	zhi dao zhi ji	1
+至道之精	zhi dao zhi jing	1
+执德不弘	zhi de bu hong	1
+只得徐妃半面妆	zhi de xu fei ban mian zhuang	1
+知德者鲜矣	zhi de zhe xian yi	1
+至德之世	zhi de zhi shi	1
+指点江山	zhi dian jiang shan	1
+志定	zhi ding	1
+直而不肆	zhi er bu si	1
+之二虫又何知	zhi er chong you he zhi	1
+直而无礼则绞	zhi er wu li ze jiao	1
+织妇词	zhi fu ci	1
+雉雊麦苗秀	zhi gou mai miao xiu	1
+执古之道	zhi gu zhi dao	1
+志怪者也	zhi guai zhe ye	1
+治国经邦	zhi guo jing bang	1
+治国去之	zhi guo qu zhi	1
+知好色则慕少艾	zhi hao se ze mu shao ai	1
+知和而和	zhi he er he	1
+知和曰常	zhi he yue chang	1
+陟岵	zhi hu	1
+指挥若定	zhi hui ruo ding	1
+指挥若定失萧曹	zhi hui ruo ding shi xiao cao	1
+只几个石头磨过	zhi ji ge shi tou mo guo	1
+至今窥牧马	zhi jin kui mu ma	1
+只今惟有温泉水	zhi jin wei you wen quan shui	1
+只今惟有西江月	zhi jin wei you xi jiang yue	1
+只今惟有鹧鸪飞	zhi jin wei you zhe gu fei	1
+至今犹忆李将军	zhi jin you yi li jiang jun	1
+卮酒安足辞	zhi jiu an zu ci	1
+置酒长安道	zhi jiu chang an dao	1
+指九天以为正兮	zhi jiu tian yi wei zheng xi	1
+志决身歼军务劳	zhi jue shen jian jun wu lao	1
+知君穿不得	zhi jun chuan bu de	1
+知君为我	zhi jun wei wo	1
+知君销不得	zhi jun xiao bu de	1
+致君尧舜	zhi jun yao shun	1
+致君尧舜上	zhi jun yao shun shang	1
+只恐流年暗中换	zhi kong liu nian an zhong huan	1
+只恐夜深花睡去	zhi kong ye shen hua shui qu	1
+直栏横槛	zhi lan heng kan	1
+芝兰其室	zhi lan qi shi	1
+至乐无乐	zhi le wu le	1
+支离东北风尘际	zhi li dong bei feng chen ji	1
+至丽物难掩	zhi li wu nan yan	1
+支离笑此身	zhi li xiao ci shen	1
+智亮	zhi liang	1
+滞虑洗孤清	zhi lv xi gu qing	1
+知谋不用	zhi mou bu yong	1
+直匍匐而归耳	zhi pu fu er gui er	1
+知其不可	zhi qi bu ke	1
+知其惑者	zhi qi huo zhe	1
+知其愚者	zhi qi yu zhe	1
+指穷于为薪	zhi qiong yu wei xin	1
+至人	zhi ren	1
+治人事天	zhi ren shi tian	1
+至仁无亲	zhi ren wu qin	1
+治人者食於人	zhi ren zhe shi yu ren	1
+知人之所为者	zhi ren zhi suo wei zhe	1
+指如削葱根	zhi ru xue cong gen	1
+之三子告	zhi san zi gao	1
+直上三十里	zhi shang san shi li	1
+质胜文则野	zhi sheng wen ze ye	1
+志士不忘在沟壑	zhi shi bu wang zai gou he	1
+只是当时已惘然	zhi shi dang shi yi wang ran	1
+知是故人来	zhi shi gu ren lai	1
+志士嗟日短	zhi shi jie ri duan	1
+志士仁人	zhi shi ren ren	1
+知世如梦无所求	zhi shi ru meng wu suo qiu	1
+只识弯弓射大雕	zhi shi wan gong she da diao	1
+知是萧郎至	zhi shi xiao lang zhi	1
+志士幽人莫怨嗟	zhi shi you ren mo yuan jie	1
+知识最为贤	zhi shi zui wei xian	1
+执手分道去	zhi shou fen dao qu	1
+炙手可热势绝伦	zhi shou ke re shi jue lun	1
+之死矢靡它	zhi si shi mi ta	1
+直台	zhi tai	1
+致万乘之势	zhi wan sheng zhi shi	1
+知忘是非	zhi wang shi fei	1
+知味良独少	zhi wei liang du shao	1
+只为馨香重	zhi wei xin xiang zhong	1
+直为斩楼兰	zhi wei zhan lou lan	1
+至微至陋	zhi wei zhi lou	1
+知我者其天乎	zhi wo zhe qi tian hu	1
+知误会前番书语	zhi wu hui qian fan shu yu	1
+知误会前翻书语	zhi wu hui qian fan shu yu	1
+直下龙岩上杭	zhi xia long yan shang hang	1
+直下骑才通	zhi xia qi cai tong	1
+知向谁边	zhi xiang shui bian	1
+知玄	zhi xuan	1
+指巡胡	zhi xun hu	1
+卮言日出	zhi yan ri chu	1
+至阳赫赫	zhi yang he he	1
+至扬州	zhi yang zhou	1
+只要肯登攀	zhi yao ken deng pan	1
+知业	zhi ye	1
+知音不易得	zhi yin bu yi de	1
+知音世所稀	zhi yin shi suo xi	1
+至阴肃肃	zhi yin su su	1
+只应是	zhi ying shi	1
+只应守寂寞	zhi ying shou ji mo	1
+至于暴矣	zhi yu bao yi	1
+至于北海	zhi yu bei hai	1
+至于成立	zhi yu cheng li	1
+至于顿丘	zhi yu dun qiu	1
+志与秋霜洁	zhi yu qiu shuang jie	1
+至于犬马	zhi yu quan ma	1
+治於人者食人	zhi yu ren zhe shi ren	1
+直欲数秋毫	zhi yu shu qiu hao	1
+至于他邦	zhi yu ta bang	1
+至誉无誉	zhi yu wu yu	1
+至于兄弟	zhi yu xiong di	1
+致远恐泥	zhi yuan kong ni	1
+只缘妖雾又重来	zhi yuan yao wu you zhong lai	1
+只在芦花浅水边	zhi zai lu hua qian shui bian	1
+直在其中矣	zhi zai qi zhong yi	1
+直哉史鱼	zhi zai shi yu	1
+至则行矣	zhi ze xing yi	1
+知章骑马似乘船	zhi zhang qi ma si cheng chuan	1
+智者必怀仁	zhi zhe bi huai ren	1
+知者不失人	zhi zhe bu shi ren	1
+智者可卷愚者豪	zhi zhe ke juan yu zhe hao	1
+知者乐水	zhi zhe le shui	1
+知者利仁	zhi zhe li ren	1
+执者失之	zhi zhe shi zhi	1
+质真若渝	zhi zhen ruo yu	1
+只争朝夕	zhi zheng zhao xi	1
+直至长风沙	zhi zhi chang feng sha	1
+知之次也	zhi zhi ci ye	1
+智之端也	zhi zhi duan ye	1
+质直而好义	zhi zhi er hao yi	1
+置之河之侧兮	zhi zhi he zhi ce xi	1
+置之河之干兮	zhi zhi he zhi gan xi	1
+知止可以不殆	zhi zhi ke yi bu dai	1
+秩秩斯干	zhi zhi si gan	1
+直指武夷山下	zhi zhi wu yi shan xia	1
+枝枝相覆盖	zhi zhi xiang fu gai	1
+知止则不殆	zhi zhi ze bu dai	1
+治之至也	zhi zhi zhi ye	1
+置之坐上	zhi zhi zuo shang	1
+雉子斑	zhi zi ban	1
+之子归	zhi zi gui	1
+稚子呼牛归	zhi zi hu niu gui	1
+止子路宿	zhi zi lu su	1
+之子期宿来	zhi zi qi su lai	1
+稚子敲针作钓钩	zhi zi qiao zhen zuo diao gou	1
+之子无裳	zhi zi wu shang	1
+之子于归	zhi zi yu gui	1
+直走咸阳	zhi zou xian yang	1
+知足少欲	zhi zu shao yu	1
+知足者富	zhi zu zhe fu	1
+至尊含笑催赐金	zhi zun han xiao cui ci jin	1
+终罢斯结庐	zhong ba si jie lu	1
+重比翼	zhong bi yi	1
+仲并	zhong bing	1
+终不解矣	zhong bu jie yi	1
+终不可用	zhong bu ke yong	1
+中朝大官老于事	zhong chao da guan lao yu shi	1
+终风	zhong feng	1
+终风且暴	zhong feng qie bao	1
+终风且霾	zhong feng qie mai	1
+终风且曀	zhong feng qie yi	1
+重感	zhong gan	1
+忠告而善道之	zhong gao er shan dao zhi	1
+仲弓问仁	zhong gong wen ren	1
+终苟免而不怀仁	zhong gou mian er bu huai ren	1
+中冓之言	zhong gou zhi yan	1
+终古垂杨有暮鸦	zhong gu chui yang you mu ya	1
+钟鼓楼中刻漏长	zhong gu lou zhong ke lou chang	1
+中谷有蓷	zhong gu you tui	1
+钟鼓云乎哉	zhong gu yun hu zai	1
+钟鼓之音	zhong gu zhi yin	1
+钟鼓馔玉不足贵	zhong gu zhuan yu bu zu gui	1
+种瓜黄台下	zhong gua huang tai xia	1
+终归大海作波涛	zhong gui da hai zuo bo tao	1
+中贵多黄金	zhong gui duo huang jin	1
+中国之民	zhong guo zhi min	1
+中涵孤月明	zhong han gu yue ming	1
+终和且平	zhong he qie ping	1
+种禾终不生豆苗	zhong he zhong bu sheng dou miao	1
+中华儿女多奇志	zhong hua er nv duo qi zhi	1
+中华民族的	zhong hua min zu de	1
+重积德则无不克	zhong ji de ze wu bu ke	1
+终见降王走传车	zhong jian jiang wang zou chuan che	1
+众狙皆怒	zhong ju jie nu	1
+众狙皆悦	zhong ju jie yue	1
+众口铄金君自宽	zhong kou shuo jin jun zi kuan	1
+终老不复取	zhong lao bu fu qu	1
+钟离春	zhong li chun	1
+钟离权	zhong li quan	1
+种荔枝	zhong li zhi	1
+钟辂	zhong lu	1
+众毛飞骨	zhong mao fei gu	1
+重门深锁无寻处	zhong men shen suo wu xun chu	1
+钟谟	zhong mo	1
+种木不种德	zhong mu bu zhong de	1
+终南别业	zhong nan bie ye	1
+终南何有	zhong nan he you	1
+中男绝短小	zhong nan jue duan xiao	1
+终南山	zhong nan shan	1
+终南望馀雪	zhong nan wang yu xue	1
+终南阴岭秀	zhong nan yin ling xiu	1
+仲尼厄而作春秋	zhong ni e er zuo chun qiu	1
+仲尼适楚	zhong ni shi chu	1
+仲尼焉学	zhong ni yan xue	1
+仲尼语之以为博	zhong ni yu zhi yi wei bo	1
+仲尼之徒	zhong ni zhi tu	1
+众鸟欣有托	zhong niao xin you tuo	1
+钟期久已没	zhong qi jiu yi mei	1
+钟蒨	zhong qian	1
+中秋月	zhong qiu yue	1
+众人皆有以	zhong ren jie you yi	1
+众人匹之	zhong ren pi zhi	1
+众人熙熙	zhong ren xi xi	1
+中人以上	zhong ren yi shang	1
+中人以下	zhong ren yi xia	1
+众人重利	zhong ren zhong li	1
+终日坎壈缠其身	zhong ri kan lan chan qi shen	1
+终日看山不厌山	zhong ri kan shan bu yan shan	1
+钟山风雨起苍黄	zhong shan feng yu qi cang huang	1
+众山遥对酒	zhong shan yao dui jiu	1
+终身不得	zhong shen bu de	1
+终身不解	zhong shen bu jie	1
+终身不离	zhong shen bu li	1
+终身不勤	zhong shen bu qin	1
+终身不忘	zhong shen bu wang	1
+众生心水净	zhong sheng xin shui jing	1
+中使频倾赤玉盘	zhong shi pin qing chi yu pan	1
+仲氏任只	zhong shi ren zhi	1
+中士闻道	zhong shi wen dao	1
+终是悠悠行路心	zhong shi you you xing lu xin	1
+忠恕而已矣	zhong shu er yi yi	1
+种树郭橐驼传	zhong shu guo tuo tuo chuan	1
+仲叔圉治宾客	zhong shu yu zhi bin ke	1
+螽斯羽	zhong si yu	1
+终岁不闻丝竹声	zhong sui bu wen si zhu sheng	1
+中岁颇好道	zhong sui po hao dao	1
+重题	zhong ti	1
+中天摧兮力不济	zhong tian cui xi li bu ji	1
+中天悬明月	zhong tian xuan ming yue	1
+中天月色好谁看	zhong tian yue se hao shui kan	1
+中庭桃李映琐窗	zhong ting tao li ying suo chuang	1
+中途不进	zhong tu bu jin	1
+重帷深下莫愁堂	zhong wei shen xia mo chou tang	1
+重为乡党所笑	zhong wei xiang dang suo xiao	1
+终温且惠	zhong wen qie hui	1
+仲夏苦夜短	zhong xia ku ye duan	1
+终鲜兄弟	zhong xian xiong di	1
+中宵劳梦想	zhong xiao lao meng xiang	1
+中心如噎	zhong xin ru ye	1
+中心如醉	zhong xin ru zui	1
+中心是悼	zhong xin shi dao	1
+中心摇摇	zhong xin yao yao	1
+忠信之薄	zhong xin zhi bo	1
+中央乐	zhong yang le	1
+中夜四五叹	zhong ye si wu tan	1
+中隐	zhong yin	1
+中庸之为德也	zhong yong zhi wei de ye	1
+重有感	zhong you gan	1
+重有金樽开	zhong you jin zun kai	1
+中有双飞鸟	zhong you shuang fei niao	1
+中有酥与饴	zhong you su yu yi	1
+中有一人字太真	zhong you yi ren zi tai zhen	1
+忠欲事明主	zhong yu shi ming zhu	1
+重与细论文	zhong yu xi lun wen	1
+中原一败势难回	zhong yuan yi bai shi nan hui	1
+终则有始	zhong ze you shi	1
+众中不敢分明语	zhong zhong bu gan fen ming yu	1
+冢中人	zhong zhong ren	1
+种种在其中	zhong zhong zai qi zhong	1
+种竹	zhong zhu	1
+仲子陵	zhong zi ling	1
+周伯阳	zhou bo yang	1
+洲长多暮归	zhou chang duo mu gui	1
+周彻	zhou che	1
+舟车之所通	zhou che zhi suo tong	1
+周墀	zhou chi	1
+周存	zhou cun	1
+周纲凌迟四海沸	zhou gang ling chi si hai fei	1
+周格非	zhou ge fei	1
+周公恐惧流言后	zhou gong kong ju liu yan hou	1
+周公作	zhou gong zuo	1
+周行而不殆	zhou hang er bu dai	1
+周弘亮	zhou hong liang	1
+周济川	zhou ji chuan	1
+舟楫恐失坠	zhou ji kong shi zhui	1
+州家申名使家抑	zhou jia shen ming shi jia yi	1
+周监于二代	zhou jian yu er dai	1
+昼锦堂	zhou jin tang	1
+周利用	zhou li yong	1
+周朴	zhou pu	1
+昼寝	zhou qin	1
+周秦行纪	zhou qin xing ji	1
+舟人夜语觉潮生	zhou ren ye yu jue chao sheng	1
+周任有言曰	zhou ren you yan yue	1
+舟人指点到今疑	zhou ren zhi dian dao jin yi	1
+周申	zhou shen	1
+州司临门	zhou si lin men	1
+周虽旧邦	zhou sui jiu bang	1
+周昙	zhou tan	1
+周渭	zhou wei	1
+昼卧	zhou wo	1
+周庠	zhou xiang	1
+周彦晖	zhou yan hui	1
+周彦昭	zhou yan zhao	1
+周繇	zhou yao	1
+昼夜勤作息	zhou ye qin zuo xi	1
+周因于殷礼	zhou yin yu yin li	1
+骤雨不终日	zhou yu bu zhong ri	1
+骤雨打新荷	zhou yu da xin he	1
+纣之不善	zhou zhi bu shan	1
+舟中读元九诗	zhou zhong du yuan jiu shi	1
+周忠介公遗事	zhou zhong jie gong yi shi	1
+舟中晓望	zhou zhong xiao wang	1
+周铢	zhou zhu	1
+周祚	zhou zuo	1
+朱褒	zhu bao	1
+珠箔飘灯独自归	zhu bo piao deng du zi gui	1
+珠箔银屏迤逦开	zhu bo yin ping yi li kai	1
+住不得	zhu bu de	1
+主称会面难	zhu cheng hui mian nan	1
+筑城去	zhu cheng qu	1
+竹窗	zhu chuang	1
+朱存	zhu cun	1
+竹簟	zhu dian	1
+朱敦复	zhu dun fu	1
+朱敦儒	zhu dun ru	1
+朱放	zhu fang	1
+主歌悲顾鹤	zhu ge bei gu he	1
+诸葛大名垂宇宙	zhu ge da ming chui yu zhou	1
+诸葛孔明起陇中	zhu ge kong ming qi long zhong	1
+诸公碌碌皆余子	zhu gong lu lu jie yu zi	1
+诸侯不得友	zhu hou bu de you	1
+诸侯不仁	zhu hou bu ren	1
+诸侯放恣	zhu hou fang zi	1
+诸侯尽西来	zhu hou jin xi lai	1
+诸侯恐惧	zhu hou kong ju	1
+诸侯之礼	zhu hou zhi li	1
+朱涣	zhu huan	1
+朱晦	zhu hui	1
+朱绛	zhu jiang	1
+竹解心虚即我师	zhu jie xin xu ji wo shi	1
+住近湓江地低湿	zhu jin pen jiang di di shi	1
+驻景挥戈	zhu jing hui ge	1
+竹径通幽处	zhu jing tong you chu	1
+朱景文	zhu jing wen	1
+朱景玄	zhu jing xuan	1
+朱均	zhu jun	1
+诸君何以答升平	zhu jun he yi da sheng ping	1
+竹开霜后翠	zhu kai shuang hou cui	1
+逐客无消息	zhu ke wu xiao xi	1
+朱逵	zhu kui	1
+珠泪阑干	zhu lei lan gan	1
+伫立以泣	zhu li yi qi	1
+珠帘不卷夜来霜	zhu lian bu juan ye lai shuang	1
+珠帘卷	zhu lian juan	1
+珠帘暮卷西山雨	zhu lian mu juan xi shan yu	1
+竹怜新雨后	zhu lian xin yu hou	1
+竹凉侵卧内	zhu liang qin wo nei	1
+株林	zhu lin	1
+竹露滴清响	zhu lu di qing xiang	1
+驻马别孤坟	zhu ma bie gu fen	1
+竹马车	zhu ma che	1
+竹马儿	zhu ma er	1
+驻马听	zhu ma ting	1
+驻马望千门	zhu ma wang qian men	1
+驻马衔杯问谪居	zhu ma xian bei wen zhe ju	1
+朱买臣	zhu mai chen	1
+朱门先达笑弹冠	zhu men xian da xiao dan guan	1
+朱穆	zhu mu	1
+祝穆	zhu mu	1
+竹批双耳峻	zhu pi shuang er jun	1
+祝钦明	zhu qin ming	1
+朱庆余	zhu qing yu	1
+朱庆馀	zhu qing yu	1
+注然勃然	zhu ran bo ran	1
+主人不相识	zhu ren bu xiang shi	1
+主人何为言少钱	zhu ren he wei yan shao qian	1
+主人忘归客不发	zhu ren wang gui ke bu fa	1
+主人下马客在船	zhu ren xia ma ke zai chuan	1
+主人有酒欢今夕	zhu ren you jiu huan jin xi	1
+朱蕤冒紫茎	zhu rui mao zi jing	1
+竹色溪下绿	zhu se xi xia lv	1
+竹深留客处	zhu shen liu ke chu	1
+竹石图	zhu shi tu	1
+朱淑真	zhu shu zhen	1
+朱淑贞	zhu shu zhen	1
+朱宿	zhu su	1
+朱孙	zhu sun	1
+逐舞飘轻袖	zhu wu piao qing xiu	1
+竹溪村路板桥斜	zhu xi cun lu ban qiao xie	1
+朱晞颜	zhu xi yan	1
+朱希真	zhu xi zhen	1
+竹下忘言对紫茶	zhu xia wang yan dui zi cha	1
+注想待元老	zhu xiang dai yuan lao	1
+竹香子	zhu xiang zi	1
+朱休	zhu xiu	1
+诸学士	zhu xue shi	1
+珠压腰衱稳称身	zhu ya yao jie wen chen shen	1
+主要参照了	zhu yao can zhao le	1
+竹叶坏水色	zhu ye huai shui se	1
+铸以为金人十二	zhu yi wei jin ren shi er	1
+竹影乱清风	zhu ying luan qing feng	1
+珠缨炫转星宿摇	zhu ying xuan zhuan xing xiu yao	1
+朱雍	zhu yong	1
+猪犹智慧胜愚曹	zhu you zhi hui sheng yu cao	1
+珠玉买歌笑	zhu yu mai ge xiao	1
+茱萸香	zhu yu xiang	1
+朱元夫	zhu yuan fu	1
+渚云低暗渡	zhu yun di an du	1
+驻云飞	zhu yun fei	1
+拄杖落手心茫然	zhu zhang luo shou xin mang ran	1
+竹枝	zhu zhi	1
+贮之黄金屋	zhu zhi huang jin wu	1
+助之长者	zhu zhi zhang zhe	1
+竹枝子	zhu zhi zi	1
+筑中置铅鱼隐刀	zhu zhong zhi qian yu yin dao	1
+朱昼	zhu zhou	1
+朱子厚	zhu zi hou	1
+诸子环洞庭而坐	zhu zi huan dong ting er zuo	1
+朱子奢	zhu zi she	1
+朱子真	zhu zi zhen	1
+转调二郎神	zhuan diao er lang shen	1
+转而攻秦	zhuan er gong qin	1
+转教人忆春山	zhuan jiao ren yi chun shan	1
+转教小玉报双成	zhuan jiao xiao yu bao shuang cheng	1
+转觉鸬鹚毛色下	zhuan jue lu ci mao se xia	1
+赚煞	zhuan sha	1
+转头向户里	zhuan tou xiang hu li	1
+转徙於江湖间	zhuan xi yu jiang hu jian	1
+转眼成人	zhuan yan cheng ren	1
+转应曲	zhuan ying qu	1
+转於僮仆亲	zhuan yu tong pu qin	1
+转轴拨弦三两声	zhuan zhou bo xian san liang sheng	1
+妆罢低声问夫婿	zhuang ba di sheng wen fu xu	1
+庄暴见孟子曰	zhuang bao jian meng zi yue	1
+庄不得击	zhuang bu de ji	1
+妆成每被秋娘妒	zhuang cheng mei bei qiu niang du	1
+妆成只是薰香坐	zhuang cheng zhi shi xun xiang zuo	1
+庄椿岁	zhuang chun sui	1
+装点此关山	zhuang dian ci guan shan	1
+壮观天下无	zhuang guan tian xia wu	1
+壮丽江山	zhuang li jiang shan	1
+壮其蔚跂	zhuang qi wei qi	1
+壮士惨不骄	zhuang shi can bu jiao	1
+壮士发冲冠	zhuang shi fa chong guan	1
+壮岁失婵娟	zhuang sui shi chan juan	1
+壮心欲填海	zhuang xin yu tian hai	1
+庄以莅之	zhuang yi li zhi	1
+壮志逐年衰	zhuang zhi zhu nian shuai	1
+庄周家贫	zhuang zhou jia pin	1
+庄子持竿不顾	zhuang zi chi gan bu gu	1
+庄子钓于濮水	zhuang zi diao yu pu shui	1
+庄子妻死	zhuang zi qi si	1
+庄子送葬	zhuang zi song zang	1
+庄子往见之	zhuang zi wang jian zhi	1
+追欢偶作	zhui huan ou zuo	1
+追凉	zhui liang	1
+追想吹箫处	zhui xiang chui xiao chu	1
+惴惴小心	zhui zhui xiao xin	1
+濯冠沐浴告祭酒	zhuo guan mu yu gao ji jiu	1
+酌酒与君君自宽	zhuo jiu yu jun jun zi kuan	1
+啄木儿	zhuo mu er	1
+啄木曲	zhuo mu qu	1
+卓牌子	zhuo pai zi	1
+斫却月中桂	zhuo que yue zhong gui	1
+卓世清	zhuo shi qing	1
+酌饮四座以散愁	zhuo yin si zuo yi san chou	1
+灼灼芙蓉姿	zhuo zhuo fu rong zi	1
+灼灼花	zhuo zhuo hua	1
+自爱名山入剡中	zi ai ming shan ru shan zhong	1
+自本自根	zi ben zi gen	1
+自彼则不见	zi bi ze bu jian	1
+自伯之东	zi bo zhi dong	1
+子不我即	zi bu wo ji	1
+子不我思	zi bu wo si	1
+自惭居处崇	zi can ju chu chong	1
+子产听郑国之政	zi chan ting zheng guo zhi zheng	1
+缁尘京国	zi chen jing guo	1
+自称臣是酒中仙	zi cheng chen shi jiu zhong xian	1
+自此以往	zi ci yi wang	1
+自从春草长	zi cong chun cao chang	1
+自从建安来	zi cong jian an lai	1
+资从岂待周	zi cong qi dai zhou	1
+自从弃置便衰朽	zi cong qi zhi bian shuai xiu	1
+自从双鬓斑斑白	zi cong shuang bin ban ban bai	1
+自从献宝朝河宗	zi cong xian bao chao he zong	1
+自大夫出	zi dai fu chu	1
+自断此生休问天	zi duan ci sheng xiu wen tian	1
+自尔为佳节	zi er wei jia jie	1
+自而治天下	zi er zhi tian xia	1
+自伐者无功	zi fa zhe wu gong	1
+紫凤放娇衔楚佩	zi feng fang jiao xian chu pei	1
+自夫子之死也	zi fu zi zhi si ye	1
+子告之曰	zi gao zhi yue	1
+自歌自舞	zi ge zi wu	1
+自公多暇延参佐	zi gong duo xia yan can zuo	1
+子贡方人	zi gong fang ren	1
+自公退食	zi gong tui shi	1
+子贡问君子	zi gong wen jun zi	1
+子贡问为仁	zi gong wen wei ren	1
+子贡问友	zi gong wen you	1
+子贡问政	zi gong wen zheng	1
+子固非鱼也	zi gu fei yu ye	1
+自古皆有死	zi gu jie you si	1
+自古谁不死	zi gu shui bu si	1
+自顾无长策	zi gu wu chang ce	1
+自古以固存	zi gu yi gu cun	1
+自挂东南枝	zi gua dong nan zhi	1
+自贵而相贱	zi gui er xiang jian	1
+子规啼月小楼西	zi gui ti yue xiao lou xi	1
+子罕第九	zi han di jiu	1
+子罕言利	zi han yan li	1
+紫毫笔	zi hao bi	1
+自河南经乱	zi he nan jing luan	1
+自恨寻芳到已迟	zi hen xun fang dao yi chi	1
+紫花儿序	zi hua er xu	1
+子华使于齐	zi hua shi yu qi	1
+子惠思我	zi hui si wo	1
+子击磬于卫	zi ji qing yu wei	1
+子几死乎	zi ji si hu	1
+自嫁黔娄百事乖	zi jia qian lou bai shi guai	1
+子见夫子乎	zi jian fu zi hu	1
+子见南子	zi jian nan zi	1
+子见齐衰者	zi jian qi shuai zhe	1
+自见者不明	zi jian zhe bu ming	1
+梓匠轮舆	zi jiang lun yu	1
+子将奚先	zi jiang xi xian	1
+自解	zi jie	1
+自今及古	zi jin ji gu	1
+自矜者不长	zi jin zhe bu chang	1
+自经于沟渎	zi jing yu gou du	1
+自觉谏书稀	zi jue jian shu xi	1
+自君别我后	zi jun bie wo hou	1
+自君之出矣	zi jun zhi chu yi	1
+自可	zi ke	1
+自可断来信	zi ke duan lai xin	1
+子兰	zi lan	1
+字立之	zi li zhi	1
+自怜碧玉亲教舞	zi lian bi yu qin jiao wu	1
+自怜春色罢	zi lian chun se ba	1
+紫骝马	zi liu ma	1
+子路不对	zi lu bu dui	1
+子路从而后	zi lu cong er hou	1
+子路第十三	zi lu di shi san	1
+子路拱而立	zi lu gong er li	1
+子路仁乎	zi lu ren hu	1
+子路宿于石门	zi lu su yu shi men	1
+子路问成人	zi lu wen cheng ren	1
+子路问君子	zi lu wen jun zi	1
+子路问事君	zi lu wen shi jun	1
+子路问曰	zi lu wen yue	1
+子路问政	zi lu wen zheng	1
+子路无宿诺	zi lu wu su nuo	1
+子路行以告	zi lu xing yi gao	1
+子路有闻	zi lu you wen	1
+姊妹弟兄皆列士	zi mei di xiong jie lie shi	1
+姊妹弟兄皆列土	zi mei di xiong jie lie tu	1
+自名秦罗敷	zi ming qin luo fu	1
+自名为鸳鸯	zi ming wei yuan yang	1
+自牧归荑	zi mu gui yi	1
+自南自北	zi nan zi bei	1
+子宁不来	zi ning bu lai	1
+子宁不嗣音	zi ning bu si yin	1
+自其同者视之	zi qi tong zhe shi zhi	1
+自其异者视之	zi qi yi zhe shi zhi	1
+子禽问于子贡曰	zi qin wen yu zi gong yue	1
+紫泉宫殿锁烟霞	zi quan gong dian suo yan xia	1
+自然而得	zi ran er de	1
+子如不言	zi ru bu yan	1
+子入太庙	zi ru tai miao	1
+自三代以下者	zi san dai yi xia zhe	1
+子生三年	zi sheng san nian	1
+子弑其父者有之	zi shi qi fu zhe you zhi	1
+自是者不彰	zi shi zhe bu zhang	1
+子帅以正	zi shuai yi zheng	1
+子所雅言	zi suo ya yan	1
+紫藤	zi teng	1
+紫藤挂云木	zi teng gua yun mu	1
+紫藤树	zi teng shu	1
+紫驼之峰出翠釜	zi tuo zhi feng chu cui fu	1
+子谓伯鱼曰	zi wei bo yu yue	1
+子为恭也	zi wei gong ye	1
+子谓公冶长	zi wei gong ye chang	1
+紫薇花	zi wei hua	1
+自谓经过旧不迷	zi wei jing guo jiu bu mi	1
+子未可以去乎	zi wei ke yi qu hu	1
+子谓南容	zi wei nan rong	1
+子谓冉有曰	zi wei ran you yue	1
+子谓颜渊曰	zi wei yan yuan yue	1
+子畏于匡	zi wei yu kuang	1
+子谓子产	zi wei zi chan	1
+子谓子贡曰	zi wei zi gong yue	1
+子谓子贱	zi wei zi jian	1
+子谓子夏曰	zi wei zi xia yue	1
+子温而厉	zi wen er li	1
+子闻之曰	zi wen zhi yue	1
+自我不见	zi wo bu jian	1
+自我徂尔	zi wo cu er	1
+自我观之	zi wo guan zhi	1
+自我来黄州	zi wo lai huang zhou	1
+子无良媒	zi wu liang mei	1
+自喜	zi xi	1
+子奚不为政	zi xi bu wei zheng	1
+自西自东	zi xi zi dong	1
+子兮子兮	zi xi zi xi	1
+子夏问孝	zi xia wen xiao	1
+子夏问曰	zi xia wen yue	1
+子夏云何	zi xia yun he	1
+自小不相识	zi xiao bu xiang shi	1
+自小阙内训	zi xiao que nei xun	1
+自信人生二百年	zi xin ren sheng er bai nian	1
+子行三军	zi xing san jun	1
+自行束修以上	zi xing shu xiu yi shang	1
+紫袖红弦明月中	zi xiu hong xian ming yue zhong	1
+自许高材老更刚	zi xu gao cai lao geng gang	1
+自言本是京城女	zi yan ben shi jing cheng nv	1
+紫阳花	zi yang hua	1
+子夜	zi ye	1
+子夜四时歌	zi ye si shi ge	1
+子夜吴歌	zi ye wu ge	1
+子夜吴歌秋歌	zi ye wu ge qiu ge	1
+缁衣	zi yi	1
+子亦来见我乎	zi yi lai jian wo hu	1
+自遗其咎	zi yi qi jiu	1
+子以四教	zi yi si jiao	1
+自以为得	zi yi wei de	1
+自以为关中之固	zi yi wei guan zhong zhi gu	1
+自咏	zi yong	1
+子游对曰	zi you dui yue	1
+兹游奇绝冠平生	zi you qi jue guan ping sheng	1
+自有岁寒心	zi you sui han xin	1
+子游为武城宰	zi you wei wu cheng zai	1
+子游问孝	zi you wen xiao	1
+自有夜珠来	zi you ye zhu lai	1
+子欲居九夷	zi yu ju jiu yi	1
+自与清波闲	zi yu qing bo xian	1
+子与人歌而善	zi yu ren ge er shan	1
+子于是日哭	zi yu shi ri ku	1
+自喻适志与	zi yu shi zhi yu	1
+紫玉箫	zi yu xiao	1
+字余曰灵均	zi yu yue ling jun	1
+子曰何其	zi yue he qi	1
+自云良家子	zi yun liang jia zi	1
+子在陈曰	zi zai chen yue	1
+子在川上曰	zi zai chuan shang yue	1
+子在齐闻韶	zi zai qi wen shao	1
+自贼者也	zi zei zhe ye	1
+子张第十九	zi zhang di shi jiu	1
+子张书诸绅	zi zhang shu zhu shen	1
+子张问仁于孔子	zi zhang wen ren yu kong zi	1
+子张问行	zi zhang wen xing	1
+子张问曰	zi zhang wen yue	1
+子张问政	zi zhang wen zheng	1
+子张学干禄	zi zhang xue gan lu	1
+子之不淑	zi zhi bu shu	1
+子之不知鱼之乐	zi zhi bu zhi yu zhi le	1
+子之清扬	zi zhi qing yang	1
+子之所慎	zi zhi suo shen	1
+子之汤兮	zi zhi tang xi	1
+子治天下	zi zhi tian xia	1
+子之武城	zi zhi wu cheng	1
+子之燕居	zi zhi yan ju	1
+子之迂也	zi zhi yu ye	1
+自知则知之	zi zhi ze zhi zhi	1
+子之知道	zi zhi zhi dao	1
+子知之乎	zi zhi zhi hu	1
+字字锦	zi zi jin	1
+字字双	zi zi shuang	1
+字子瞻	zi zi zhan	1
+自足荡心耳	zi zu dang xin er	1
+总不能避免	zong bu neng bi mian	1
+宗臣遗像肃清高	zong chen yi xiang su qing gao	1
+宗楚客	zong chu ke	1
+总此十思	zong ci shi si	1
+纵横计不就	zong heng ji bu jiu	1
+总角之宴	zong jiao zhi yan	1
+纵浪大化中	zong lang da hua zhong	1
+纵令然诺暂相许	zong ling ran nuo zan xiang xu	1
+宗庙会同	zong miao hui tong	1
+宗庙之事	zong miao zhi shi	1
+纵然一夜风吹去	zong ran yi ye feng chui qu	1
+纵使长条似旧垂	zong shi chang tiao si jiu chui	1
+纵使君来岂堪折	zong shi jun lai qi kan zhe	1
+纵使有花兼有月	zong shi you hua jian you yue	1
+纵死侠骨香	zong si xia gu xiang	1
+纵死犹闻侠骨香	zong si you wen xia gu xiang	1
+总为浮云能蔽日	zong wei fu yun neng bi ri	1
+纵一苇之所如	zong yi wei zhi suo ru	1
+纵有健妇把锄犁	zong you jian fu ba chu li	1
+纵有笙歌亦断肠	zong you sheng ge yi duan chang	1
+宗之潇洒美少年	zong zhi xiao sa mei shao nian	1
+奏赋入明光	zou fu ru ming guang	1
+走马还寻去岁村	zou ma hai xun qu sui cun	1
+走马红阳城	zou ma hong yang cheng	1
+走马兰台类转蓬	zou ma lan tai lei zhuan peng	1
+走马去如云	zou ma qu ru yun	1
+走马西来欲到天	zou ma xi lai yu dao tian	1
+邹人与楚人战	zou ren yu chu ren zhan	1
+鲰生说我曰	zou sheng shuo wo yue	1
+邹应龙	zou ying long	1
+驺虞	zou yu	1
+邹与鲁哄	zou yu lu hong	1
+俎豆之事	zu dou zhi shi	1
+足疾	zu ji	1
+足茧荒山转愁疾	zu jian huang shan zhuan chou ji	1
+卒就死耳	zu jiu si er	1
+祖可	zu ke	1
+祖母无臣	zu mu wu chen	1
+族庖月更刀	zu pao yue geng dao	1
+租税从何出	zu shui cong he chu	1
+足下蹑丝履	zu xia nie si lv	1
+足以荣汝身	zu yi rong ru shen	1
+足以息肩	zu yi xi jian	1
+祖咏	zu yong	1
+足之所履	zu zhi suo lv	1
+钻燧改火	zuan sui gai huo	1
+醉别江楼橘柚香	zui bie jiang lou ju you xiang	1
+醉不成欢惨将别	zui bu cheng huan can jiang bie	1
+醉春风	zui chun feng	1
+醉春台	zui chun tai	1
+醉东风	zui dong feng	1
+醉扶归	zui fu gui	1
+最高春	zui gao chun	1
+最高楼	zui gao lou	1
+醉公子	zui gong zi	1
+醉归扶路人应笑	zui gui fu lu ren ying xiao	1
+醉归应犯夜	zui gui ying fan ye	1
+醉和金甲舞	zui he jin jia wu	1
+醉红妆	zui hong zhuang	1
+醉后	zui hou	1
+醉后凉风起	zui hou liang feng qi	1
+醉花春	zui hua chun	1
+醉花番	zui hua fan	1
+醉花间	zui hua jian	1
+醉花荫	zui hua yin	1
+醉江月	zui jiang yue	1
+醉来脱宝剑	zui lai tuo bao jian	1
+醉里得真如	zui li de zhen ru	1
+醉里时时错问君	zui li shi shi cuo wen jun	1
+醉落魄	zui luo po	1
+醉梅花	zui mei hua	1
+醉眠秋共被	zui mian qiu gong bei	1
+醉蓬莱	zui peng lai	1
+醉起步溪月	zui qi bu xi yue	1
+醉杀洞庭秋	zui sha dong ting qiu	1
+最是楚宫俱泯灭	zui shi chu gong ju min mie	1
+最是繁丝摇落后	zui shi fan si yao luo hou	1
+醉时勇	zui shi yong	1
+醉思凡	zui si fan	1
+醉思仙	zui si xian	1
+醉太平	zui tai ping	1
+醉桃园	zui tao yuan	1
+醉桃源	zui tao yuan	1
+醉翁操	zui weng cao	1
+醉卧不知白日暮	zui wo bu zhi bai ri mu	1
+最下腐刑极矣	zui xia fu xing ji yi	1
+醉乡春	zui xiang chun	1
+醉行	zui xing	1
+醉瑶瑟	zui yao se	1
+醉吟	zui yin	1
+醉游平泉	zui you ping quan	1
+醉月频中圣	zui yue pin zhong sheng	1
+罪在朕躬	zui zai zhen gong	1
+醉则从他醉	zui ze cong ta zui	1
+醉折花枝当酒筹	zui zhe hua zhi dang jiu chou	1
+醉中天	zui zhong tian	1
+醉妆词	zui zhuang ci	1
+遵大路	zun da lu	1
+遵大路兮	zun da lu xi	1
+樽酒家贫只旧醅	zun jiu jia pin zhi jiu pei	1
+樽酒慰离颜	zun jiu wei li yan	1
+尊其瞻视	zun qi zhan shi	1
+尊亲之至	zun qin zhi zhi	1
+遵事迹犹遽	zun shi ji you ju	1
+尊贤而重士	zun xian er zhong shi	1
+尊主强国之人	zun zhu qiang guo zhi ren	1
+昨别今已春	zuo bie jin yi chun	1
+坐愁红颜老	zuo chou hong yan lao	1
+坐地日行八万里	zuo di ri xing ba wan li	1
+坐对真成被花恼	zuo dui zhen cheng bei hua nao	1
+作赋凌相如	zuo fu ling xiang ru	1
+坐忽枉故人诗	zuo hu wang gu ren shi	1
+作计何不量	zuo ji he bu liang	1
+作计乃尔立	zuo ji nai er li	1
+坐见落花长叹息	zuo jian luo hua chang tan xi	1
+坐久落花多	zuo jiu luo hua duo	1
+坐觉长安空	zuo jue chang an kong	1
+坐看红树不知远	zuo kan hong shu bu zhi yuan	1
+座客	zuo ke	1
+坐客三千人	zuo ke san qian ren	1
+座客三千人	zuo ke san qian ren	1
+坐谋资庙略	zuo mou zi miao lue	1
+左丘明耻之	zuo qiu ming chi zhi	1
+昨日登高罢	zuo ri deng gao ba	1
+昨日看花花灼灼	zuo ri kan hua hua zhuo zhuo	1
+坐伤时节阑	zuo shang shi jie lan	1
+坐使青灯晓	zuo shi qing deng xiao	1
+作师说以贻之	zuo shi shuo yi yi zhi	1
+左手低	zuo shou di	1
+作为此诗	zuo wei ci shi	1
+坐我潇湘洞庭	zuo wo xiao xiang dong ting	1
+左相日兴费万钱	zuo xiang ri xing fei wan qian	1
+作性不能无	zuo xing bu neng wu	1
+左旋右抽	zuo xuan you chou	1
+左偃	zuo yan	1
+作燕歌行以示适	zuo yan ge xing yi shi shi	1
+昨夜东风吹血腥	zuo ye dong feng chui xue xing	1
+昨夜斗回北	zuo ye dou hui bei	1
+昨夜风开露井桃	zuo ye feng kai lu jing tao	1
+昨夜秋风入汉关	zuo ye qiu feng ru han guan	1
+昨夜裙带解	zuo ye qun dai jie	1
+昨夜三更	zuo ye san geng	1
+昨夜上皇新授箓	zuo ye shang huang xin shou lu	1
+昨夜谁为吴会吟	zuo ye shui wei wu hui yin	1
+昨夜微霜初度河	zuo ye wei shuang chu du he	1
+昨夜月同行	zuo ye yue tong hang	1
+坐也坐不定	zuo ye zuo bu ding	1
+作一词	zuo yi ci	1
+左右皆曰贤	zuo you jie yue xian	1
+左右种梧桐	zuo you zhong wu tong	1
+左誉	zuo yu	1
+昨与故人期	zuo yu gu ren qi	1
+作者七人矣	zuo zhe qi ren yi	1
+昨者州前槌大鼓	zuo zhe zhou qian chui da gu	1
+左执簧	zuo zhi huang	1
+座中泣下谁最多	zuo zhong qi xia shui zui duo	1
+座中醉客延醒客	zuo zhong zui ke yan xing ke	1


### PR DESCRIPTION
这个古诗词的词典还挺全的，但是我发现有些诗词打不出来，比如“醉里挑灯看剑”。

Rime 要求是中文、拼音、权重之间用 Tab 隔开，拼音之间可以用空格。
看了一下发现直到 [阿秤亦闻有笔端 a cheng yi wen you bi duan  1] 这一行之前都是正确的。
从这一行开始，全是用空格了，我就拆开分成了两部分1和2，前面正确的没动，后面的批量用Tab修正了。

测试后可以正确打出来了。